### PR TITLE
Suggestion/combat end on death optional

### DIFF
--- a/app/src/main/kotlin/com/fantasyidler/simulator/CombatSimulator.kt
+++ b/app/src/main/kotlin/com/fantasyidler/simulator/CombatSimulator.kt
@@ -156,7 +156,12 @@ object CombatSimulator {
             if (diedThisMinute) break   // stop simulation on death
         }
 
-        return SkillSimulator.Result(frames, SkillSimulator.sessionDurationMs(agilityLevel))
+        val fullDurationMs = SkillSimulator.sessionDurationMs(agilityLevel)
+        val perFrameMs = (fullDurationMs / 60L).coerceAtLeast(1L)
+        val simulatedFrames = frames.size.coerceAtLeast(1)
+        val actualDurationMs = perFrameMs * simulatedFrames
+
+        return SkillSimulator.Result(frames, actualDurationMs)
     }
 
     // ------------------------------------------------------------------

--- a/app/src/main/kotlin/com/fantasyidler/ui/screen/CombatScreen.kt
+++ b/app/src/main/kotlin/com/fantasyidler/ui/screen/CombatScreen.kt
@@ -63,6 +63,7 @@ import com.fantasyidler.data.json.BossData
 import com.fantasyidler.data.json.DungeonData
 import com.fantasyidler.data.json.EquipmentData
 import com.fantasyidler.data.json.SpellData
+import com.fantasyidler.data.model.SessionFrame
 import com.fantasyidler.data.model.SkillSession
 import com.fantasyidler.data.model.Skills
 import com.fantasyidler.ui.theme.GoldPrimary
@@ -75,6 +76,8 @@ import com.fantasyidler.util.formatCoins
 import com.fantasyidler.util.formatXp
 import com.fantasyidler.util.toCountdown
 import kotlinx.coroutines.delay
+import kotlinx.serialization.decodeFromString
+import kotlinx.serialization.json.Json
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -539,6 +542,16 @@ private fun CombatSessionBanner(
     }
 
     val isDone = session.completed || now >= endsAt
+    val actualCombatEndsAt = remember(session.sessionId, session.skillName, session.frames, session.startedAt, session.endsAt) {
+        if (session.skillName != "combat") return@remember null
+        val frames = runCatching { Json.decodeFromString<List<SessionFrame>>(session.frames) }
+            .getOrElse { emptyList() }
+        if (frames.isEmpty()) return@remember null
+        val fullDurationMs = (session.endsAt - session.startedAt).coerceAtLeast(1L)
+        val perFrameMs = (fullDurationMs / 60L).coerceAtLeast(1L)
+        val actualFrames = frames.size.coerceAtMost(60)
+        session.startedAt + perFrameMs * actualFrames
+    }
 
     Column(
         modifier = modifier
@@ -570,6 +583,14 @@ private fun CombatSessionBanner(
                 fontWeight = FontWeight.Bold,
                 color = MaterialTheme.colorScheme.primary,
             )
+            if (BuildConfig.DEBUG && actualCombatEndsAt != null) {
+                Spacer(Modifier.height(4.dp))
+                Text(
+                    text  = remember(now, actualCombatEndsAt) { "Actual remaining: ${actualCombatEndsAt.toCountdown()}" },
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
             Spacer(Modifier.height(24.dp))
         }
 

--- a/app/src/main/kotlin/com/fantasyidler/ui/screen/CombatScreen.kt
+++ b/app/src/main/kotlin/com/fantasyidler/ui/screen/CombatScreen.kt
@@ -542,15 +542,14 @@ private fun CombatSessionBanner(
     }
 
     val isDone = session.completed || now >= endsAt
-    val actualCombatEndsAt = remember(session.sessionId, session.skillName, session.frames, session.startedAt, session.endsAt) {
+    val fullCombatEndsAt = remember(session.sessionId, session.skillName, session.frames, session.startedAt, session.endsAt) {
         if (session.skillName != "combat") return@remember null
         val frames = runCatching { Json.decodeFromString<List<SessionFrame>>(session.frames) }
             .getOrElse { emptyList() }
-        if (frames.isEmpty()) return@remember null
-        val fullDurationMs = (session.endsAt - session.startedAt).coerceAtLeast(1L)
-        val perFrameMs = (fullDurationMs / 60L).coerceAtLeast(1L)
-        val actualFrames = frames.size.coerceAtMost(60)
-        session.startedAt + perFrameMs * actualFrames
+        if (frames.size !in 1..59) return@remember endsAt
+        val actualDurationMs = (session.endsAt - session.startedAt).coerceAtLeast(1L)
+        val perFrameMs = (actualDurationMs / frames.size).coerceAtLeast(1L)
+        session.startedAt + (perFrameMs * 60L)
     }
 
     Column(
@@ -576,17 +575,18 @@ private fun CombatSessionBanner(
         Spacer(Modifier.height(16.dp))
 
         if (!isDone) {
-            val remaining = remember(now) { endsAt.toCountdown() }
+            val primaryEndsAt = fullCombatEndsAt ?: endsAt
+            val remaining = remember(now, primaryEndsAt) { primaryEndsAt.toCountdown() }
             Text(
                 text  = remaining,
                 style = MaterialTheme.typography.displaySmall,
                 fontWeight = FontWeight.Bold,
                 color = MaterialTheme.colorScheme.primary,
             )
-            if (BuildConfig.DEBUG && actualCombatEndsAt != null) {
+            if (BuildConfig.DEBUG && session.skillName == "combat") {
                 Spacer(Modifier.height(4.dp))
                 Text(
-                    text  = remember(now, actualCombatEndsAt) { "Actual remaining: ${actualCombatEndsAt.toCountdown()}" },
+                    text  = remember(now, endsAt) { "Actual remaining: ${endsAt.toCountdown()}" },
                     style = MaterialTheme.typography.bodySmall,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                 )

--- a/app/src/main/kotlin/com/fantasyidler/ui/screen/HomeScreen.kt
+++ b/app/src/main/kotlin/com/fantasyidler/ui/screen/HomeScreen.kt
@@ -334,15 +334,14 @@ private fun HomeSessionCard(
     }
 
     val isDone = session.completed || now >= endsAt
-    val actualCombatEndsAt = remember(session.sessionId, session.skillName, session.frames, session.startedAt, session.endsAt) {
+    val fullCombatEndsAt = remember(session.sessionId, session.skillName, session.frames, session.startedAt, session.endsAt) {
         if (session.skillName != "combat") return@remember null
         val frames = runCatching { Json.decodeFromString<List<SessionFrame>>(session.frames) }
             .getOrElse { emptyList() }
-        if (frames.isEmpty()) return@remember null
-        val fullDurationMs = (session.endsAt - session.startedAt).coerceAtLeast(1L)
-        val perFrameMs = (fullDurationMs / 60L).coerceAtLeast(1L)
-        val actualFrames = frames.size.coerceAtMost(60)
-        session.startedAt + perFrameMs * actualFrames
+        if (frames.size !in 1..59) return@remember endsAt
+        val actualDurationMs = (session.endsAt - session.startedAt).coerceAtLeast(1L)
+        val perFrameMs = (actualDurationMs / frames.size).coerceAtLeast(1L)
+        session.startedAt + (perFrameMs * 60L)
     }
 
     val skillLabel = when (session.skillName) {
@@ -383,16 +382,17 @@ private fun HomeSessionCard(
 
             if (!isDone) {
                 Spacer(Modifier.height(8.dp))
+                val primaryEndsAt = fullCombatEndsAt ?: endsAt
                 Text(
-                    text  = remember(now) { endsAt.toCountdown() },
+                    text  = remember(now, primaryEndsAt) { primaryEndsAt.toCountdown() },
                     style = MaterialTheme.typography.headlineSmall,
                     fontWeight = FontWeight.Bold,
                     color = MaterialTheme.colorScheme.onSecondaryContainer,
                 )
-                if (BuildConfig.DEBUG && actualCombatEndsAt != null) {
+                if (BuildConfig.DEBUG && session.skillName == "combat") {
                     Spacer(Modifier.height(2.dp))
                     Text(
-                        text  = remember(now, actualCombatEndsAt) { "Actual remaining: ${actualCombatEndsAt.toCountdown()}" },
+                        text  = remember(now, endsAt) { "Actual remaining: ${endsAt.toCountdown()}" },
                         style = MaterialTheme.typography.bodySmall,
                         color = MaterialTheme.colorScheme.onSecondaryContainer.copy(alpha = 0.8f),
                     )

--- a/app/src/main/kotlin/com/fantasyidler/ui/screen/HomeScreen.kt
+++ b/app/src/main/kotlin/com/fantasyidler/ui/screen/HomeScreen.kt
@@ -51,6 +51,7 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import com.fantasyidler.BuildConfig
 import com.fantasyidler.R
 import com.fantasyidler.data.model.QueuedAction
+import com.fantasyidler.data.model.SessionFrame
 import com.fantasyidler.data.model.SkillSession
 import com.fantasyidler.ui.theme.GoldPrimary
 import com.fantasyidler.ui.viewmodel.HomeViewModel
@@ -61,6 +62,8 @@ import com.fantasyidler.util.GameStrings
 import com.fantasyidler.util.formatCoins
 import com.fantasyidler.util.toCountdown
 import kotlinx.coroutines.delay
+import kotlinx.serialization.decodeFromString
+import kotlinx.serialization.json.Json
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -331,6 +334,16 @@ private fun HomeSessionCard(
     }
 
     val isDone = session.completed || now >= endsAt
+    val actualCombatEndsAt = remember(session.sessionId, session.skillName, session.frames, session.startedAt, session.endsAt) {
+        if (session.skillName != "combat") return@remember null
+        val frames = runCatching { Json.decodeFromString<List<SessionFrame>>(session.frames) }
+            .getOrElse { emptyList() }
+        if (frames.isEmpty()) return@remember null
+        val fullDurationMs = (session.endsAt - session.startedAt).coerceAtLeast(1L)
+        val perFrameMs = (fullDurationMs / 60L).coerceAtLeast(1L)
+        val actualFrames = frames.size.coerceAtMost(60)
+        session.startedAt + perFrameMs * actualFrames
+    }
 
     val skillLabel = when (session.skillName) {
         "combat" -> context.getString(R.string.label_combat)
@@ -376,6 +389,14 @@ private fun HomeSessionCard(
                     fontWeight = FontWeight.Bold,
                     color = MaterialTheme.colorScheme.onSecondaryContainer,
                 )
+                if (BuildConfig.DEBUG && actualCombatEndsAt != null) {
+                    Spacer(Modifier.height(2.dp))
+                    Text(
+                        text  = remember(now, actualCombatEndsAt) { "Actual remaining: ${actualCombatEndsAt.toCountdown()}" },
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSecondaryContainer.copy(alpha = 0.8f),
+                    )
+                }
             }
 
             Spacer(Modifier.height(12.dp))


### PR DESCRIPTION
As a suggestion, Ive added a method that stops the combat session as soon as there is no food left and the playerHealth <= 0, without spoiling when that will be. The Session timer will show the full duration, but theres a 2nd timer that is responsible for the ending of the session (viewable in my earlier pull request that add the Actual Time -Timer

<img width="460" height="581" alt="image" src="https://github.com/user-attachments/assets/1bd75118-1ff9-40ec-9786-c3cbdba98f95" />