### PR TITLE
Changed dwarven drop chance text from 1/500 to 1/100 to reflect code …

### DIFF
--- a/app/src/main/res/value-es-rES/strings.xml
+++ b/app/src/main/res/value-es-rES/strings.xml
@@ -513,7 +513,7 @@
     <string name="label_daily">Daily</string>
     <string name="label_daily_quests">Daily Quests</string>
     <string name="label_daily_reset">Resets at 6:00 AM</string>
-    <string name="label_daily_reward">2,000 coins (1/500: Dwarven gear)</string>
+    <string name="label_daily_reward">2,000 coins (1/100: Dwarven gear)</string>
     <string name="msg_daily_claimed_coins">Daily quest complete! +2,000 coins.</string>
     <string name="msg_daily_claimed_dwarven">Daily quest complete! You found %1$s!</string>
     <string name="label_hide_completed">Hide completed</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -261,7 +261,7 @@
     <string name="label_daily">Daily</string>
     <string name="label_daily_quests">Tagesaufgaben</string>
     <string name="label_daily_reset">Reset um 6:00 Uhr</string>
-    <string name="label_daily_reward">2.000 Münzen (1/500: Zwergengear)</string>
+    <string name="label_daily_reward">2.000 Münzen (1/100: Zwergengear)</string>
     <string name="msg_daily_claimed_coins">Tagesaufgabe abgeschlossen! +2.000 Münzen.</string>
     <string name="msg_daily_claimed_dwarven">Tagesaufgabe abgeschlossen! Du hast %1$s gefunden!</string>
 

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -563,7 +563,7 @@
     <string name="label_daily">Daily</string>
     <string name="label_daily_quests">Daily Quests</string>
     <string name="label_daily_reset">Resets at 6:00 AM</string>
-    <string name="label_daily_reward">2,000 coins (1/500: Dwarven gear)</string>
+    <string name="label_daily_reward">2,000 coins (1/100: Dwarven gear)</string>
     <string name="msg_daily_claimed_coins">Daily quest complete! +2,000 coins.</string>
     <string name="msg_daily_claimed_dwarven">Daily quest complete! You found %1$s!</string>
     <string name="label_hide_completed">Hide completed</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -252,7 +252,7 @@
     <string name="label_daily">Quotidien</string>
     <string name="label_daily_quests">Quêtes quotidiennes</string>
     <string name="label_daily_reset">Se réinitialise à 6 heures</string>
-    <string name="label_daily_reward">2 000 pièces (1/500 : équipement nanique)</string>
+    <string name="label_daily_reward">2 000 pièces (1/100 : équipement nanique)</string>
     <string name="msg_daily_claimed_coins">Quête quotidienne terminée ! +2 000 pièces.</string>
     <string name="msg_daily_claimed_dwarven">Quête quotidienne terminée ! Vous avez trouvé %1$s !</string>
 

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -261,7 +261,7 @@
     <string name="label_daily">Giornaliere</string>
     <string name="label_daily_quests">Quest Giornaliere</string>
     <string name="label_daily_reset">Nuove questa alle 06:00</string>
-    <string name="label_daily_reward">2000 monete (1/500: equipaggiamento Nanico)</string>
+    <string name="label_daily_reward">2000 monete (1/100: equipaggiamento Nanico)</string>
     <string name="msg_daily_claimed_coins">Quest giornaliera completata! +2000 coins.</string>
     <string name="msg_daily_claimed_dwarven">Quest giornaliera completata! Hai trovato %1$s!</string>
     <string name="label_hide_completed">Nascondi completate</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -261,7 +261,7 @@
     <string name="label_daily">Per Dag</string>
     <string name="label_daily_quests">Dagelijkse Quests</string>
     <string name="label_daily_reset">Reset om 06:00</string>
-    <string name="label_daily_reward">2000 ducaten (1/500: Dwergenuitrusting)</string>
+    <string name="label_daily_reward">2000 ducaten (1/100: Dwergenuitrusting)</string>
     <string name="msg_daily_claimed_coins">Dagelijkse quest voltooid! +2000 ducaten.</string>
     <string name="msg_daily_claimed_dwarven">Dagelijkse quest voltooid! Je hebt %1$s gevonden!</string>
     <string name="label_hide_completed">Verberg Voltooid</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -583,7 +583,7 @@
     <string name="label_daily">Daily</string>
     <string name="label_daily_quests">Daily Quests</string>
     <string name="label_daily_reset">Resets at 6:00 AM</string>
-    <string name="label_daily_reward">2,000 coins (1/500: Dwarven gear)</string>
+    <string name="label_daily_reward">2,000 coins (1/100: Dwarven gear)</string>
     <string name="msg_daily_claimed_coins">Daily quest complete! +2,000 coins.</string>
     <string name="msg_daily_claimed_dwarven">Daily quest complete! You found %1$s!</string>
     <string name="label_hide_completed">Hide completed</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -261,7 +261,7 @@
     <string name="label_daily">Daily</string>
     <string name="label_daily_quests">Daily Quests</string>
     <string name="label_daily_reset">Resets at 6:00 AM</string>
-    <string name="label_daily_reward">2,000 coins (1/500: Dwarven gear)</string>
+    <string name="label_daily_reward">2,000 coins (1/100: Dwarven gear)</string>
     <string name="msg_daily_claimed_coins">Daily quest complete! +2,000 coins.</string>
     <string name="msg_daily_claimed_dwarven">Daily quest complete! You found %1$s!</string>
     <string name="label_hide_completed">Hide completed</string>


### PR DESCRIPTION
In [v1.4.3](https://github.com/tristinbaker/IdleFantasy/releases/tag/v1.4.3) the drop chance from dwarven gear was changed from 1/500 to 1/100. This was not reflected in the notification text. This PR changed all xml files to represent the new drop chance.