### PR TITLE
feat(i18n): Add Russian (ru) locale translation

### DIFF
--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -1,0 +1,1005 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="app_name">Idle Fantasy</string>
+
+    <!-- ===== Bottom navigation ===== -->
+    <string name="nav_skills">Навыки</string>
+    <string name="nav_combat">Бой</string>
+    <string name="nav_home">Домой</string>
+    <string name="nav_crafting">Крафт</string>
+    <string name="nav_quests">Квесты</string>
+    <string name="nav_profile">Профиль</string>
+
+    <!-- ===== Common buttons ===== -->
+    <string name="btn_start">Начать</string>
+    <string name="btn_start_session">Начать сессию</string>
+    <string name="btn_abandon_session">Прервать сессию</string>
+    <string name="btn_collect_results">Собрать результаты</string>
+    <string name="btn_cancel">Отмена</string>
+    <string name="btn_craft">Скрафтить</string>
+    <string name="btn_confirm">Подтвердить</string>
+    <string name="btn_abandon">Прервать</string>
+    <string name="btn_repeat_action">Повторить</string>
+    <string name="btn_collect">Собрать награды</string>
+    <string name="btn_equip">Экипировать</string>
+    <string name="btn_unequip">Снять</string>
+    <string name="btn_buy">Купить</string>
+    <string name="btn_sell">Продать</string>
+    <string name="btn_plant">Посадить</string>
+    <string name="btn_harvest">Собрать</string>
+    <string name="btn_harvest_all">Собрать всё</string>
+    <string name="btn_clear">Очистить</string>
+    <string name="btn_clear_all">Очистить всё</string>
+    <string name="btn_inspect">Осмотреть</string>
+    <string name="btn_view_drops">Добыча</string>
+    <string name="btn_start_quest">Начать квест</string>
+    <string name="btn_abandon_quest">Прервать квест</string>
+    <string name="btn_enter_dungeon">Войти в подземелье</string>
+    <string name="btn_enter_arena">Войти на арену</string>
+    <string name="btn_activate">Активировать</string>
+    <string name="btn_deactivate">Деактивировать</string>
+    <string name="btn_close">Закрыть</string>
+    <string name="btn_back">Назад</string>
+
+    <!-- ===== Common labels ===== -->
+    <string name="label_level">Уровень</string>
+    <string name="label_xp">Опыт</string>
+    <string name="label_coins">Монеты</string>
+    <string name="label_hp">Здоровье</string>
+    <string name="label_attack">Атака</string>
+    <string name="label_strength">Сила</string>
+    <string name="label_defense">Защита</string>
+    <string name="label_ranged">Стрельба</string>
+    <string name="label_magic">Магия</string>
+    <string name="label_prayer">Молитва</string>
+    <string name="label_hitpoints">Здоровье</string>
+    <string name="label_inventory">Инвентарь</string>
+    <string name="label_equipment">Снаряжение</string>
+    <string name="label_pets">Питомцы</string>
+    <string name="label_achievements">Достижения</string>
+    <string name="label_session_in_progress">Сессия в процессе</string>
+    <string name="label_session_active">Сессия активна</string>
+    <string name="label_no_active_session">Нет активной сессии</string>
+    <string name="label_session_complete">Сессия завершена!</string>
+    <string name="label_training">Тренировка</string>
+    <string name="label_gathering_skills">Добыча</string>
+    <string name="label_crafting_skills">Крафт</string>
+    <string name="label_choose_activity">Выберите занятие</string>
+    <string name="label_coming_soon">Скоро</string>
+    <string name="label_time_remaining">Осталось времени</string>
+    <string name="label_session_results">Результаты сессии</string>
+    <string name="label_xp_gained">Получено опыта</string>
+    <string name="label_items_collected">Предметов собрано</string>
+    <string name="label_level_ups">Уровней получено</string>
+    <string name="label_requirements">Требования</string>
+    <string name="label_rewards">Награды</string>
+    <string name="label_your_level">Ваш уровень</string>
+    <string name="label_xp_to_next">Опыта до следующего уровня</string>
+    <string name="label_total_xp">Всего опыта</string>
+    <string name="label_quantity">Количество</string>
+    <string name="label_price">Цена</string>
+    <string name="label_available">Доступно</string>
+    <string name="label_patch">Участок</string>
+    <string name="label_growth_time">Время роста</string>
+    <string name="label_ready_to_harvest">Готово к сбору</string>
+    <string name="label_empty">Пусто</string>
+    <string name="inventory_sort_quantity">Количество</string>
+    <string name="inventory_sort_az">А-Я</string>
+    <string name="inventory_cat_weapons">Оружие</string>
+    <string name="inventory_cat_armour">Броня</string>
+    <string name="inventory_cat_tools">Инструменты</string>
+    <string name="inventory_cat_food">Еда</string>
+    <string name="inventory_cat_potions">Зелья</string>
+    <string name="inventory_cat_materials">Материалы</string>
+    <string name="inventory_cat_other">Прочее</string>
+    <string name="label_combat_style">Стиль боя</string>
+    <string name="label_active_spell">Активное заклинание</string>
+    <string name="label_drops">Добыча</string>
+    <string name="label_boss">Босс</string>
+    <string name="label_dungeon">Подземелье</string>
+    <string name="label_difficulty">Сложность</string>
+    <string name="label_completed">Завершено</string>
+    <string name="label_in_progress">В процессе</string>
+    <string name="label_available_quests">Доступно</string>
+    <string name="label_stats">Характеристики</string>
+    <string name="label_skills">Навыки</string>
+    <string name="label_shop">Магазин</string>
+    <string name="label_sell_items">Продать предметы</string>
+    <string name="label_total_level">Общий уровень</string>
+    <string name="label_wins">Победы</string>
+    <string name="label_losses">Поражения</string>
+    <string name="label_active">Активно</string>
+    <string name="label_inactive">Неактивно</string>
+    <string name="label_boost">Бонус</string>
+    <string name="label_xp_boost">Бонус опыта</string>
+    <string name="label_weapon">Оружие</string>
+    <string name="label_armour">Броня</string>
+    <string name="label_food">Еда</string>
+    <string name="label_arrows_consumed">Стрел потрачено</string>
+    <string name="label_arrows_reclaimed">Стрел возвращено</string>
+    <string name="label_runes_consumed">Рун потрачено</string>
+    <string name="label_runes_reclaimed">Рун возвращено</string>
+    <string name="label_arrows">Стрелы</string>
+    <string name="label_runes">Руны</string>
+    <string name="label_spell">Заклинание</string>
+    <string name="label_none">Нет</string>
+    <string name="label_melee">Ближний бой</string>
+    <string name="label_ranged_style">Стрельба</string>
+    <string name="label_magic_style">Магия</string>
+    <string name="label_gathering">Добыча</string>
+    <string name="label_crafting">Крафт</string>
+    <string name="label_jewellery">Ювелирные изделия</string>
+    <string name="label_combat">Бой</string>
+    <string name="label_recipe">Рецепт</string>
+    <string name="label_recipes">Рецепты</string>
+    <string name="label_ingredients">Ингредиенты</string>
+    <string name="label_output">Результат</string>
+    <string name="label_xp_per_action">Опыта за действие</string>
+    <string name="label_unlocked_at">Открывается на уровне</string>
+    <string name="label_kills">Убийств</string>
+    <string name="label_personal_best">Личный рекорд</string>
+    <string name="label_daily_dig">Ежедневный раскоп</string>
+    <string name="label_dig_depth">Глубина ямы</string>
+    <string name="label_version">Версия</string>
+    <string name="label_open_source">Открытый исходный код</string>
+
+    <!-- ===== Format strings — all use positional args for Weblate ===== -->
+    <!-- Translator note: %1$d = level number, %2$s = formatted XP string -->
+    <string name="format_level_xp">Уровень %1$d — %2$s опыта</string>
+    <!-- Translator note: %1$s = formatted XP amount, %2$d = target level number -->
+    <string name="format_xp_to_next">%1$s опыта до уровня %2$d</string>
+    <!-- Translator note: %1$s = time string (e.g. "42m 10s") -->
+    <string name="format_time_remaining">Осталось %1$s</string>
+    <!-- Translator note: %1$s = relative time (e.g. "5m ago") -->
+    <string name="format_started_ago">Начато %1$s назад</string>
+    <!-- Translator note: %1$s = item display name, %2$d = quantity -->
+    <string name="format_item_quantity">%1$s ×%2$d</string>
+    <!-- Translator note: %1$d = coin amount -->
+    <string name="format_price_coins">%1$d монет</string>
+    <!-- Translator note: %1$d = required level, %2$s = skill display name -->
+    <string name="format_level_requirement">Требуется %2$s уровня %1$d</string>
+    <!-- Translator note: %1$s = formatted XP amount -->
+    <string name="format_xp_per_action">%1$s опыта за действие</string>
+    <!-- Translator note: %1$d = patch number -->
+    <string name="format_patch_number">Участок %1$d</string>
+    <!-- Translator note: %1$d = wins, %2$d = losses -->
+    <string name="format_arena_record">%1$d побед / %2$d поражений</string>
+    <!-- Translator note: %1$s = skill display name, %2$d = level number -->
+    <string name="format_skill_level">%1$s: Уровень %2$d</string>
+    <!-- Translator note: %1$d = boost percentage -->
+    <string name="format_xp_boost_percent">+%1$d%% опыта</string>
+    <!-- Translator note: %1$s = item/resource name, %2$d = quantity drop amount -->
+    <string name="format_drop_chance">%1$s: %2$d</string>
+    <!-- Translator note: %1$d = minutes remaining -->
+    <string name="format_minutes_remaining">Осталось %1$d мин</string>
+    <!-- Translator note: %1$s = version string (e.g. "0.1.0") -->
+    <string name="format_version">Версия %1$s</string>
+
+    <!-- ===== Plurals ===== -->
+    <plurals name="plural_level_ups">
+        <item quantity="one">%1$d уровень получен</item>
+        <item quantity="few">%1$d уровня получено</item>
+        <item quantity="many">%1$d уровней получено</item>
+        <item quantity="other">%1$d уровней получено</item>
+    </plurals>
+    <plurals name="plural_items">
+        <item quantity="one">%1$d предмет</item>
+        <item quantity="few">%1$d предмета</item>
+        <item quantity="many">%1$d предметов</item>
+        <item quantity="other">%1$d предметов</item>
+    </plurals>
+    <plurals name="plural_minutes">
+        <item quantity="one">%1$d минута</item>
+        <item quantity="few">%1$d минуты</item>
+        <item quantity="many">%1$d минут</item>
+        <item quantity="other">%1$d минут</item>
+    </plurals>
+    <plurals name="plural_hours">
+        <item quantity="one">%1$d час</item>
+        <item quantity="few">%1$d часа</item>
+        <item quantity="many">%1$d часов</item>
+        <item quantity="other">%1$d часов</item>
+    </plurals>
+    <plurals name="plural_patches">
+        <item quantity="one">%1$d участок</item>
+        <item quantity="few">%1$d участка</item>
+        <item quantity="many">%1$d участков</item>
+        <item quantity="other">%1$d участков</item>
+    </plurals>
+    <plurals name="plural_kills">
+        <item quantity="one">%1$d убийство</item>
+        <item quantity="few">%1$d убийства</item>
+        <item quantity="many">%1$d убийств</item>
+        <item quantity="other">%1$d убийств</item>
+    </plurals>
+    <plurals name="plural_quests_completed">
+        <item quantity="one">%1$d квест завершён</item>
+        <item quantity="few">%1$d квеста завершено</item>
+        <item quantity="many">%1$d квестов завершено</item>
+        <item quantity="other">%1$d квестов завершено</item>
+    </plurals>
+
+    <!-- ===== Error messages ===== -->
+    <string name="error_no_player">Не удалось загрузить данные игрока. Пожалуйста, перезапустите приложение.</string>
+    <string name="error_session_already_active">У вас уже есть активная сессия. Завершите или прервите её сначала.</string>
+    <string name="error_not_enough_coins">Недостаточно монет.</string>
+    <!-- Translator note: %1$s = item display name -->
+    <string name="error_not_enough_items">Недостаточно %1$s.</string>
+    <!-- Translator note: %1$s = skill display name -->
+    <string name="error_level_too_low">Ваш уровень %1$s слишком низкий.</string>
+    <!-- Translator note: %1$s = item display name -->
+    <string name="error_inventory_required">Вам нужен %1$s для этого.</string>
+    <string name="error_patch_occupied">Этот участок уже засажен.</string>
+    <string name="error_patch_empty">Этот участок пуст.</string>
+    <string name="error_crop_not_ready">Этот урожай ещё не готов.</string>
+    <string name="error_quest_active">У вас уже есть активный квест.</string>
+    <string name="error_quest_requirements_not_met">Вы не соответствуете требованиям этого квеста.</string>
+    <string name="error_dungeon_level_too_low">Ваш боевой уровень слишком низкий для этого подземелья.</string>
+    <string name="error_unknown">Что-то пошло не так. Пожалуйста, попробуйте снова.</string>
+
+    <!-- ===== Session dialogs ===== -->
+    <string name="session_abandon_title">Прервать сессию?</string>
+    <string name="session_abandon_body">Весь прогресс этой сессии будет потерян.</string>
+
+    <!-- ===== Onboarding ===== -->
+    <string name="onboarding_welcome_title">Добро пожаловать в Idle Fantasy</string>
+    <string name="onboarding_welcome_body">Начните сессию тренировки навыка и наблюдайте за ростом персонажа. Сессии длятся один час, даже когда приложение закрыто.</string>
+    <string name="onboarding_first_session_hint">Нажмите на любой навык, чтобы начать.</string>
+
+    <!-- ===== Settings ===== -->
+    <string name="settings_title">Настройки</string>
+    <string name="settings_notifications">Уведомления о сессиях</string>
+    <string name="settings_notifications_desc">Показывать уведомление по завершении сессии</string>
+    <string name="settings_battery_optimization">Оптимизация батареи</string>
+    <string name="settings_battery_optimization_desc">Отключите оптимизацию батареи для Idle Fantasy, чтобы получать своевременные уведомления</string>
+    <string name="settings_battery_optimization_btn">Изменить настройку</string>
+    <string name="settings_language">Язык</string>
+    <string name="settings_about">О приложении</string>
+    <string name="settings_open_source_licenses">Лицензии открытого ПО</string>
+
+    <!-- ===== HomeScreen ===== -->
+    <string name="label_player_stats">Характеристики игрока</string>
+    <string name="label_combat_level">Боевой уровень</string>
+    <string name="label_shop_desc">Покупайте снаряжение и продавайте добычу</string>
+    <string name="label_no_session_hint">Перейдите в Навыки или Бой, чтобы начать тренировку.</string>
+    <string name="label_recent_activity">Последняя активность</string>
+    <string name="settings_recent_activity_desc">Показывать кнопку «Последняя активность» на главном экране</string>
+    <string name="label_no_sessions_yet">Сессий ещё не завершено.</string>
+
+    <!-- ===== CombatScreen ===== -->
+    <string name="label_dungeons_tab">Подземелья</string>
+    <string name="btn_fight">Сражаться!</string>
+
+    <!-- ===== SkillsScreen ===== -->
+    <string name="btn_back_arrow">← Назад</string>
+    <string name="btn_start_burying">Начать захоронение</string>
+    <string name="btn_start_crafting">Начать крафт</string>
+    <string name="btn_select">Выбрать</string>
+    <string name="label_special">Особое</string>
+
+    <!-- ===== QuestsScreen ===== -->
+    <string name="label_claim_reward">Получить награду</string>
+    <string name="label_daily">Ежедневные</string>
+    <string name="label_daily_quests">Ежедневные квесты</string>
+    <string name="label_daily_reset">Обновление в 6:00</string>
+    <string name="label_daily_reward">2 000 монет (1/100: дварфское снаряжение)</string>
+    <string name="msg_daily_claimed_coins">Ежедневный квест выполнен! +2 000 монет.</string>
+    <string name="msg_daily_claimed_dwarven">Ежедневный квест выполнен! Вы нашли %1$s!</string>
+    <string name="label_hide_completed">Скрыть завершённые</string>
+
+    <!-- ===== OnboardingScreen ===== -->
+    <string name="onboarding_lets_go">Вперёд!</string>
+    <string name="onboarding_skip">Пропустить</string>
+    <string name="onboarding_next">Далее</string>
+
+    <!-- ===== Settings (continued) ===== -->
+    <string name="settings_notifications_header">Уведомления</string>
+    <string name="settings_performance_header">Производительность</string>
+    <string name="settings_general_header">Общие</string>
+    <string name="settings_tutorial_title">Обучение</string>
+    <string name="settings_tutorial_desc">Показать введение ещё раз</string>
+    <string name="settings_reopen">Открыть</string>
+    <string name="settings_changelog_title">Что нового</string>
+    <string name="settings_changelog_desc">Посмотреть последние изменения</string>
+    <string name="settings_changelog_btn">Просмотр</string>
+    <string name="settings_foss_desc">Idle Fantasy — свободное программное обеспечение с открытым исходным кодом.</string>
+    <string name="settings_reset_title">Сбросить прогресс</string>
+    <string name="settings_reset_desc">Удалить все навыки, предметы, квесты и монеты</string>
+    <string name="settings_reset_btn">Сбросить</string>
+    <string name="reset_confirm1_title">Сбросить весь прогресс?</string>
+    <string name="reset_confirm1_body">Это удалит весь опыт навыков, предметы, монеты и прогресс квестов. Это нельзя отменить.</string>
+    <string name="reset_confirm2_title">Вы уверены?</string>
+    <string name="reset_confirm2_body">Всё будет потеряно. Вы начнёте с самого начала.</string>
+    <string name="reset_confirm2_btn">Да, сбросить всё</string>
+
+    <!-- ===== Battery prompt dialog ===== -->
+    <string name="battery_prompt_title">Держите сессии активными</string>
+    <string name="battery_prompt_body">Для лучшего опыта разрешите Idle Fantasy работать в фоновом режиме, чтобы получать своевременные уведомления о сессиях.</string>
+    <string name="battery_prompt_open_settings">Открыть настройки</string>
+    <string name="battery_prompt_dismiss">Не сейчас</string>
+
+    <!-- ===== Easter egg ===== -->
+    <string name="dig_action">Копать</string>
+    <string name="dig_result">Вы копаете глубже в землю…</string>
+    <!-- Translator note: %1$d = total hole depth in metres -->
+    <string name="dig_depth_format">Яма глубиной %1$d метров.</string>
+
+    <!-- ===== Settings — appearance / language / save data ===== -->
+    <string name="settings_appearance">Внешний вид</string>
+    <string name="settings_theme">Тема</string>
+    <string name="settings_theme_desc">Выберите цветовую схему</string>
+    <string name="settings_theme_dark">Тёмная</string>
+    <string name="settings_theme_light">Светлая</string>
+    <string name="settings_theme_system">Системная</string>
+    <string name="settings_font_size">Размер шрифта</string>
+    <string name="settings_font_tiny">Крошечный</string>
+    <string name="settings_font_small">Маленький</string>
+    <string name="settings_font_normal">Обычный</string>
+    <string name="settings_font_large">Большой</string>
+    <string name="settings_font_huge">Огромный</string>
+    <string name="settings_language_desc">Изменить язык приложения</string>
+    <string name="settings_lang_english">English</string>
+    <string name="settings_lang_deutsch">Deutsch</string>
+    <string name="settings_lang_français">Français</string>
+    <string name="settings_lang_dutch">Nederlands</string>
+    <string name="settings_lang_español">Español</string>
+    <string name="settings_lang_español_españa">Español (España)</string>
+    <string name="settings_lang_turkish">Türkçe</string>
+    <string name="settings_lang_italiano">Italiano</string>
+    <string name="settings_lang_russian">Русский</string>
+    <string name="settings_lang_system">Системный</string>
+    <string name="settings_save_data">Сохранение данных</string>
+    <string name="settings_export">Экспорт сохранения</string>
+    <string name="settings_export_desc">Сохранить прогресс в файл</string>
+    <string name="settings_export_btn">Экспорт</string>
+    <string name="settings_import">Импорт сохранения</string>
+    <string name="settings_import_desc">Восстановить прогресс из файла</string>
+    <string name="settings_import_btn">Импорт</string>
+    <string name="settings_source_code">Исходный код</string>
+    <string name="settings_source_url" translatable="false">github.com/tristinbaker/IdleFantasy</string>
+    <string name="settings_source_open">Открыть</string>
+    <string name="settings_exported_ok">Сохранение экспортировано</string>
+    <string name="settings_imported_ok">Сохранение успешно импортировано</string>
+    <string name="settings_imported_fail">Ошибка импорта — недействительный файл</string>
+    <string name="settings_backup_title">Автоматическое резервное копирование</string>
+    <string name="settings_backup_folder">Папка резервных копий</string>
+    <string name="settings_backup_no_folder">Папка не выбрана</string>
+    <string name="settings_backup_choose">Выбрать</string>
+    <string name="settings_backup_frequency">Частота</string>
+    <string name="settings_backup_off">Выкл</string>
+    <string name="settings_backup_hourly">Каждый час</string>
+    <string name="settings_backup_daily">Ежедневно</string>
+    <string name="settings_backup_weekly">Еженедельно</string>
+    <string name="settings_backup_at_5am">в 5:00</string>
+    <string name="settings_backup_now">Создать копию сейчас</string>
+    <string name="settings_backup_success">Резервная копия сохранена.</string>
+    <string name="settings_backup_failed">Ошибка создания резервной копии.</string>
+    <string name="settings_backup_folder_set">Папка резервных копий установлена.</string>
+
+    <!-- ===== HomeScreen (continued) ===== -->
+    <string name="home_town_title">Город</string>
+    <string name="home_town_desc">Посетите магазин, таверну, гильдию, церковь и мастера убийств</string>
+    <string name="guild_dailies_available">Ежедневные доступны</string>
+    <string name="guild_do_dailies_hint">Выполняйте ежедневные квесты для роста репутации</string>
+    <string name="guild_quest_gate_blocked">Завершите квесты для повышения ранга</string>
+    <string name="guild_quest_required">Квест необходим для повышения</string>
+    <string name="home_died_message">Вы погибли и потеряли большую часть добычи.</string>
+    <string name="home_xp_boost_was_active">Бонус ×2 опыта был активен</string>
+    <string name="home_xp_boost_active">Бонус ×2 опыта активен — %1$s осталось</string>
+    <string name="home_loot">Добыча</string>
+    <string name="home_food_consumed">Еда использована</string>
+    <string name="home_bones_buried">Кости захоронены</string>
+    <string name="home_whats_new">Что нового</string>
+    <string name="home_got_it">Понятно</string>
+    <!-- Translator note: %1$s = player name or "Adventurer" -->
+    <string name="home_welcome">С возвращением, %1$s!</string>
+    <string name="home_adventurer">Авантюрист</string>
+    <!-- Translator note: %1$d = queue size (always 3 max) -->
+    <string name="home_up_next">Следующая (%1$d/3)</string>
+    <!-- Translator note: %1$s = formatted duration string (e.g. "2h 15m") -->
+    <string name="home_queue_ends_in">Очередь завершится через %1$s</string>
+    <!-- Translator note: %1$d = number of sessions to collect -->
+    <plurals name="plural_collect_sessions">
+        <item quantity="one">Собрать награды за %1$d сессию</item>
+        <item quantity="few">Собрать награды за %1$d сессии</item>
+        <item quantity="many">Собрать награды за %1$d сессий</item>
+        <item quantity="other">Собрать награды за %1$d сессий</item>
+    </plurals>
+
+    <!-- ===== CombatScreen (continued) ===== -->
+    <string name="combat_level_label">Боевой ур.</string>
+    <string name="combat_log_label">Журнал боя</string>
+    <string name="combat_solo_bosses">Одиночные боссы</string>
+    <!-- Translator note: %1$d = number of completed dungeon runs -->
+    <string name="combat_dungeon_runs">%1$d заходов</string>
+    <string name="combat_atk">АТК</string>
+    <string name="combat_str">СИЛ</string>
+    <string name="combat_def">ЗАЩ</string>
+    <!-- Translator note: %1$d = HP healed -->
+    <string name="combat_heals_hp">лечит %1$d здоровья</string>
+    <string name="combat_defeated_so_far">уже побеждено.</string>
+    <string name="combat_fighting">Сражение…</string>
+    <string name="combat_log_you_hit">Вы попали</string>
+    <string name="combat_log_hit_you">попал по вам</string>
+    <string name="combat_log_dmg">урон</string>
+    <string name="combat_log_missed">промах</string>
+    <string name="combat_log_you_missed">Вы промахнулись</string>
+    <string name="combat_rec_level">Рекомендуемый боевой уровень</string>
+    <string name="combat_your_level">Ваш боевой уровень</string>
+    <string name="combat_no_strength_bonus">Нет (бонус силы отсутствует)</string>
+    <string name="combat_best_arrow">Лучшая стрела</string>
+    <string name="combat_arrow_auto">Авто (лучшая доступная)</string>
+    <string name="combat_label_arrow">Стрела</string>
+    <string name="combat_enemies">Враги</string>
+    <string name="combat_no_spells">Нет доступных заклинаний на вашем уровне магии.</string>
+    <string name="combat_only_castable">Только доступные</string>
+    <string name="combat_max_hit">макс. удар</string>
+    <string name="combat_no_potion">Без зелья</string>
+    <string name="combat_req_level">Требуемый боевой уровень</string>
+    <string name="combat_duration">Длительность</string>
+    <!-- Translator note: %1$d = minutes -->
+    <string name="combat_duration_min">%1$d мин</string>
+    <string name="combat_xp_on_victory">Опыт за победу</string>
+    <string name="combat_you_died">Вы погибли!</string>
+    <string name="combat_died_reward">Вы получили 10% наград.</string>
+    <!-- Translator note: %1$d = gear bonus value -->
+    <string name="combat_gear_bonus">+%1$d снаряжение</string>
+
+    <!-- ===== ProfileScreen ===== -->
+    <string name="profile_unnamed">Безымянный авантюрист</string>
+    <string name="profile_no_pets">Нет доступных питомцев</string>
+    <string name="profile_pet_collected">Найден</string>
+    <string name="profile_pet_not_found">Ещё не найден</string>
+    <string name="profile_equip_best">Надеть лучшее снаряжение</string>
+    <string name="profile_weapons">Оружие</string>
+    <string name="profile_combat_gear">Боевое снаряжение</string>
+    <string name="profile_view_combat_gear">Просмотр боевого снаряжения</string>
+    <string name="profile_gathering_tools">Инструменты добычи</string>
+    <string name="profile_food_dungeon">Еда (подземелье)</string>
+    <string name="profile_no_food">Нет приготовленной еды в инвентаре</string>
+    <!-- Translator note: %1$d = quantity, %2$d = heal value -->
+    <string name="profile_food_desc">×%1$d  •  лечит %2$d здоровья</string>
+    <!-- Translator note: %1$s = slot display name (e.g. "Weapon") -->
+    <string name="profile_choose_slot">Выбрать %1$s</string>
+    <string name="profile_no_items">Нет подходящих предметов в инвентаре</string>
+    <string name="profile_stat_atk">Атк</string>
+    <string name="profile_stat_str">Сил</string>
+    <string name="profile_stat_ranged">Стрельба</string>
+    <string name="profile_stat_magic">Магия</string>
+    <string name="profile_stat_mining">Добыча руды</string>
+    <string name="profile_stat_wc">Рубка</string>
+    <string name="profile_stat_fishing">Рыбалка</string>
+    <string name="profile_stat_farming">Фермерство</string>
+    <string name="profile_stat_def">Защ</string>
+    <string name="profile_req_lv">Треб. ур.</string>
+
+    <!-- ===== SkillsScreen (continued) ===== -->
+    <!-- Translator note: %1$d = session duration in minutes -->
+    <string name="skills_session_duration">Сессия: %1$d мин</string>
+    <string name="skills_only_craftable">Только крафтовые</string>
+    <string name="skills_filter_all">Все</string>
+    <string name="skills_add_to_queue">Добавить в очередь сессий</string>
+    <string name="skills_add_queue_short">В очередь</string>
+    <!-- Translator note: %1$d = level required, %2$s = XP per action -->
+    <string name="skills_level_req_xp">Ур. %1$d  •  %2$s опыта/руда</string>
+    <!-- Translator note: %1$s = formatted multiplier (e.g. "1.15") -->
+    <string name="skills_tool_bonus">×%1$s бонус инструмента</string>
+    <!-- Translator note: %1$d = fishing level -->
+    <string name="skills_fishing_desc">Уровень %1$d  •  Улов по уровню</string>
+    <!-- Translator note: %1$d = prayer level -->
+    <string name="skills_prayer_desc">Уровень %1$d  •  Захороните кости или рассейте прах для опыта молитвы</string>
+    <string name="skills_no_bones">Нет костей или праха в инвентаре</string>
+    <!-- Translator note: %1$d = XP per bone, %2$d = quantity in inventory -->
+    <string name="skills_bone_qty">%1$d опыта за шт.  •  %2$d в инвентаре</string>
+    <!-- Translator note: %1$d = XP per bone, %2$d = quantity available -->
+    <string name="skills_bone_selected">%1$d опыта за шт.  •  %2$d доступно</string>
+    <!-- Translator note: %1$d = total XP -->
+    <string name="skills_xp_total">+%1$d опыта всего</string>
+    <string name="skills_no_essence">Нет рунической эссенции в инвентаре — добыйте сначала</string>
+    <string name="skills_no_runes">Руны ещё не открыты</string>
+    <!-- Translator note: %1$d = essence quantity -->
+    <string name="skills_essence_qty">%1$d рунической эссенции в инвентаре</string>
+    <!-- Translator note: %1$d = XP per rune, %2$d = level required -->
+    <string name="skills_rune_desc">%1$d опыта/руна  •  Ур. %2$d</string>
+    <!-- Translator note: %1$d = XP per rune, %2$d = essence available -->
+    <string name="skills_rune_selected">%1$d опыта/руна  •  %2$d эссенции доступно</string>
+    <!-- Translator note: %1$d = level reached -->
+    <string name="skills_level_reached">Достигнут уровень %1$d!</string>
+    <string name="skills_no_logs">Нет брёвен в инвентаре</string>
+    <!-- Translator note: %1$d = level required, %2$s = XP per log -->
+    <string name="skills_log_desc">Ур. %1$d  •  %2$s опыта/бревно</string>
+    <!-- Translator note: %1$d = level required, %2$s = XP per catch -->
+    <string name="skills_fish_desc">Ур. %1$d  •  %2$s опыта/улов</string>
+    <!-- Translator note: %1$d = required level, %2$s = skill name, %3$d = player level, %4$s = skill name again -->
+    <string name="skills_req_with_have">Требуется %1$d %2$s (У вас %3$d %4$s)</string>
+
+    <!-- ===== ShopScreen ===== -->
+    <string name="shop_active">АКТИВНО</string>
+    <string name="shop_sell_junk">Продать хлам</string>
+    <string name="shop_sell_old_gear">Продать старое снаряжение</string>
+    <string name="shop_equipped_label">(надето)</string>
+    <!-- Translator note: %1$d = quantity -->
+    <string name="shop_qty_in_inv">×%1$d в инвентаре</string>
+    <!-- Translator note: %1$s = formatted coin amount -->
+    <string name="shop_price_each">%1$s монет шт.</string>
+    <!-- Translator note: %1$s = item name -->
+    <string name="shop_buy_prefix">Купить: %1$s</string>
+    <string name="shop_sell_prefix">Продать: %1$s</string>
+    <!-- Translator note: %1$s = formatted coin amount -->
+    <string name="shop_price_each_long">%1$s монет за шт.</string>
+    <string name="shop_total_cost">Итого</string>
+    <string name="shop_youll_receive">Вы получите</string>
+    <!-- Translator note: %1$s = formatted coin amount -->
+    <string name="shop_total_amount">%1$s монет</string>
+
+    <!-- ===== CraftingScreen ===== -->
+    <string name="crafting_no_mats">Нет материалов</string>
+    <!-- Translator note: %1$d = total quantity, %2$s = item name -->
+    <string name="crafting_produces">= %1$d %2$s</string>
+    <string name="crafting_effects">Эффекты</string>
+    <!-- Translator note: %1$d = total XP -->
+    <string name="crafting_xp_total">+%1$d опыта всего</string>
+    <string name="crafting_decrease">Уменьшить</string>
+    <string name="crafting_increase">Увеличить</string>
+    <!-- Translator note: %1$d = needed, %2$d = have -->
+    <string name="crafting_needed_have">%1$d (есть %2$d)</string>
+    <!-- Translator note: %1$d = quantity in inventory -->
+    <string name="crafting_in_inventory">В инвентаре: ×%1$d</string>
+
+    <!-- ===== FarmingScreen ===== -->
+    <!-- Translator note: %1$s = crop name -->
+    <string name="farming_harvested">Собрано: %1$s</string>
+    <!-- Translator note: %1$d = farming level -->
+    <string name="farming_title">Фермерство — Уровень %1$d</string>
+    <!-- Translator note: %1$d = patch count -->
+    <string name="farming_patches">%1$d участков открыто</string>
+    <string name="farming_clear_patch">Очистить участок</string>
+    <string name="farming_clear_desc">Удалить культуру без награды?</string>
+    <string name="farming_harvest_and_plant">Собрать и посадить всё</string>
+    <string name="farming_no_crops_ready">Нет готовых к сбору культур</string>
+    <string name="farming_no_empty_patches">Нет свободных участков</string>
+    <!-- Translator note: %1$s = seed name -->
+    <string name="farming_no_seeds_inventory">Недостаточно %1$s в инвентаре</string>
+    <!-- Translator note: %1$d = count, %2$s = seed name -->
+    <string name="farming_planted">Посажено %1$d %2$s</string>
+
+    <!-- ===== QuestsScreen ===== -->
+    <string name="quests_none_in_category">Нет квестов в этой категории.</string>
+
+    <!-- ===== CharacterSetupSheet ===== -->
+    <string name="character_create_title">Создайте персонажа</string>
+    <string name="character_edit_title">Редактировать персонажа</string>
+    <string name="character_name_label">Имя персонажа</string>
+    <string name="character_gender">Пол</string>
+    <string name="character_gender_male">Мужской</string>
+    <string name="character_gender_female">Женский</string>
+    <string name="character_gender_other">Другой</string>
+    <string name="character_race">Раса</string>
+    <string name="character_race_human">Человек</string>
+    <string name="character_race_elf">Эльф</string>
+    <string name="character_race_dwarf">Дварф</string>
+    <string name="character_race_orc">Орк</string>
+    <string name="character_race_halfling">Полурослик</string>
+    <string name="character_race_gnome">Гном</string>
+
+    <!-- ===== OnboardingScreen ===== -->
+    <string name="onboarding_sessions_title">Сессии</string>
+    <string name="onboarding_sessions_desc">Выберите навык и начните тренировочную сессию. Сессии работают в фоне, даже когда приложение закрыто. Возвращайтесь, чтобы забрать добычу и опыт.</string>
+    <string name="onboarding_progress_title">Поднимайтесь выше</string>
+    <string name="onboarding_progress_desc">Добывайте руду, чтобы плавить слитки, затем куйте лучшее оружие и броню. Надевайте крепкое снаряжение, чтобы проходить подземелья и боссов. Лучшие инструменты ускоряют добычу, а снаряжение высокого уровня открывает контент, где слабое не выживет.</string>
+    <string name="onboarding_quests_title">Квесты и питомцы</string>
+    <string name="onboarding_quests_desc">Выполняйте квесты за опыт. Редкие питомцы могут появиться при тренировке навыков и дают постоянный бонус опыта.</string>
+    <string name="onboarding_welcome_desc">РПГ в стиле покоя, вдохновлённая классическими MMORPG. Тренируйте навыки, сражайтесь в подземельях, крафтите снаряжение. Всё офлайн, без аккаунтов и рекламы.</string>
+
+    <!-- Quantity picker quick buttons -->
+    <string name="qty_max">Макс</string>
+
+    <!-- ===== Inn / Worker ===== -->
+    <string-array name="worker_names">
+        <item>Aldric</item>
+        <item>Brenna</item>
+        <item>Calder</item>
+        <item>Dwyn</item>
+        <item>Elara</item>
+        <item>Finn</item>
+        <item>Gwenna</item>
+        <item>Hadwin</item>
+        <item>Isla</item>
+        <item>Jorvik</item>
+        <item>Kira</item>
+        <item>Leofwin</item>
+        <item>Maren</item>
+        <item>Nessa</item>
+        <item>Oswin</item>
+        <item>Petra</item>
+        <item>Quill</item>
+        <item>Rowena</item>
+        <item>Sven</item>
+        <item>Tilda</item>
+        <item>Urick</item>
+        <item>Veda</item>
+        <item>Wren</item>
+        <item>Xander</item>
+        <item>Yara</item>
+    </string-array>
+    <string name="inn_title">Таверна</string>
+    <string name="inn_desc">Наймите работника для тренировки навыков или купите еду из ежедневного меню.</string>
+    <string name="inn_worker_already_hired">Работник уже нанят.</string>
+    <string name="inn_not_enough_coins">Недостаточно монет.</string>
+    <string name="inn_hire">Нанять</string>
+    <string name="inn_worker_active">Работник нанят и тренирует</string>
+    <string name="inn_hire_cost">%1$s монет</string>
+    <string name="worker_long_laborer">Долгий чернорабочий</string>
+    <string name="worker_apprentice">Подмастерье</string>
+    <string name="worker_journeyman">Умелец</string>
+    <string name="worker_master">Мастер</string>
+    <string name="inn_long_laborer_desc">8ч добыча, ×0.5 эффективность. Без ограничений на крафт, молитву и руническое ремесло. Ставьте в очередь сколько хотите. Он медленный, но сделает что угодно.</string>
+    <string name="inn_apprentice_desc">8ч добыча, ×1 эффективность. Крафт, молитва и руническое ремесло — лимит 480 предметов за сессию.</string>
+    <string name="inn_journeyman_desc">6ч добыча, ×1.25 эффективность. Крафт, молитва и руническое ремесло — лимит 360 предметов за сессию.</string>
+    <string name="inn_master_desc">4ч добыча, ×2 эффективность. Крафт, молитва и руническое ремесло — лимит 240 предметов за сессию.</string>
+    <string name="inn_gathering_note">Добыча: часы сессии × множитель эффективности применяется к луту и опыту</string>
+    <string name="inn_crafting_note">Крафт/молитва/руническое ремесло: количество ограничено по уровню; у Долгого чернорабочего нет лимита</string>
+    <string name="worker_skills_title">Работник: %1$s</string>
+    <string name="worker_session_active">Сессия работника активна</string>
+    <string name="worker_session_complete">Сессия работника завершена</string>
+    <string name="worker_manage_from_home">Заберите на главном экране</string>
+    <string name="worker_card_title">Работник</string>
+    <string name="worker_idle">Работник свободен — сессии в очереди начнутся автоматически</string>
+    <string name="worker_collect_btn">Забрать сессию работника</string>
+    <string name="worker_dismiss_btn">Уволить работника</string>
+    <string name="worker_dismiss_confirm_title">Уволить работника?</string>
+    <string name="worker_dismiss_confirm_body">Активная сессия и очередь будут отменены. Стоимость найма и материалы из очереди будут возвращены.</string>
+    <string name="inn_daily_menu">Ежедневное меню</string>
+    <string name="inn_laborers_header">Рабочие</string>
+    <string name="inn_slot1_header">Долгий чернорабочий</string>
+    <string name="inn_slot2_header">Квалифицированный работник</string>
+
+    <!-- ===== Combat difficulty ratings ===== -->
+    <string name="combat_difficulty_likely">Посильный противник</string>
+    <string name="combat_difficulty_risky">Рискованно при текущей экипировке</string>
+    <string name="combat_difficulty_unlikely">Скорее всего погибнете</string>
+
+    <!-- ===== Achievements ===== -->
+    <string name="achievement_group_levelling">Уровни</string>
+    <string name="achievement_group_combat">Бой</string>
+    <string name="achievement_group_quests">Квесты</string>
+    <string name="achievement_group_collection">Коллекция</string>
+
+    <string name="achievement_total_50_name">Авантюрист</string>
+    <string name="achievement_total_50_desc">Достичь суммарного уровня 50</string>
+    <string name="achievement_total_100_name">Умелец</string>
+    <string name="achievement_total_100_desc">Достичь суммарного уровня 100</string>
+    <string name="achievement_total_250_name">Опытный</string>
+    <string name="achievement_total_250_desc">Достичь суммарного уровня 250</string>
+    <string name="achievement_total_500_name">Ветеран</string>
+    <string name="achievement_total_500_desc">Достичь суммарного уровня 500</string>
+    <string name="achievement_total_750_name">Мастер</string>
+    <string name="achievement_total_750_desc">Достичь суммарного уровня 750</string>
+    <string name="achievement_total_1000_name">Легенда</string>
+    <string name="achievement_total_1000_desc">Достичь суммарного уровня 1000</string>
+    <string name="achievement_total_1500_name">Чемпион</string>
+    <string name="achievement_total_1500_desc">Достичь суммарного уровня 1500</string>
+    <string name="achievement_skill_99_name">Первая мастерство</string>
+    <string name="achievement_skill_99_desc">Прокачать любой навык до 99 уровня</string>
+    <string name="achievement_all_99_name">Комплексист</string>
+    <string name="achievement_all_99_desc">Прокачать все навыки до 99 уровня</string>
+
+    <string name="achievement_combat_10_name">Боец</string>
+    <string name="achievement_combat_10_desc">Достичь боевого уровня 10</string>
+    <string name="achievement_combat_30_name">Воин</string>
+    <string name="achievement_combat_30_desc">Достичь боевого уровня 30</string>
+    <string name="achievement_combat_50_name">Чемпион</string>
+    <string name="achievement_combat_50_desc">Достичь боевого уровня 50</string>
+    <string name="achievement_combat_75_name">Элита</string>
+    <string name="achievement_combat_75_desc">Достичь боевого уровня 75</string>
+    <string name="achievement_combat_99_name">Макс. бой</string>
+    <string name="achievement_combat_99_desc">Достичь боевого уровня 99</string>
+
+    <string name="achievement_quest_1_name">Квестер</string>
+    <string name="achievement_quest_1_desc">Выполнить 1 квест</string>
+    <string name="achievement_quest_5_name">Усердный</string>
+    <string name="achievement_quest_5_desc">Выполнить 5 квестов</string>
+    <string name="achievement_quest_25_name">Охотник за квестами</string>
+    <string name="achievement_quest_25_desc">Выполнить 25 квестов</string>
+    <string name="achievement_quest_50_name">Мастер квестов</string>
+    <string name="achievement_quest_50_desc">Выполнить 50 квестов</string>
+    <string name="achievement_quest_all_name">Чемпион квестов</string>
+    <string name="achievement_quest_all_desc">Выполнить все квесты</string>
+
+    <string name="achievement_pet_first_name">Друг животных</string>
+    <string name="achievement_pet_first_desc">Найти первого питомца</string>
+    <string name="achievement_pet_all_name">Зверинец</string>
+    <string name="achievement_pet_all_desc">Собрать всех 7 питомцев</string>
+
+    <!-- ===== Quest display names ===== -->
+    <string name="quest_kbd_slayer_1_name">Убийца Короля Чёрных Драконов I</string>
+    <string name="quest_kbd_slayer_2_name">Убийца Короля Чёрных Драконов II</string>
+    <string name="quest_kbd_slayer_3_name">Убийца Короля Чёрных Драконов III</string>
+    <string name="inn_daily_resets">Обновляется ежедневно в 6:00</string>
+    <string name="inn_food_heal">+%1$d здоровья</string>
+    <string name="inn_food_purchased">Еда куплена.</string>
+    <string name="inn_buy_qty">Количество</string>
+    <string name="inn_buy_total">Итого: %1$s</string>
+    <string name="inn_card_desc">Нанимайте работников и покупайте еду</string>
+    <string name="worker_no_active_session">Работник свободен — нет сессий в очереди</string>
+    <string name="worker_add_sessions">Добавить сессии</string>
+    <string name="inn_worker_tier">%1$s работник</string>
+    <string name="worker_skills_title_nav">Навыки работника</string>
+
+    <!-- Guild Hall -->
+    <string name="guild_hall_title">Зал гильдий</string>
+    <string name="guild_hall_desc">Вступайте в гильдии и получайте награды за репутацию</string>
+    <string name="guild_hall_intro">Гильдии награждают за действия, которые вы уже выполняете. Завершайте квесты и ежедневные поручения, чтобы получать межнавыковые материалы, монеты и опыт — специалисты получат ресурсы даже от навыков, которые не тренируют.</string>
+    <string name="guild_level_label">Уровень %1$d</string>
+    <string name="guild_level_max">Уровень 10 (Макс.)</string>
+    <string name="guild_tab_quests">Квесты</string>
+    <string name="guild_tab_dailies">Ежедневные поручения</string>
+    <string name="guild_daily_resets_in">Обновляется ежедневно в 6:00</string>
+    <string name="guild_locked_hint">Требуется уровень гильдии %1$d</string>
+    <string name="guild_no_dailies">Завершайте квесты гильдии, чтобы зарабатывать репутацию и открывать ежедневные поручения.</string>
+    <string name="guild_contribute_inventory">Передать из инвентаря (%1$d доступно)</string>
+    <string name="guild_quest_desc_gather">Собрать %1$d %2$s для %3$s.</string>
+    <string name="guild_quest_desc_craft">Скрафтить %1$d %2$s для %3$s.</string>
+    <string name="guild_quest_desc_kill">Победить %1$d врагов в ближнем бою (%2$s).</string>
+    <string name="guild_quest_desc_prayer">Захоронить %1$d костей для %2$s.</string>
+    <string name="guild_quest_desc_sessions">Завершить %1$d сессий %2$s для %3$s.</string>
+    <string name="guild_quest_desc_trade">Завершить %1$d торговых маршрутов для %2$s.</string>
+    <string name="guild_quest_desc_earn_coins">Заработать %1$s монет через торговые маршруты для %2$s.</string>
+    <string name="guild_combat_melee">ближний бой</string>
+    <string name="guild_combat_ranged">дальний бой</string>
+    <string name="guild_combat_magic">магия</string>
+    <string name="guild_rep_label">%1$d / %2$d реп.</string>
+    <string name="guild_quest_complete">Квест завершён: %1$s</string>
+    <string name="guild_daily_complete">Награда за ежедневное поручение получена!</string>
+    <string name="guild_name_mining">Гильдия рудокопов</string>
+    <string name="guild_name_fishing">Гильдия рыболовов</string>
+    <string name="guild_name_woodcutting">Гильдия лесорубов</string>
+    <string name="guild_name_farming">Гильдия фермеров</string>
+    <string name="guild_name_firemaking">Гильдия костёров</string>
+    <string name="guild_name_agility">Гильдия ловкости</string>
+    <string name="guild_name_smithing">Гильдия кузнецов</string>
+    <string name="guild_name_cooking">Гильдия поваров</string>
+    <string name="guild_name_fletching">Гильдия лучников</string>
+    <string name="guild_name_crafting">Гильдия ремесленников</string>
+    <string name="guild_name_runecrafting">Гильдия руноделов</string>
+    <string name="guild_name_herblore">Гильдия травников</string>
+    <string name="guild_name_warriors">Гильдия воинов</string>
+    <string name="guild_name_archers">Гильдия стрелков</string>
+    <string name="guild_name_mages">Гильдия магов</string>
+    <string name="guild_name_prayer">Гильдия молитвы</string>
+    <string name="guild_name_mercantile">Гильдия торговцев</string>
+
+    <!-- Mercantile skill -->
+    <string name="skill_mercantile">Торговля</string>
+    <string name="label_support_skills">Поддержка</string>
+    <string name="mercantile_routes_label">Торговые маршруты</string>
+    <string name="mercantile_level_label">Уровень %1$d Торговли</string>
+    <string name="mercantile_xp_label">Опыт: %1$s</string>
+    <string name="mercantile_coins_label">Монеты: %1$s</string>
+    <string name="mercantile_cost_label">Стоимость: %1$s</string>
+    <string name="mercantile_return_range">Доход: %1$s – %2$s</string>
+    <string name="mercantile_dispatch_label">Отправить</string>
+    <string name="mercantile_queue_label">В очередь</string>
+
+    <!-- Church -->
+    <string name="church_title">Церковь</string>
+    <string name="church_desc">Благословения для опыта, защиты и монет</string>
+    <string name="church_no_active_blessing">Нет активного благословения — посетите Церковь для молитвы.</string>
+    <string name="church_active_label">Активное благословение</string>
+    <string name="church_expires_in">Истекает через %1$s</string>
+    <string name="church_blessing_active_fmt">%1$s • %2$s осталось</string>
+    <string name="church_section_xp">Благословения опыта</string>
+    <string name="church_section_defense">Благословения защиты</string>
+    <string name="church_section_coins">Благословения монет</string>
+    <string name="church_locked_level">Требуется уровень Молитвы %1$d</string>
+    <string name="church_active_chip">Активно</string>
+    <string name="church_activate">Активировать</string>
+    <string name="church_blessing_bonus">+%1$s от благословения</string>
+    <string name="church_blessing_suffix">от благословения</string>
+    <string name="church_effect_xp">×%1$.2f опыта на 24 часа</string>
+    <string name="church_effect_def">+%1$d Защиты на 24 часа</string>
+    <string name="church_effect_coins">+%1$d%% монет с добычи на 24 часа</string>
+    <string name="church_cost_bones">Стоимость: %1$d костей</string>
+    <string name="church_confirm_title">Активировать благословение?</string>
+    <string name="church_bones_available">У вас %1$d костей (все виды)</string>
+    <string name="church_not_enough_bones">Недостаточно костей (нужно %1$d)</string>
+    <string name="church_already_active">Благословение уже активно</string>
+
+    <!-- Blessing names -->
+    <string name="blessing_blessed_focus_name">Благословенный фокус</string>
+    <string name="blessing_stone_skin_name">Каменная кожа</string>
+    <string name="blessing_blessed_focus_ii_name">Благословенный фокус II</string>
+    <string name="blessing_stone_skin_ii_name">Каменная кожа II</string>
+    <string name="blessing_blessed_focus_iii_name">Благословенный фокус III</string>
+    <string name="blessing_stone_skin_iii_name">Каменная кожа III</string>
+    <string name="blessing_tithe_blessing_name">Десятина</string>
+    <string name="blessing_stone_skin_iv_name">Каменная кожа IV</string>
+    <string name="blessing_fortune_i_name">Удача I</string>
+    <string name="blessing_tithe_blessing_ii_name">Десятина II</string>
+    <string name="blessing_iron_ward_name">Железный оберег</string>
+    <string name="blessing_fortune_ii_name">Удача II</string>
+    <string name="blessing_tithe_blessing_iii_name">Десятина III</string>
+    <string name="blessing_iron_ward_ii_name">Железный оберег II</string>
+    <string name="blessing_fortune_iii_name">Удача III</string>
+    <string name="blessing_divine_focus_name">Божественный фокус</string>
+    <string name="blessing_diamond_skin_name">Алмазная кожа</string>
+    <string name="blessing_fortune_iv_name">Удача IV</string>
+    <string name="blessing_divine_focus_ii_name">Божественный фокус II</string>
+    <string name="blessing_diamond_skin_ii_name">Алмазная кожа II</string>
+    <string name="blessing_fortune_v_name">Удача V</string>
+    <string name="blessing_divine_grace_name">Божественная благодать</string>
+    <string name="blessing_holy_shield_name">Священный щит</string>
+    <string name="blessing_abundance_name">Изобилие</string>
+    <string name="blessing_divine_grace_ii_name">Божественная благодать II</string>
+    <string name="blessing_holy_shield_ii_name">Священный щит II</string>
+    <string name="blessing_abundance_ii_name">Изобилие II</string>
+    <string name="blessing_sacred_grace_name">Священная благодать</string>
+    <string name="blessing_aegis_name">Эгида</string>
+    <string name="blessing_abundance_iii_name">Изобилие III</string>
+
+    <!-- Skilling dungeon names and descriptions -->
+    <string name="skilling_dungeon_copper_caverns_name">Медные пещеры</string>
+    <string name="skilling_dungeon_copper_caverns_desc">Заброшенная шахта под предгорьями. Медные жилы всё ещё мерцают во тьме.</string>
+    <string name="skilling_dungeon_dwarven_depths_name">Дварфские глубины</string>
+    <string name="skilling_dungeon_dwarven_depths_desc">Глубочайший уровень древней дварфской выработки. Богатые жилы редкого металла скрыты за костями своих строителей.</string>
+    <string name="skilling_dungeon_whispering_grove_name">Шепчущая роща</string>
+    <string name="skilling_dungeon_whispering_grove_desc">Первобытный лес, где деревья росли тысячи лет безмятежно. Что-то шепчет между ветвей.</string>
+    <string name="skilling_dungeon_corrupted_canopy_name">Осквернённая крона</string>
+    <string name="skilling_dungeon_corrupted_canopy_desc">Лес, где тень заменила солнечный свет. Деревья кровоточат чёрным соком, а воздух отдаёт старой магией.</string>
+    <string name="skilling_dungeon_sunken_grotto_name">Затопленный грот</string>
+    <string name="skilling_dungeon_sunken_grotto_desc">Морская пещера, выточенная веками приливов. Странные каменные столбы поднимаются из воды.</string>
+    <string name="skilling_dungeon_abyssal_lagoon_name">Бездонная лагуна</string>
+    <string name="skilling_dungeon_abyssal_lagoon_desc">Чёрная неподвижная лагуна без видимого дна. Рыбы здесь слабо мерцают и растворяются через минуты после ловли.</string>
+    <string name="skilling_dungeon_crumbling_watchtower_name">Руинная башня</string>
+    <string name="skilling_dungeon_crumbling_watchtower_desc">Обветшалая каменная башня на краю предгорий. Что-то всё ещё охраняет то, что когда-то хранилось внутри.</string>
+    <string name="skilling_dungeon_shattered_spire_name">Разрушенный шпиль</string>
+    <string name="skilling_dungeon_shattered_spire_desc">Останки башни мага, превращённые в поле обломков. Воздух всё ещё потрескивает от остаточной магии.</string>
+
+    <!-- Expeditions -->
+    <string name="nav_expeditions">Экспедиции</string>
+    <string name="expeditions_title">Экспедиции</string>
+    <string name="expedition_explore_button">Исследовать</string>
+    <string name="expedition_dungeon_unlocked">Боевое подземелье открыто!</string>
+    <string name="expedition_discover_hint">Откройте через Экспедиции</string>
+    <string name="expedition_loading">Загрузка…</string>
+    <string name="expedition_lore_notes">%1$d / %2$d заметок</string>
+    <string name="expedition_lock_level">Требуется %1$s уровень %2$d</string>
+    <string name="expedition_lock_notes">Найдите все заметки в %1$s, чтобы открыть</string>
+    <string name="expedition_lock_prerequisite">Выполните предварительное условие для открытия</string>
+    <string name="label_notes">Заметки</string>
+
+    <!-- Slayer -->
+    <string name="skill_slayer_name">Убийца</string>
+    <string name="skill_slayer_desc">Получайте задания от Мастера убийц в Городе.</string>
+    <string name="slayer_title">Мастер убийств</string>
+    <string name="slayer_card_desc">Задания и награды для убийц</string>
+    <string name="slayer_desc">Выполняйте задания для опыта Убийцы и очков. Тратьте очки в магазине за эксклюзивное снаряжение.</string>
+    <string name="slayer_level_label">Уровень %1$d</string>
+    <string name="slayer_xp_label">%1$s опыта</string>
+    <string name="slayer_points">%1$d очков</string>
+    <string name="slayer_active_task">Активное задание</string>
+    <string name="slayer_kills_remaining">%1$d / %2$d убийств</string>
+    <string name="slayer_get_task">Получить задание</string>
+    <string name="slayer_skip_task">Пропустить (30 очков)</string>
+    <string name="slayer_no_task">Нет активного задания. Нажмите «Получить задание».</string>
+    <string name="slayer_task_stuck">Этот враг обитает только в подземелье Экспедиций, которое вы ещё не открыли. Переназначить бесплатно.</string>
+    <string name="slayer_reroll_free">Переназначить (бесплатно)</string>
+    <string name="slayer_no_eligible_tasks">Нет доступных заданий на вашем уровне Убийцы.</string>
+    <string name="slayer_task_complete">Задание выполнено! Посетите Мастера убийств за новым.</string>
+    <string name="slayer_xp_per_kill">%1$d опыта/убийство</string>
+    <string name="slayer_points_on_complete">+%1$d очков за выполнение</string>
+    <string name="slayer_shop_title">Магазин убийц</string>
+    <string name="slayer_shop_cost">%1$d очков</string>
+    <string name="slayer_not_enough_points">Недостаточно очков Убийцы.</string>
+    <string name="slayer_already_owned">Уже приобретено.</string>
+    <string name="slayer_purchased">Добавлено в инвентарь.</string>
+    <string name="slayer_owned">Куплено</string>
+    <string name="slayer_lamp_purchased">Опыт добавлен в %1$s!</string>
+    <string name="slayer_lamp_pick_skill">Выберите навык</string>
+    <string name="slayer_lamp_small">Лампа опыта (малая)</string>
+    <string name="slayer_lamp_large">Лампа опыта (большая)</string>
+    <string name="slayer_lamp_small_desc">+10 000 опыта в любой навык</string>
+    <string name="slayer_lamp_large_desc">+50 000 опыта в любой навык</string>
+    <string name="slayer_found_in">Где найти: %1$s</string>
+    <string name="slayer_requires">Требуется: %1$s</string>
+
+    <!-- Prestige system -->
+    <string name="prestige">Престиж</string>
+    <string name="prestige_max">Макс. престиж</string>
+    <string name="prestige_confirm_title">Престиж %s?</string>
+    <string name="prestige_confirm_message_xp">Ваш уровень %1$s сбросится до 1, но вы получите постоянный бонус +%2$d%% опыта для этого навыка.</string>
+    <string name="prestige_confirm_message_stat">Ваш уровень %1$s сбросится до 1, но вы получите постоянный бонус +%2$d к характеристикам.</string>
+
+    <!-- Prestige achievements -->
+    <string name="achievement_prestige_first_name">Первый сброс</string>
+    <string name="achievement_prestige_first_desc">Сделать престиж любого навыка впервые</string>
+    <string name="achievement_prestige_any_3_name">Мастер</string>
+    <string name="achievement_prestige_any_3_desc">Достичь Престижа 3 на любом навыке</string>
+    <string name="achievement_prestige_all_1_name">Чистый лист</string>
+    <string name="achievement_prestige_all_1_desc">Сделать престиж всех навыков хотя бы один раз</string>
+    <string name="achievement_prestige_all_3_name">Истинный престиж</string>
+    <string name="achievement_prestige_all_3_desc">Достичь Престижа 3 на каждом навыке</string>
+
+    <!-- Slayer gear item names/descs -->
+    <string name="item_slayer_helm_name">Шлем убийцы</string>
+    <string name="item_slayer_helm_desc">Крепкий шлем, носимый ветеранами убийц.</string>
+    <string name="item_abyssal_whip_name">Бездонный кнут</string>
+    <string name="item_abyssal_whip_desc">Кнут, выкованный из бездонной энергии. Отличен для тренировки силы.</string>
+    <string name="item_slayer_platebody_name">Нагрудник убийцы</string>
+    <string name="item_slayer_platebody_desc">Тяжёлая броня, покрытая рунами убийц.</string>
+    <string name="item_slayer_platelegs_name">Поножи убийцы</string>
+    <string name="item_slayer_platelegs_desc">Защитные поножи, созданные для длительных походов в подземелья.</string>
+
+    <!-- Shop categories -->
+    <string name="shop_cat_ores_and_materials">Руды и материалы</string>
+    <string name="shop_cat_logs_and_wood">Брёвна и дерево</string>
+    <string name="shop_cat_seeds_and_farming">Семена и фермерство</string>
+    <string name="shop_cat_merchants_guild">Гильдия торговцев</string>
+    <string name="shop_cat_equipment">Снаряжение</string>
+    <string name="shop_cat_special">Особое</string>
+    <string name="shop_cat_weapons">Оружие</string>
+    <string name="shop_cat_armor">Броня</string>
+    <string name="shop_cat_tools">Инструменты</string>
+    <string name="shop_cat_food">Еда</string>
+    <string name="shop_cat_materials">Материалы</string>
+    <string name="shop_cat_misc">Разное</string>
+
+    <string name="crafting_per_craft">×%1$d за крафт</string>
+
+    <!-- Skills screen localisation -->
+    <string name="farming_ready_in">Готово через %1$s</string>
+    <string name="trade_route_local_market_name">Местный рынок</string>
+    <string name="trade_route_river_trading_post_name">Речной торговый пост</string>
+    <string name="trade_route_eastern_caravan_name">Восточный караван</string>
+    <string name="trade_route_grand_exchange_name">Великая биржа</string>
+    <string name="trade_route_merchants_quarter_name">Торговый квартал</string>
+    <string name="trade_route_northern_ports_name">Северные порты</string>
+    <string name="trade_route_local_market_desc">Торгуйте обычными товарами на местном рынке. Доход скромный, но непредсказуемый.</string>
+    <string name="trade_route_river_trading_post_desc">Везите товары по речному маршруту. Прибыль переменчива, но часто worthwhile.</string>
+    <string name="trade_route_eastern_caravan_desc">Присоединитесь к торговому каравану на восток. Долгий путь окупается, когда сделка проходит.</string>
+    <string name="trade_route_grand_exchange_desc">Торгуйте на легендарной Великой бирже, где состояния обретаются и теряются.</string>
+    <string name="trade_route_merchants_quarter_desc">Торгуйте редкими товарами в престижном торговом квартале.</string>
+    <string name="trade_route_northern_ports_desc">Доставьте ценный груз в северные портовые города. Высокий риск, высокая награда.</string>
+    <string name="crafting_cat_bar">Слиток</string>
+    <string name="crafting_cat_component">Компонент</string>
+    <string name="crafting_cat_tool">Инструмент</string>
+    <string name="crafting_cat_weapon">Оружие</string>
+    <string name="crafting_cat_armour">Броня</string>
+    <string name="crafting_cat_equipment">Снаряжение</string>
+    <string name="crafting_cat_food">Еда</string>
+    <string name="crafting_cat_ammunition">Боеприпасы</string>
+    <string name="crafting_cat_jewellery">Ювелирные изделия</string>
+    <string name="crafting_cat_potion">Зелье</string>
+
+    <!-- Crafting tier filter chips -->
+    <string name="crafting_tier_adamantite">Адамантит</string>
+    <string name="crafting_tier_arrow">Стрелы</string>
+    <string name="crafting_tier_bronze">Бронза</string>
+    <string name="crafting_tier_gold">Золото</string>
+    <string name="crafting_tier_iron">Железо</string>
+    <string name="crafting_tier_magic">Магия</string>
+    <string name="crafting_tier_maple">Клён</string>
+    <string name="crafting_tier_mithril">Мифрил</string>
+    <string name="crafting_tier_oak">Дуб</string>
+    <string name="crafting_tier_platinum">Платина</string>
+    <string name="crafting_tier_runite">Рунит</string>
+    <string name="crafting_tier_shortbow">Короткий лук</string>
+    <string name="crafting_tier_silver">Серебро</string>
+    <string name="crafting_tier_staff">Посох</string>
+    <string name="crafting_tier_steel">Сталь</string>
+    <string name="crafting_tier_willow">Ива</string>
+    <string name="crafting_tier_yew">Тис</string>
+
+    <!-- Firemaking rework + ash catalyst + fertilizer -->
+    <string name="firemaking_logs_in_inventory">в инвентаре</string>
+    <string name="firemaking_burns_to">Сгорает в %1$s</string>
+    <string name="firemaking_burn">Сжечь</string>
+    <string name="farming_fertilizer">Удобрение</string>
+    <string name="farming_fertilizer_optional">Добавить удобрение (необязательно)</string>
+    <string name="farming_fertilizer_yield">+%1$d%% урожай</string>
+    <string name="farming_fertilized">Удобрено</string>
+    <string name="catalyst_optional">Пепельный катализатор (необязательно)</string>
+    <string name="catalyst_enhanced_output">Производит усиленное зелье</string>
+    <string name="catalyst_rune_bonus">%1$d рун за эссенцию</string>
+    <string name="catalyst_none">Без катализатора</string>
+</resources>

--- a/app/src/main/res/values-ru/strings_enemies.xml
+++ b/app/src/main/res/values-ru/strings_enemies.xml
@@ -1,0 +1,90 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- ===== Enemy names ===== -->
+    <string name="enemy_giant_rat_name">Гигантская крыса</string>
+    <string name="enemy_goblin_name">Гоблин</string>
+    <string name="enemy_skeleton_name">Скелет</string>
+    <string name="enemy_zombie_name">Зомби</string>
+    <string name="enemy_bandit_name">Бандит</string>
+    <string name="enemy_guard_name">Стражник</string>
+    <string name="enemy_dark_wizard_name">Тёмный маг</string>
+    <string name="enemy_orc_warrior_name">Орк-воин</string>
+    <string name="enemy_spider_name">Гигантский паук</string>
+    <string name="enemy_wild_dog_name">Дикая собака</string>
+    <string name="enemy_rogue_name">Бродяга</string>
+    <string name="enemy_knight_name">Рыцарь</string>
+    <string name="enemy_hellhound_name">Адская гончая</string>
+    <string name="enemy_troll_name">Горный тролль</string>
+    <string name="enemy_demon_name">Малый демон</string>
+    <string name="enemy_dragon_name">Зелёный дракон</string>
+    <string name="enemy_imp_name">Бес</string>
+    <string name="enemy_chicken_name">Курица</string>
+    <string name="enemy_sheep_name">Овца</string>
+    <string name="enemy_cow_name">Корова</string>
+
+    <!-- ===== Dungeon names and descriptions ===== -->
+    <string name="dungeon_imp_cavern_name">Пещера бесов</string>
+    <string name="dungeon_imp_cavern_desc">Мелкая пещера, полная озорных бесов. Идеально для абсолютных новичков!</string>
+    <string name="dungeon_goblin_cave_name">Пещера гоблинов</string>
+    <string name="dungeon_goblin_cave_desc">Тёмная пещера, кишащая гоблинами и гигантскими крысами. Хорошее место для тренировки начинающих искателей приключений.</string>
+    <string name="dungeon_spider_den_name">Логово пауков</string>
+    <string name="dungeon_spider_den_desc">Пещера, затянутая паутиной, где ползают ядовитые пауки. Захватите противоядие!</string>
+    <string name="dungeon_bandit_camp_name">Лагерь бандитов</string>
+    <string name="dungeon_bandit_camp_desc">Укрытие воров и бродяг в глуши. Следите за своим кошельком!</string>
+    <string name="dungeon_undead_crypt_name">Крипта нежити</string>
+    <string name="dungeon_undead_crypt_desc">Древнее кладбище, где мёртвые отказываются упокоиться. Остерегайтесь тёмной магии!</string>
+    <string name="dungeon_fortress_ruins_name">Руины крепости</string>
+    <string name="dungeon_fortress_ruins_desc">Разрушенные остатки древнего замка, ныне охраняемого рыцарями и солдатами.</string>
+    <string name="dungeon_orc_stronghold_name">Крепость орков</string>
+    <string name="dungeon_orc_stronghold_desc">Укреплённое поселение орков глубоко в горах. Только смельчаки осмеливаются войти.</string>
+    <string name="dungeon_volcanic_depths_name">Вулканические глубины</string>
+    <string name="dungeon_volcanic_depths_desc">Обжигающая пещера, населённая адскими гончими и малыми демонами. Жара невыносима!</string>
+    <string name="dungeon_dragon_lair_name">Логово дракона</string>
+    <string name="dungeon_dragon_lair_desc">Легендарное обиталище зелёных драконов. Только воины-мастера выживают в этом испытании.</string>
+    <string name="dungeon_farm_name">Ферма</string>
+    <string name="dungeon_farm_desc">Мирная ферма со скотом. Отлично для новичков, желающих собрать еду!</string>
+    <string name="dungeon_infernal_stronghold_name">Инфернальная цитадель</string>
+    <string name="dungeon_infernal_stronghold_desc">Крепость огня и серы, управляемая демонами и адскими гончими. Одна лишь жара может убить неподготовленного.</string>
+    <string name="dungeon_ancient_temple_name">Древний храм</string>
+    <string name="dungeon_ancient_temple_desc">Древний храм, охраняемый самыми могущественными существами в мире. Только сильнейшие воины осмеливаются войти.</string>
+
+    <!-- ===== Solo boss names (raid bosses retargeted for solo play) ===== -->
+    <string name="boss_king_black_dragon_name">Чёрный король-дракон</string>
+    <string name="boss_demon_lord_name">Повелитель демонов</string>
+    <string name="boss_kraken_name">Кракен</string>
+    <string name="boss_balrog_name">Балрог</string>
+
+    <!-- ===== Pet names and descriptions ===== -->
+    <string name="pet_dragon_whelp_name">Дракончик</string>
+    <string name="pet_dragon_whelp_desc">Молодой дракон, увеличивающий ваш боевой опыт.</string>
+    <string name="pet_imp_pet_name">Бес-питомец</string>
+    <string name="pet_imp_pet_desc">Озорной бес, усиливающий вашу тренировку Молитвы.</string>
+    <string name="pet_baby_kraken_name">Кракенчик</string>
+    <string name="pet_baby_kraken_desc">Крошечный кракен, улучшающий ваш опыт Кулинарии.</string>
+    <string name="pet_rock_golem_name">Каменный голем</string>
+    <string name="pet_rock_golem_desc">Живая скальная формация, усиливающая ваш опыт Добычи руды.</string>
+    <string name="pet_ent_name">Энт</string>
+    <string name="pet_ent_desc">Древний дух дерева, увеличивающий ваш опыт Рубки леса.</string>
+    <string name="pet_tiny_templar_name">Крошечный храмовник</string>
+    <string name="pet_tiny_templar_desc">Маленький рыбный спутник, увеличивающий ваш опыт Рыбалки.</string>
+    <string name="pet_tangleroot_name">Путаник</string>
+    <string name="pet_tangleroot_desc">Магическое растение, усиливающее ваш опыт Фермерства.</string>
+
+    <!-- Missing dungeons -->
+    <string name="dungeon_collapsed_mine_name">Обвалившаяся шахта</string>
+    <string name="dungeon_collapsed_mine_desc">Обширная пещера под медными рудниками. Пещерные тролли и каменные големы бродят среди обломков, а гигантские пауки плетут сети в обвалившихся штольнях.</string>
+    <string name="dungeon_shadow_den_name">Теневое логово</string>
+    <string name="dungeon_shadow_den_desc">Сеть подземных камер, используемых гильдией воров региона. Бродяги, убийцы и теневые существа скрываются в каждом углу.</string>
+    <string name="dungeon_abyssal_ruins_name">Бездонные руины</string>
+    <string name="dungeon_abyssal_ruins_desc">Древние руины, существующие одновременно над и под смертной плоскостью. Странные бездонные существа то появляются, то исчезают из реальности.</string>
+    <string name="dungeon_ancient_forest_ruins_name">Руины древнего леса</string>
+    <string name="dungeon_ancient_forest_ruins_desc">Каменные руины, поглощённые первобытным лесом, ныне населённые дикими существами и мстительными духами друидов.</string>
+    <string name="dungeon_ancient_forge_name">Древняя кузня</string>
+    <string name="dungeon_ancient_forge_desc">Обширная гномья кузня, горящая веками без остановки. Огненные элементали и стражи кузни охраняют её секреты.</string>
+    <string name="dungeon_arcane_ruins_name">Тайные руины</string>
+    <string name="dungeon_arcane_ruins_desc">Действующие подземные камеры разрушенной башни мага. Магические конструкты и зачарованные стражи всё ещё патрулируют её залы.</string>
+    <string name="dungeon_corrupted_sanctum_name">Осквернённое святилище</string>
+    <string name="dungeon_corrupted_sanctum_desc">Святилище, пропитанное тьмой, в центре осквернённого полога. Тёмные жрецы и осквернённые твари охраняют древнее зло.</string>
+    <string name="dungeon_drowned_temple_name">Затопленный храм</string>
+    <string name="dungeon_drowned_temple_desc">Затонувший храм под морским гротом, его залы заполнены водой и морскими существами, сделавшими его своим домом.</string>
+</resources>

--- a/app/src/main/res/values-ru/strings_game.xml
+++ b/app/src/main/res/values-ru/strings_game.xml
@@ -1,0 +1,91 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- ===== Level-up messages ===== -->
+    <!-- Translator note: %1$s = skill display name, %2$d = new level number -->
+    <string name="game_level_up">Новый уровень! %1$s теперь уровень %2$d!</string>
+    <!-- Translator note: %1$s = skill display name, %2$d = new level number -->
+    <string name="game_level_up_short">%1$s → %2$d</string>
+    <string name="game_max_level">Достигнут максимальный уровень!</string>
+
+    <!-- ===== Session result summaries ===== -->
+    <string name="game_session_results_title">Результаты сессии</string>
+    <!-- Translator note: %1$s = skill display name -->
+    <string name="game_session_summary_header">Сессия %1$s завершена</string>
+    <!-- Translator note: %1$s = formatted XP amount (e.g. "1,234") -->
+    <string name="game_session_xp_total">+%1$s опыта получено</string>
+    <string name="game_session_no_items">Предметы не найдены</string>
+    <string name="game_session_no_level_ups">В этой сессии нет новых уровней</string>
+    <!-- Translator note: %1$d = number of level ups -->
+    <string name="game_session_level_up_count">%1$d новый уровень!</string>
+
+    <!-- ===== Combat messages ===== -->
+    <!-- Translator note: %1$s = player or enemy name, %2$d = damage amount -->
+    <string name="game_combat_hit">%1$s наносит %2$d урона.</string>
+    <string name="game_combat_miss">%1$s промахивается!</string>
+    <!-- Translator note: %1$s = enemy display name -->
+    <string name="game_combat_enemy_defeated">%1$s повержен!</string>
+    <!-- Translator note: %1$d = HP restored -->
+    <string name="game_combat_food_eaten">Еда съедена — восстановлено %1$d HP.</string>
+    <string name="game_combat_player_died">Вы потерпели поражение.</string>
+    <string name="game_dungeon_cleared">Подземелье пройдено!</string>
+    <!-- Translator note: %1$s = dungeon display name -->
+    <string name="game_dungeon_summary">%1$s пройдено.</string>
+
+    <!-- ===== Farming messages ===== -->
+    <!-- Translator note: %1$s = crop display name -->
+    <string name="game_farming_planted">%1$s посажен.</string>
+    <!-- Translator note: %1$s = crop display name, %2$d = yield quantity -->
+    <string name="game_farming_harvested">Собрано %2$d %1$s.</string>
+    <string name="game_farming_all_harvested">Все готовые участки собраны.</string>
+    <string name="game_farming_patch_cleared">Участок очищен.</string>
+    <string name="game_farming_not_ready">Этот урожай ещё не готов.</string>
+    <!-- Translator note: %1$s = crop display name, %2$s = time remaining -->
+    <string name="game_farming_ready_in">%1$s будет готов через %2$s.</string>
+
+    <!-- ===== Crafting messages ===== -->
+    <!-- Translator note: %1$d = quantity crafted, %2$s = item display name -->
+    <string name="game_crafted">Создано %1$d %2$s.</string>
+    <!-- Translator note: %1$s = item display name -->
+    <string name="game_missing_ingredient">Не хватает ингредиента: %1$s.</string>
+
+    <!-- ===== Shop messages ===== -->
+    <!-- Translator note: %1$d = quantity, %2$s = item display name, %3$d = total cost -->
+    <string name="game_shop_purchased">Куплено %1$d %2$s за %3$d монет.</string>
+    <!-- Translator note: %1$d = quantity, %2$s = item display name, %3$d = coins received -->
+    <string name="game_shop_sold">Продано %1$d %2$s за %3$d монет.</string>
+
+    <!-- ===== Prayer / burying ===== -->
+    <!-- Translator note: %1$s = bone display name, %2$s = formatted XP gained -->
+    <string name="game_bones_buried">Кости %1$s захоронены — +%2$s опыта Молитвы.</string>
+
+    <!-- ===== Quest messages ===== -->
+    <!-- Translator note: %1$s = quest display name -->
+    <string name="game_quest_started">Квест начат: %1$s</string>
+    <string name="game_quest_completed">Квест завершён: %1$s</string>
+    <string name="game_quest_abandoned">Квест отменён.</string>
+    <!-- Translator note: %1$d = current progress, %2$d = target amount -->
+    <string name="game_quest_progress">Прогресс: %1$d / %2$d</string>
+
+    <!-- ===== XP gain messages (shown in session frame log) ===== -->
+    <!-- Translator note: %1$s = formatted XP gained this minute -->
+    <string name="game_xp_gained">+%1$s опыта</string>
+    <!-- Translator note: %1$s = item display name, %2$d = quantity -->
+    <string name="game_item_received">+%2$d %1$s</string>
+
+    <!-- ===== Arena messages ===== -->
+    <!-- Translator note: %1$s = opponent display name -->
+    <string name="game_arena_challenged">Вас вызвал %1$s!</string>
+    <string name="game_arena_victory">Победа!</string>
+    <string name="game_arena_defeat">Поражение.</string>
+    <!-- Translator note: %1$d = coins won -->
+    <string name="game_arena_coins_won">Выиграно %1$d монет.</string>
+
+    <!-- ===== Easter egg / dig ===== -->
+    <string name="game_dig_you_dig">Вы копаете землю…</string>
+    <string name="game_dig_nothing">Вы нашли только грязь.</string>
+    <!-- Translator note: %1$s = item display name -->
+    <string name="game_dig_found">Вы откопали %1$s!</string>
+    <!-- Translator note: %1$d = current hole depth in metres -->
+    <string name="game_dig_depth">Яма глубиной %1$d метров.</string>
+    <string name="game_dig_cooldown">Вы уже копали сегодня. Приходите завтра.</string>
+</resources>

--- a/app/src/main/res/values-ru/strings_guild_quests.xml
+++ b/app/src/main/res/values-ru/strings_guild_quests.xml
@@ -1,0 +1,460 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Agility Guild Quests -->
+    <string name="quest_agility_guild_1_name">Первые круги</string>
+    <string name="quest_agility_guild_2_name">Преданный бегун</string>
+    <string name="quest_agility_guild_3_name">Забег на выносливость</string>
+    <string name="quest_agility_guild_4_name">Эксперт препятствий</string>
+    <string name="quest_agility_guild_5_name">Стремительные ноги</string>
+    <string name="quest_agility_guild_6_name">Мастер полосы</string>
+    <string name="quest_agility_guild_7_name">Элитный бегун</string>
+    <string name="quest_agility_guild_8_name">Неутомимый</string>
+    <string name="quest_agility_guild_9_name">Непреклонный</string>
+    <string name="quest_agility_guild_10_name">Мастер движения</string>
+
+    <!-- Archers Guild Quests -->
+    <string name="quest_archers_guild_1_name">Первая стрела</string>
+    <string name="quest_archers_guild_2_name">Острый глаз</string>
+    <string name="quest_archers_guild_3_name">Меткий стрелок</string>
+    <string name="quest_archers_guild_4_name">Снайпер</string>
+    <string name="quest_archers_guild_5_name">Орлиный глаз</string>
+    <string name="quest_archers_guild_6_name">Беспощадный выстрел</string>
+    <string name="quest_archers_guild_7_name">Снайпер-призрак</string>
+    <string name="quest_archers_guild_8_name">Соколиный глаз</string>
+    <string name="quest_archers_guild_9_name">Призрак</string>
+    <string name="quest_archers_guild_10_name">Мастер лучников</string>
+
+    <!-- Cooking Guild Quests -->
+    <string name="quest_cooking_guild_1_name">Куриный забег</string>
+    <string name="quest_cooking_guild_2_name">Праздник форели</string>
+    <string name="quest_cooking_guild_3_name">Заказ говядины</string>
+    <string name="quest_cooking_guild_4_name">Лобстер-приём</string>
+    <string name="quest_cooking_guild_5_name">Гала меч-рыбы</string>
+    <string name="quest_cooking_guild_6_name">Мастерок монахфиша</string>
+    <string name="quest_cooking_guild_7_name">Акулий деликатес</string>
+    <string name="quest_cooking_guild_8_name">Барановый марафон</string>
+    <string name="quest_cooking_guild_9_name">Праздник морской черепахи</string>
+    <string name="quest_cooking_guild_10_name">Мастер-повар</string>
+
+    <!-- Crafting Guild Quests -->
+    <string name="quest_crafting_guild_1_name">Серебряные украшения</string>
+    <string name="quest_crafting_guild_2_name">Золотые безделушки</string>
+    <string name="quest_crafting_guild_3_name">Сапфировый набор</string>
+    <string name="quest_crafting_guild_4_name">Изумрудная коллекция</string>
+    <string name="quest_crafting_guild_5_name">Рубиновые кольца</string>
+    <string name="quest_crafting_guild_6_name">Огранка алмазов</string>
+    <string name="quest_crafting_guild_7_name">Платиновые украшения</string>
+    <string name="quest_crafting_guild_8_name">Платиновые ожерелья</string>
+    <string name="quest_crafting_guild_9_name">Сокровищница самоцветов</string>
+    <string name="quest_crafting_guild_10_name">Мастер ремесла</string>
+
+    <!-- Farming Guild Quests -->
+    <string name="quest_farming_guild_1_name">Сбор картофеля</string>
+    <string name="quest_farming_guild_2_name">Доставка моркови</string>
+    <string name="quest_farming_guild_3_name">Запас кукурузы</string>
+    <string name="quest_farming_guild_4_name">Тыквенный участок</string>
+    <string name="quest_farming_guild_5_name">Клубничный сезон</string>
+    <string name="quest_farming_guild_6_name">Магические травы</string>
+    <string name="quest_farming_guild_7_name">Урожай драконьего фрукта</string>
+    <string name="quest_farming_guild_8_name">Золотая пшеница</string>
+    <string name="quest_farming_guild_9_name">Духовные травы</string>
+    <string name="quest_farming_guild_10_name">Мастер-фермер</string>
+
+    <!-- Firemaking Guild Quests -->
+    <string name="quest_firemaking_guild_1_name">Первые огни</string>
+    <string name="quest_firemaking_guild_2_name">Дубовый костёр</string>
+    <string name="quest_firemaking_guild_3_name">Ивовые уголья</string>
+    <string name="quest_firemaking_guild_4_name">Клёновый пожар</string>
+    <string name="quest_firemaking_guild_5_name">Тисовый огонь</string>
+    <string name="quest_firemaking_guild_6_name">Магический костёр</string>
+    <string name="quest_firemaking_guild_7_name">Краснодревный костёр</string>
+    <string name="quest_firemaking_guild_8_name">Древний огонь</string>
+    <string name="quest_firemaking_guild_9_name">Наследие красного дерева</string>
+    <string name="quest_firemaking_guild_10_name">Мастер огня</string>
+
+    <!-- Fishing Guild Quests -->
+    <string name="quest_fishing_guild_1_name">Улов креветок</string>
+    <string name="quest_fishing_guild_2_name">Забег форели</string>
+    <string name="quest_fishing_guild_3_name">Улов лосося</string>
+    <string name="quest_fishing_guild_4_name">Доставка тунца</string>
+    <string name="quest_fishing_guild_5_name">Ловля лобстеров</string>
+    <string name="quest_fishing_guild_6_name">Квота меч-рыбы</string>
+    <string name="quest_fishing_guild_7_name">Заказ монахфиша</string>
+    <string name="quest_fishing_guild_8_name">Акулий промысел</string>
+    <string name="quest_fishing_guild_9_name">Резерв манта-скатов</string>
+    <string name="quest_fishing_guild_10_name">Мастер-рыболов</string>
+
+    <!-- Fletching Guild Quests -->
+    <string name="quest_fletching_guild_1_name">Стрельные древки</string>
+    <string name="quest_fletching_guild_2_name">Бронзовые стрелы</string>
+    <string name="quest_fletching_guild_3_name">Железный полёт</string>
+    <string name="quest_fletching_guild_4_name">Стальная стрела</string>
+    <string name="quest_fletching_guild_5_name">Мифриловый дождь</string>
+    <string name="quest_fletching_guild_6_name">Адамантитовый арсенал</string>
+    <string name="quest_fletching_guild_7_name">Рунитовый колчан</string>
+    <string name="quest_fletching_guild_8_name">Тисовые длинные луки</string>
+    <string name="quest_fletching_guild_9_name">Магические длинные луки</string>
+    <string name="quest_fletching_guild_10_name">Мастер флетчинга</string>
+
+    <!-- Herblore Guild Quests -->
+    <string name="quest_herblore_guild_1_name">Зелья атаки</string>
+    <string name="quest_herblore_guild_2_name">Настойки атаки</string>
+    <string name="quest_herblore_guild_3_name">Настойки силы</string>
+    <string name="quest_herblore_guild_4_name">Настойки дальнего боя</string>
+    <string name="quest_herblore_guild_5_name">Настойки магии</string>
+    <string name="quest_herblore_guild_6_name">Супер-зелья</string>
+    <string name="quest_herblore_guild_7_name">Супер дальнего боя</string>
+    <string name="quest_herblore_guild_8_name">Супер магия</string>
+    <string name="quest_herblore_guild_9_name">Запас перегрузок</string>
+    <string name="quest_herblore_guild_10_name">Мастер-травник</string>
+
+    <!-- Mages Guild Quests -->
+    <string name="quest_mages_guild_1_name">Ученик чародея</string>
+    <string name="quest_mages_guild_2_name">Арканный ученик</string>
+    <string name="quest_mages_guild_3_name">Подмастерье мага</string>
+    <string name="quest_mages_guild_4_name">Повелитель хаоса</string>
+    <string name="quest_mages_guild_5_name">Колдун</string>
+    <string name="quest_mages_guild_6_name">Чернокнижник</string>
+    <string name="quest_mages_guild_7_name">Архимаг</string>
+    <string name="quest_mages_guild_8_name">Лич</string>
+    <string name="quest_mages_guild_9_name">Ткач заклинаний</string>
+    <string name="quest_mages_guild_10_name">Великий маг</string>
+
+    <!-- Mercantile Guild Quests -->
+    <string name="quest_mercantile_guild_1_name">Первая сделка</string>
+    <string name="quest_mercantile_guild_2_name">Начинающий торговец</string>
+    <string name="quest_mercantile_guild_3_name">Речной торговец</string>
+    <string name="quest_mercantile_guild_4_name">Мастер караванов</string>
+    <string name="quest_mercantile_guild_5_name">Портовый инспектор</string>
+    <string name="quest_mercantile_guild_6_name">Торговый принц</string>
+    <string name="quest_mercantile_guild_7_name">Барон торговли</string>
+    <string name="quest_mercantile_guild_8_name">Великий торговец</string>
+    <string name="quest_mercantile_guild_9_name">Легендарный торговец</string>
+    <string name="quest_mercantile_guild_10_name">Мастер биржи</string>
+
+    <!-- Mining Guild Quests -->
+    <string name="quest_mining_guild_1_name">Медный забег</string>
+    <string name="quest_mining_guild_2_name">Железная квота</string>
+    <string name="quest_mining_guild_3_name">Доставка угля</string>
+    <string name="quest_mining_guild_4_name">Серебряная поставка</string>
+    <string name="quest_mining_guild_5_name">Мифриловый заказ</string>
+    <string name="quest_mining_guild_6_name">Золотой стандарт</string>
+    <string name="quest_mining_guild_7_name">Адамантитовый заказ</string>
+    <string name="quest_mining_guild_8_name">Платиновая добыча</string>
+    <string name="quest_mining_guild_9_name">Рунитовый резерв</string>
+    <string name="quest_mining_guild_10_name">Мастер-шахтёр</string>
+
+    <!-- Prayer Guild Quests -->
+    <string name="quest_prayer_guild_1_name">Первое подношение</string>
+    <string name="quest_prayer_guild_2_name">Преданный</string>
+    <string name="quest_prayer_guild_3_name">Благочестивый</string>
+    <string name="quest_prayer_guild_4_name">Праведный</string>
+    <string name="quest_prayer_guild_5_name">Святой</string>
+    <string name="quest_prayer_guild_6_name">Священный</string>
+    <string name="quest_prayer_guild_7_name">Благословенный</string>
+    <string name="quest_prayer_guild_8_name">Божественный</string>
+    <string name="quest_prayer_guild_9_name">Трансцендентный</string>
+    <string name="quest_prayer_guild_10_name">Верховный жрец</string>
+
+    <!-- Runecrafting Guild Quests -->
+    <string name="quest_runecrafting_guild_1_name">Воздушный запас</string>
+    <string name="quest_runecrafting_guild_2_name">Земляная партия</string>
+    <string name="quest_runecrafting_guild_3_name">Огненный запас</string>
+    <string name="quest_runecrafting_guild_4_name">Создание разума</string>
+    <string name="quest_runecrafting_guild_5_name">Хаос-заказ</string>
+    <string name="quest_runecrafting_guild_6_name">Смертная партия</string>
+    <string name="quest_runecrafting_guild_7_name">Кровавый резерв</string>
+    <string name="quest_runecrafting_guild_8_name">Руническое хранилище</string>
+    <string name="quest_runecrafting_guild_9_name">Арканный запас</string>
+    <string name="quest_runecrafting_guild_10_name">Мастер рунического ремесла</string>
+
+    <!-- Smithing Guild Quests -->
+    <string name="quest_smithing_guild_1_name">Бронзовые основы</string>
+    <string name="quest_smithing_guild_2_name">Железные работы</string>
+    <string name="quest_smithing_guild_3_name">Сталеварное производство</string>
+    <string name="quest_smithing_guild_4_name">Мифриловая литейная</string>
+    <string name="quest_smithing_guild_5_name">Адамантитовая кузница</string>
+    <string name="quest_smithing_guild_6_name">Платиновая плавка</string>
+    <string name="quest_smithing_guild_7_name">Рунитовая плавка</string>
+    <string name="quest_smithing_guild_8_name">Склад оружия</string>
+    <string name="quest_smithing_guild_9_name">Хранилище брони</string>
+    <string name="quest_smithing_guild_10_name">Мастер-кузнец</string>
+
+    <!-- Warriors Guild Quests -->
+    <string name="quest_warriors_guild_1_name">Первая кровь</string>
+    <string name="quest_warriors_guild_2_name">Застрельщик</string>
+    <string name="quest_warriors_guild_3_name">Закалённый в бою</string>
+    <string name="quest_warriors_guild_4_name">Ветеран войны</string>
+    <string name="quest_warriors_guild_5_name">Элитный воин</string>
+    <string name="quest_warriors_guild_6_name">Легенда поля боя</string>
+    <string name="quest_warriors_guild_7_name">Чемпион</string>
+    <string name="quest_warriors_guild_8_name">Военачальник</string>
+    <string name="quest_warriors_guild_9_name">Завоеватель</string>
+    <string name="quest_warriors_guild_10_name">Мастер войны</string>
+
+    <!-- Woodcutting Guild Quests -->
+    <string name="quest_woodcutting_guild_1_name">Обычные брёвна</string>
+    <string name="quest_woodcutting_guild_2_name">Доставка дуба</string>
+    <string name="quest_woodcutting_guild_3_name">Ивовый забег</string>
+    <string name="quest_woodcutting_guild_4_name">Клёновый заказ</string>
+    <string name="quest_woodcutting_guild_5_name">Тисовая добыча</string>
+    <string name="quest_woodcutting_guild_6_name">Магический лес</string>
+    <string name="quest_woodcutting_guild_7_name">Запас красного дерева</string>
+    <string name="quest_woodcutting_guild_8_name">Древесина древних</string>
+    <string name="quest_woodcutting_guild_9_name">Наследие красного дерева</string>
+    <string name="quest_woodcutting_guild_10_name">Мастер лесоруба</string>
+
+    <!-- Agility Daily Quests -->
+    <string name="quest_agility_daily_1a_name">Утренний бег</string>
+    <string name="quest_agility_daily_1b_name">Спринтерская тренировка</string>
+    <string name="quest_agility_daily_1c_name">Полоса препятствий</string>
+    <string name="quest_agility_daily_4a_name">Круг выносливости</string>
+    <string name="quest_agility_daily_4b_name">Элитный спринт</string>
+    <string name="quest_agility_daily_4c_name">Продвинутый бег</string>
+    <string name="quest_agility_daily_7a_name">Мастерский круг</string>
+    <string name="quest_agility_daily_7b_name">Чемпионский бег</string>
+    <string name="quest_agility_daily_7c_name">Легендарный спринт</string>
+
+    <!-- Archers Daily Quests -->
+    <string name="quest_archers_daily_1a_name">Практика стрельбы</string>
+    <string name="quest_archers_daily_1b_name">Дежурство на стрельбище</string>
+    <string name="quest_archers_daily_1c_name">Ежедневная охота</string>
+    <string name="quest_archers_daily_1d_name">Зов меткого стрелка</string>
+    <string name="quest_archers_daily_4a_name">Рейд снайпера</string>
+    <string name="quest_archers_daily_4b_name">Дежурство орлиного глаза</string>
+    <string name="quest_archers_daily_4c_name">Марш призрака</string>
+    <string name="quest_archers_daily_7a_name">Рейд снайпера-призрака</string>
+    <string name="quest_archers_daily_7b_name">Марш соколиного глаза</string>
+    <string name="quest_archers_daily_7c_name">Великая охота</string>
+
+    <!-- Cooking Daily Quests -->
+    <string name="quest_cooking_daily_1a_name">Партия креветок</string>
+    <string name="quest_cooking_daily_1b_name">Праздник форели</string>
+    <string name="quest_cooking_daily_1c_name">Лососевый ужин</string>
+    <string name="quest_cooking_daily_1d_name">Улов сельди</string>
+    <string name="quest_cooking_daily_1e_name">Партия тунца</string>
+    <string name="quest_cooking_daily_4a_name">Лобстер-пир</string>
+    <string name="quest_cooking_daily_4b_name">Забег меч-рыбы</string>
+    <string name="quest_cooking_daily_4c_name">Партия монахфиша</string>
+    <string name="quest_cooking_daily_4d_name">Резерв лобстеров</string>
+    <string name="quest_cooking_daily_4e_name">Резерв меч-рыбы</string>
+    <string name="quest_cooking_daily_7a_name">Акулий пир</string>
+    <string name="quest_cooking_daily_7b_name">Банкет манта-скатов</string>
+    <string name="quest_cooking_daily_7c_name">Праздник морской черепахи</string>
+    <string name="quest_cooking_daily_7d_name">Резерв акул</string>
+
+    <!-- Crafting Daily Quests -->
+    <string name="quest_crafting_daily_1a_name">Серебряные кольца</string>
+    <string name="quest_crafting_daily_1b_name">Золотые кольца</string>
+    <string name="quest_crafting_daily_1c_name">Сапфировые камни</string>
+    <string name="quest_crafting_daily_1d_name">Серебряные ожерелья</string>
+    <string name="quest_crafting_daily_1e_name">Золотые ожерелья</string>
+    <string name="quest_crafting_daily_4a_name">Изумрудные кольца</string>
+    <string name="quest_crafting_daily_4b_name">Рубиновые камни</string>
+    <string name="quest_crafting_daily_4c_name">Платиновые кольца</string>
+    <string name="quest_crafting_daily_4d_name">Алмазный набор</string>
+    <string name="quest_crafting_daily_4e_name">Платиновые ожерелья</string>
+    <string name="quest_crafting_daily_7a_name">Платиновые алмазы</string>
+    <string name="quest_crafting_daily_7b_name">Алмазные ожерелья</string>
+    <string name="quest_crafting_daily_7c_name">Сокровищница самоцветов</string>
+
+    <!-- Farming Daily Quests -->
+    <string name="quest_farming_daily_1a_name">Картофельный забег</string>
+    <string name="quest_farming_daily_1b_name">Доставка лука</string>
+    <string name="quest_farming_daily_1c_name">Запас моркови</string>
+    <string name="quest_farming_daily_1d_name">Доставка капусты</string>
+    <string name="quest_farming_daily_1e_name">Партия кукурузы</string>
+    <string name="quest_farming_daily_4a_name">Урожай клубники</string>
+    <string name="quest_farming_daily_4b_name">Доставка тыкв</string>
+    <string name="quest_farming_daily_4c_name">Арбузный забег</string>
+    <string name="quest_farming_daily_4d_name">Партия магических трав</string>
+    <string name="quest_farming_daily_4e_name">Забег драконьего фрукта</string>
+    <string name="quest_farming_daily_7a_name">Духовные травы</string>
+    <string name="quest_farming_daily_7b_name">Небесный цветок</string>
+    <string name="quest_farming_daily_7c_name">Золотая пшеница</string>
+    <string name="quest_farming_daily_7d_name">Доставка старфрута</string>
+    <string name="quest_farming_daily_7e_name">Лотос пустоты</string>
+
+    <!-- Firemaking Daily Quests -->
+    <string name="quest_firemaking_daily_1a_name">Сжигание брёвен</string>
+    <string name="quest_firemaking_daily_1b_name">Дубовый костёр</string>
+    <string name="quest_firemaking_daily_1c_name">Ивовый огонь</string>
+    <string name="quest_firemaking_daily_1d_name">Запас углей</string>
+    <string name="quest_firemaking_daily_1e_name">Клёновый огонь</string>
+    <string name="quest_firemaking_daily_4a_name">Тисовый пожар</string>
+    <string name="quest_firemaking_daily_4b_name">Магический костёр</string>
+    <string name="quest_firemaking_daily_4c_name">Излишек клёна</string>
+    <string name="quest_firemaking_daily_4d_name">Запас тиса</string>
+    <string name="quest_firemaking_daily_4e_name">Магический всплеск</string>
+    <string name="quest_firemaking_daily_7a_name">Краснодревный костёр</string>
+    <string name="quest_firemaking_daily_7b_name">Запас красного дерева</string>
+    <string name="quest_firemaking_daily_7c_name">Древний огонь</string>
+    <string name="quest_firemaking_daily_7d_name">Вечное пламя</string>
+    <string name="quest_firemaking_daily_7e_name">Великий костёр</string>
+
+    <!-- Fishing Daily Quests -->
+    <string name="quest_fishing_daily_1a_name">Улов креветок</string>
+    <string name="quest_fishing_daily_1b_name">Забег форели</string>
+    <string name="quest_fishing_daily_1c_name">Партия лосося</string>
+    <string name="quest_fishing_daily_1d_name">Улов сардин</string>
+    <string name="quest_fishing_daily_1e_name">Доставка тунца</string>
+    <string name="quest_fishing_daily_4a_name">Ловля лобстеров</string>
+    <string name="quest_fishing_daily_4b_name">Забег меч-рыбы</string>
+    <string name="quest_fishing_daily_4c_name">Улов монахфиша</string>
+    <string name="quest_fishing_daily_4d_name">Излишек тунца</string>
+    <string name="quest_fishing_daily_4e_name">Запас лосося</string>
+    <string name="quest_fishing_daily_7a_name">Акулий промысел</string>
+    <string name="quest_fishing_daily_7b_name">Улов манта-скатов</string>
+    <string name="quest_fishing_daily_7c_name">Акулий наплыв</string>
+    <string name="quest_fishing_daily_7d_name">Улов морских черепах</string>
+    <string name="quest_fishing_daily_7e_name">Запас манта-скатов</string>
+
+    <!-- Fletching Daily Quests -->
+    <string name="quest_fletching_daily_1a_name">Стрельные древки</string>
+    <string name="quest_fletching_daily_1b_name">Бронзовая стрела</string>
+    <string name="quest_fletching_daily_1c_name">Железные стрелы</string>
+    <string name="quest_fletching_daily_1d_name">Забег коротких луков</string>
+    <string name="quest_fletching_daily_1e_name">Стальной полёт</string>
+    <string name="quest_fletching_daily_4a_name">Мифриловая стрела</string>
+    <string name="quest_fletching_daily_4b_name">Адамантитовый колчан</string>
+    <string name="quest_fletching_daily_4c_name">Рунитовые стрелы</string>
+    <string name="quest_fletching_daily_4d_name">Тисовый короткий лук</string>
+    <string name="quest_fletching_daily_4e_name">Магический короткий лук</string>
+    <string name="quest_fletching_daily_7a_name">Тисовые длинные луки</string>
+    <string name="quest_fletching_daily_7b_name">Магические длинные луки</string>
+    <string name="quest_fletching_daily_7c_name">Рунитовый колчан</string>
+    <string name="quest_fletching_daily_7d_name">Великий арсенал</string>
+
+    <!-- Herblore Daily Quests -->
+    <string name="quest_herblore_daily_1a_name">Зелья атаки</string>
+    <string name="quest_herblore_daily_1b_name">Зелья защиты</string>
+    <string name="quest_herblore_daily_1c_name">Зелья силы</string>
+    <string name="quest_herblore_daily_1d_name">Настойки атаки</string>
+    <string name="quest_herblore_daily_1e_name">Настойки силы</string>
+    <string name="quest_herblore_daily_4a_name">Настойки дальнего боя</string>
+    <string name="quest_herblore_daily_4b_name">Настойки магии</string>
+    <string name="quest_herblore_daily_4c_name">Супер силы</string>
+    <string name="quest_herblore_daily_4d_name">Супер дальнего боя</string>
+    <string name="quest_herblore_daily_4e_name">Супер магия</string>
+    <string name="quest_herblore_daily_7a_name">Партия перегрузок</string>
+    <string name="quest_herblore_daily_7b_name">Запас перегрузок</string>
+    <string name="quest_herblore_daily_7c_name">Великий запас</string>
+
+    <!-- Mages Daily Quests -->
+    <string name="quest_mages_daily_1a_name">Практика заклинаний</string>
+    <string name="quest_mages_daily_1b_name">Арканное дежурство</string>
+    <string name="quest_mages_daily_1c_name">Ежедневное колдовство</string>
+    <string name="quest_mages_daily_1d_name">Зов колдуна</string>
+    <string name="quest_mages_daily_4a_name">Рейд чернокнижника</string>
+    <string name="quest_mages_daily_4b_name">Дежурство архимага</string>
+    <string name="quest_mages_daily_4c_name">Великое колдовство</string>
+    <string name="quest_mages_daily_7a_name">Рейд лича</string>
+    <string name="quest_mages_daily_7b_name">Дежурство великого мага</string>
+    <string name="quest_mages_daily_7c_name">Арканное завоевание</string>
+
+    <!-- Mercantile Daily Quests -->
+    <string name="quest_mercantile_daily_1a_name">Быстрая сделка</string>
+    <string name="quest_mercantile_daily_1b_name">Рыночный забег</string>
+    <string name="quest_mercantile_daily_1c_name">Загруженный день</string>
+    <string name="quest_mercantile_daily_1d_name">Заработчик монет</string>
+    <string name="quest_mercantile_daily_1e_name">Рыночная прибыль</string>
+    <string name="quest_mercantile_daily_4a_name">Активный торговец</string>
+    <string name="quest_mercantile_daily_4b_name">Большой объём</string>
+    <string name="quest_mercantile_daily_4c_name">Портовые связи</string>
+    <string name="quest_mercantile_daily_4d_name">Добыча монет</string>
+    <string name="quest_mercantile_daily_4e_name">Движение прибыли</string>
+    <string name="quest_mercantile_daily_7a_name">Великая торговля</string>
+    <string name="quest_mercantile_daily_7b_name">Элитные маршруты</string>
+    <string name="quest_mercantile_daily_7c_name">Мастер биржи</string>
+    <string name="quest_mercantile_daily_7d_name">Забег удачи</string>
+    <string name="quest_mercantile_daily_7e_name">Великая прибыль</string>
+
+    <!-- Mining Daily Quests -->
+    <string name="quest_mining_daily_1a_name">Доставка железа</string>
+    <string name="quest_mining_daily_1b_name">Медная квота</string>
+    <string name="quest_mining_daily_1c_name">Угольный забег</string>
+    <string name="quest_mining_daily_1d_name">Оловянный запас</string>
+    <string name="quest_mining_daily_1e_name">Серебряная находка</string>
+    <string name="quest_mining_daily_4a_name">Мифриловая партия</string>
+    <string name="quest_mining_daily_4b_name">Золотая добыча</string>
+    <string name="quest_mining_daily_4c_name">Адамантитовый забег</string>
+    <string name="quest_mining_daily_4d_name">Угольный резерв</string>
+    <string name="quest_mining_daily_4e_name">Железный излишек</string>
+    <string name="quest_mining_daily_7a_name">Платиновый забег</string>
+    <string name="quest_mining_daily_7b_name">Рунитовая квота</string>
+    <string name="quest_mining_daily_7c_name">Адамантитовый наплыв</string>
+    <string name="quest_mining_daily_7d_name">Платиновый запас</string>
+    <string name="quest_mining_daily_7e_name">Глубинная добыча</string>
+
+    <!-- Prayer Daily Quests -->
+    <string name="quest_prayer_daily_1a_name">Утреннее подношение</string>
+    <string name="quest_prayer_daily_1b_name">Ежедневные обряды</string>
+    <string name="quest_prayer_daily_1c_name">Священное подношение</string>
+    <string name="quest_prayer_daily_1d_name">Благочестивый долг</string>
+    <string name="quest_prayer_daily_4a_name">Святые обряды</string>
+    <string name="quest_prayer_daily_4b_name">Священные обряды</string>
+    <string name="quest_prayer_daily_4c_name">Великое подношение</string>
+    <string name="quest_prayer_daily_7a_name">Божественное подношение</string>
+    <string name="quest_prayer_daily_7b_name">Трансцендентные обряды</string>
+    <string name="quest_prayer_daily_7c_name">Великое благочестие</string>
+
+    <!-- Runecrafting Daily Quests -->
+    <string name="quest_runecrafting_daily_1a_name">Воздушные руны</string>
+    <string name="quest_runecrafting_daily_1b_name">Водные руны</string>
+    <string name="quest_runecrafting_daily_1c_name">Земляные руны</string>
+    <string name="quest_runecrafting_daily_1d_name">Огненные руны</string>
+    <string name="quest_runecrafting_daily_1e_name">Руны разума</string>
+    <string name="quest_runecrafting_daily_4a_name">Партия хаоса</string>
+    <string name="quest_runecrafting_daily_4b_name">Партия смерти</string>
+    <string name="quest_runecrafting_daily_4c_name">Кровавый резерв</string>
+    <string name="quest_runecrafting_daily_4d_name">Запас смерти</string>
+    <string name="quest_runecrafting_daily_4e_name">Кровавая партия</string>
+    <string name="quest_runecrafting_daily_7a_name">Кровавое хранилище</string>
+    <string name="quest_runecrafting_daily_7b_name">Арканный резерв</string>
+    <string name="quest_runecrafting_daily_7c_name">Великий запас</string>
+
+    <!-- Smithing Daily Quests -->
+    <string name="quest_smithing_daily_1a_name">Бронзовая партия</string>
+    <string name="quest_smithing_daily_1b_name">Железный забег</string>
+    <string name="quest_smithing_daily_1c_name">Доставка стали</string>
+    <string name="quest_smithing_daily_1d_name">Железный излишек</string>
+    <string name="quest_smithing_daily_1e_name">Стальной резерв</string>
+    <string name="quest_smithing_daily_4a_name">Мифриловая партия</string>
+    <string name="quest_smithing_daily_4b_name">Адамантитовый забег</string>
+    <string name="quest_smithing_daily_4c_name">Платиновая партия</string>
+    <string name="quest_smithing_daily_4d_name">Мифриловый резерв</string>
+    <string name="quest_smithing_daily_4e_name">Адамантитовый резерв</string>
+    <string name="quest_smithing_daily_7a_name">Рунитовая партия</string>
+    <string name="quest_smithing_daily_7b_name">Рунитовый резерв</string>
+    <string name="quest_smithing_daily_7c_name">Платиновое хранилище</string>
+    <string name="quest_smithing_daily_7d_name">Великая кузня</string>
+
+    <!-- Warriors Daily Quests -->
+    <string name="quest_warriors_daily_1a_name">Первая стычка</string>
+    <string name="quest_warriors_daily_1b_name">Ежедневный рейд</string>
+    <string name="quest_warriors_daily_1c_name">Долг воина</string>
+    <string name="quest_warriors_daily_1d_name">Боевая практика</string>
+    <string name="quest_warriors_daily_4a_name">Элитный рейд</string>
+    <string name="quest_warriors_daily_4b_name">Долг ветерана</string>
+    <string name="quest_warriors_daily_4c_name">Марш чемпиона</string>
+    <string name="quest_warriors_daily_7a_name">Рейд военачальника</string>
+    <string name="quest_warriors_daily_7b_name">Марш завоевателя</string>
+    <string name="quest_warriors_daily_7c_name">Великая битва</string>
+
+    <!-- Woodcutting Daily Quests -->
+    <string name="quest_woodcutting_daily_1a_name">Запас брёвен</string>
+    <string name="quest_woodcutting_daily_1b_name">Дубовый забег</string>
+    <string name="quest_woodcutting_daily_1c_name">Ивовая партия</string>
+    <string name="quest_woodcutting_daily_1d_name">Дубовый излишек</string>
+    <string name="quest_woodcutting_daily_1e_name">Ивовый резерв</string>
+    <string name="quest_woodcutting_daily_4a_name">Клёновая партия</string>
+    <string name="quest_woodcutting_daily_4b_name">Тисовый забег</string>
+    <string name="quest_woodcutting_daily_4c_name">Магический лес</string>
+    <string name="quest_woodcutting_daily_4d_name">Клёновый излишек</string>
+    <string name="quest_woodcutting_daily_4e_name">Тисовый резерв</string>
+    <string name="quest_woodcutting_daily_7a_name">Магическая добыча</string>
+    <string name="quest_woodcutting_daily_7b_name">Забег красного дерева</string>
+    <string name="quest_woodcutting_daily_7c_name">Древесина древних</string>
+    <string name="quest_woodcutting_daily_7d_name">Запас красного дерева</string>
+    <string name="quest_woodcutting_daily_7e_name">Мастерский лес</string>
+</resources>

--- a/app/src/main/res/values-ru/strings_items.xml
+++ b/app/src/main/res/values-ru/strings_items.xml
@@ -1,0 +1,610 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- ===== Ores ===== -->
+    <string name="item_copper_ore_name">Медная руда</string>
+    <string name="item_copper_ore_desc">Обычная руда. Смешайте с оловянной рудой для выплавки бронзовых слитков.</string>
+    <string name="item_tin_ore_name">Оловянная руда</string>
+    <string name="item_tin_ore_desc">Обычная руда. Смешайте с медной рудой для выплавки бронзовых слитков.</string>
+    <string name="item_iron_ore_name">Железная руда</string>
+    <string name="item_iron_ore_desc">Универсальная руда для выплавки железных и стальных слитков.</string>
+    <string name="item_coal_name">Уголь</string>
+    <string name="item_coal_desc">Используется как топливный компонент при выплавке стальных и более высокоуровневых слитков.</string>
+    <string name="item_silver_ore_name">Серебряная руда</string>
+    <string name="item_silver_ore_desc">Драгоценная руда для создания серебряных слитков и украшений.</string>
+    <string name="item_gold_ore_name">Золотая руда</string>
+    <string name="item_gold_ore_desc">Драгоценная руда для создания золотых слитков и украшений.</string>
+    <string name="item_mithril_ore_name">Мифриловая руда</string>
+    <string name="item_mithril_ore_desc">Редкая руда с магическими свойствами.</string>
+    <string name="item_adamantite_ore_name">Адамантитовая руда</string>
+    <string name="item_adamantite_ore_desc">Экстремально твёрдая и очень редкая руда.</string>
+    <string name="item_runite_ore_name">Рунитовая руда</string>
+    <string name="item_runite_ore_desc">Самая редкая добываемая руда, используемая для сильнейшего снаряжения.</string>
+    <string name="item_rune_essence_name">Руническая эссенция</string>
+    <string name="item_rune_essence_desc">Сырой магический камень для создания всех типов рун.</string>
+
+    <!-- ===== Metal bars ===== -->
+    <string name="item_bronze_bar_name">Бронзовый слиток</string>
+    <string name="item_bronze_bar_desc">Выплавлен из медной и оловянной руды. Самый базовый металлический слиток.</string>
+    <string name="item_iron_bar_name">Железный слиток</string>
+    <string name="item_iron_bar_desc">Прочный железный слиток для создания железного снаряжения.</string>
+    <string name="item_silver_bar_name">Серебряный слиток</string>
+    <string name="item_silver_bar_desc">Очищенный серебряный слиток для создания украшений.</string>
+    <string name="item_steel_bar_name">Стальной слиток</string>
+    <string name="item_steel_bar_desc">Прочнее железа. Используется для создания стального снаряжения.</string>
+    <string name="item_gold_bar_name">Золотой слиток</string>
+    <string name="item_gold_bar_desc">Очищенный золотой слиток для создания украшений и золотого снаряжения.</string>
+    <string name="item_mithril_bar_name">Мифриловый слиток</string>
+    <string name="item_mithril_bar_desc">Легковесный магический металлический слиток.</string>
+    <string name="item_adamantite_bar_name">Адамантитовый слиток</string>
+    <string name="item_adamantite_bar_desc">Экстремально твёрдый металлический слиток.</string>
+    <string name="item_platinum_bar_name">Платиновый слиток</string>
+    <string name="item_platinum_bar_desc">Редкий и блестящий платиновый слиток для высокоуровневых украшений.</string>
+    <string name="item_runite_bar_name">Рунитовый слиток</string>
+    <string name="item_runite_bar_desc">Самый прочный выплавляемый металлический слиток.</string>
+
+    <!-- ===== Gems ===== -->
+    <string name="item_sapphire_name">Сапфир</string>
+    <string name="item_sapphire_desc">Синий драгоценный камень, используемый в ремесле украшений.</string>
+    <string name="item_emerald_name">Изумруд</string>
+    <string name="item_emerald_desc">Зелёный драгоценный камень средней редкости.</string>
+    <string name="item_ruby_name">Рубин</string>
+    <string name="item_ruby_desc">Красный драгоценный камень. Редкий и ценный.</string>
+    <string name="item_diamond_name">Алмаз</string>
+    <string name="item_diamond_desc">Самый редкий и ценный драгоценный камень.</string>
+
+    <!-- ===== Logs ===== -->
+    <string name="item_log_name">Брёвна</string>
+    <string name="item_log_desc">Обычные брёвна. Используются в Разжигании огня и Флетчинге.</string>
+    <string name="item_oak_log_name">Дубовые брёвна</string>
+    <string name="item_oak_log_desc">Брёвна из дуба.</string>
+    <string name="item_willow_log_name">Ивовые брёвна</string>
+    <string name="item_willow_log_desc">Лёгкие брёвна из ивы.</string>
+    <string name="item_maple_log_name">Кленовые брёвна</string>
+    <string name="item_maple_log_desc">Плотные брёвна из клёна.</string>
+    <string name="item_yew_log_name">Тисовые брёвна</string>
+    <string name="item_yew_log_desc">Брёвна из древнего тиса.</string>
+    <string name="item_magic_log_name">Магические брёвна</string>
+    <string name="item_magic_log_desc">Зачарованные брёвна из редких магических деревьев.</string>
+    <string name="item_redwood_log_name">Брёвна секвойи</string>
+    <string name="item_redwood_log_desc">Массивные брёвна из самых высоких деревьев секвойи.</string>
+
+    <!-- ===== Raw fish ===== -->
+    <string name="item_raw_shrimp_name">Сырая креветка</string>
+    <string name="item_raw_shrimp_desc">Сырая креветка. Приготовьте перед употреблением.</string>
+    <string name="item_raw_sardine_name">Сырая сардина</string>
+    <string name="item_raw_sardine_desc">Сырая сардина. Приготовьте перед употреблением.</string>
+    <string name="item_raw_herring_name">Сырая сельдь</string>
+    <string name="item_raw_herring_desc">Сырая сельдь. Приготовьте перед употреблением.</string>
+    <string name="item_raw_mackerel_name">Сырая скумбрия</string>
+    <string name="item_raw_mackerel_desc">Сырая скумбрия. Приготовьте перед употреблением.</string>
+    <string name="item_raw_trout_name">Сырая форель</string>
+    <string name="item_raw_trout_desc">Сырая форель. Приготовьте перед употреблением.</string>
+    <string name="item_raw_salmon_name">Сырой лосось</string>
+    <string name="item_raw_salmon_desc">Сырой лосось. Приготовьте перед употреблением.</string>
+    <string name="item_raw_tuna_name">Сырой тунец</string>
+    <string name="item_raw_tuna_desc">Сырой тунец. Приготовьте перед употреблением.</string>
+    <string name="item_raw_lobster_name">Сырой омар</string>
+    <string name="item_raw_lobster_desc">Сырой омар. Приготовьте перед употреблением.</string>
+    <string name="item_raw_swordfish_name">Сырая рыба-меч</string>
+    <string name="item_raw_swordfish_desc">Сырая рыба-меч. Приготовьте перед употреблением.</string>
+    <string name="item_raw_monkfish_name">Сырой морской черт</string>
+    <string name="item_raw_monkfish_desc">Сырой морской черт. Приготовьте перед употреблением.</string>
+    <string name="item_raw_shark_name">Сырая акула</string>
+    <string name="item_raw_shark_desc">Сырая акула. Приготовьте перед употреблением.</string>
+    <string name="item_raw_sea_turtle_name">Сырая морская черепаха</string>
+    <string name="item_raw_sea_turtle_desc">Сырая морская черепаха. Приготовьте перед употреблением.</string>
+    <string name="item_raw_manta_ray_name">Сырой манта</string>
+    <string name="item_raw_manta_ray_desc">Сырой манта. Приготовьте перед употреблением.</string>
+
+    <!-- ===== Cooked fish ===== -->
+    <string name="item_shrimp_name">Креветка</string>
+    <string name="item_shrimp_desc">Приготовленная креветка. Восстанавливает немного HP.</string>
+    <string name="item_sardine_name">Сардина</string>
+    <string name="item_sardine_desc">Приготовленная сардина. Восстанавливает HP при употреблении.</string>
+    <string name="item_herring_name">Сельдь</string>
+    <string name="item_herring_desc">Приготовленная сельдь. Восстанавливает HP при употреблении.</string>
+    <string name="item_mackerel_name">Скумбрия</string>
+    <string name="item_mackerel_desc">Приготовленная скумбрия. Восстанавливает HP при употреблении.</string>
+    <string name="item_trout_name">Форель</string>
+    <string name="item_trout_desc">Приготовленная форель. Восстанавливает HP при употреблении.</string>
+    <string name="item_salmon_name">Лосось</string>
+    <string name="item_salmon_desc">Приготовленный лосось. Восстанавливает HP при употреблении.</string>
+    <string name="item_tuna_name">Тунец</string>
+    <string name="item_tuna_desc">Приготовленный тунец. Восстанавливает HP при употреблении.</string>
+    <string name="item_lobster_name">Омар</string>
+    <string name="item_lobster_desc">Приготовленный омар. Восстанавливает хорошее количество HP.</string>
+    <string name="item_swordfish_name">Рыба-меч</string>
+    <string name="item_swordfish_desc">Приготовленная рыба-меч. Восстанавливает значительное количество HP.</string>
+    <string name="item_monkfish_name">Морской черт</string>
+    <string name="item_monkfish_desc">Приготовленный морской черт. Восстанавливает солидное количество HP.</string>
+    <string name="item_shark_name">Акула</string>
+    <string name="item_shark_desc">Приготовленная акула. Восстанавливает большое количество HP.</string>
+    <string name="item_sea_turtle_name">Морская черепаха</string>
+    <string name="item_sea_turtle_desc">Приготовленная морская черепаха. Восстанавливает очень большое количество HP.</string>
+    <string name="item_manta_ray_name">Манта</string>
+    <string name="item_manta_ray_desc">Приготовленный манта. Одна из лучших доступных блюд.</string>
+
+    <!-- ===== Raw meat ===== -->
+    <string name="item_raw_rat_meat_name">Сырое крысиное мясо</string>
+    <string name="item_raw_rat_meat_desc">Сырое крысиное мясо. Приготовьте перед употреблением.</string>
+    <string name="item_raw_chicken_name">Сырая курица</string>
+    <string name="item_raw_chicken_desc">Сырая курица. Приготовьте перед употреблением.</string>
+    <string name="item_raw_mutton_name">Сырая баранина</string>
+    <string name="item_raw_mutton_desc">Сырая баранина. Приготовьте перед употреблением.</string>
+    <string name="item_raw_beef_name">Сырая говядина</string>
+    <string name="item_raw_beef_desc">Сырая говядина. Приготовьте перед употреблением.</string>
+    <string name="item_raw_meat_name">Сырое мясо</string>
+    <string name="item_raw_meat_desc">Неопознанное сырое мясо. Приготовьте перед употреблением.</string>
+
+    <!-- ===== Cooked meat ===== -->
+    <string name="item_cooked_rat_meat_name">Крысиное мясо</string>
+    <string name="item_cooked_rat_meat_desc">Приготовленное крысиное мясо. Вряд ли съедобно, но восстанавливает крошечное количество HP.</string>
+    <string name="item_cooked_chicken_name">Курица</string>
+    <string name="item_cooked_chicken_desc">Приготовленная курица. Восстанавливает HP при употреблении.</string>
+    <string name="item_cooked_mutton_name">Баранина</string>
+    <string name="item_cooked_mutton_desc">Приготовленная баранина. Восстанавливает HP при употреблении.</string>
+    <string name="item_cooked_beef_name">Говядина</string>
+    <string name="item_cooked_beef_desc">Приготовленная говядина. Восстанавливает HP при употреблении.</string>
+
+    <!-- ===== Melee weapons — bronze ===== -->
+    <string name="item_bronze_sword_name">Бронзовый меч</string>
+    <string name="item_bronze_sword_desc">Базовый одноручный бронзовый клинок.</string>
+    <string name="item_bronze_scimitar_name">Бронзовый ятаган</string>
+    <string name="item_bronze_scimitar_desc">Изогнутый одноручный бронзовый клинок с хорошим бонусом силы.</string>
+    <string name="item_bronze_2h_sword_name">Бронзовый двуручный меч</string>
+    <string name="item_bronze_2h_sword_desc">Двуручный бронзовый меч. Высокий урон, медленная скорость.</string>
+    <string name="item_bronze_warhammer_name">Бронзовый молот войны</string>
+    <string name="item_bronze_warhammer_desc">Тяжёлый одноручный бронзовый молот.</string>
+    <string name="item_bronze_battleaxe_name">Бронзовая секира</string>
+    <string name="item_bronze_battleaxe_desc">Грозный одноручный бронзовый топор.</string>
+    <string name="item_bronze_dagger_name">Бронзовый кинжал</string>
+    <string name="item_bronze_dagger_desc">Быстрый и лёгкий бронзовый кинжал.</string>
+
+    <!-- Melee weapons — iron -->
+    <string name="item_iron_sword_name">Железный меч</string>
+    <string name="item_iron_sword_desc">Одноручный железный клинок.</string>
+    <string name="item_iron_scimitar_name">Железный ятаган</string>
+    <string name="item_iron_scimitar_desc">Изогнутый одноручный железный клинок с хорошим бонусом силы.</string>
+    <string name="item_iron_2h_sword_name">Железный двуручный меч</string>
+    <string name="item_iron_2h_sword_desc">Двуручный железный меч.</string>
+    <string name="item_iron_warhammer_name">Железный молот войны</string>
+    <string name="item_iron_warhammer_desc">Тяжёлый одноручный железный молот.</string>
+    <string name="item_iron_battleaxe_name">Железная секира</string>
+    <string name="item_iron_battleaxe_desc">Грозный одноручный железный топор.</string>
+    <string name="item_iron_dagger_name">Железный кинжал</string>
+    <string name="item_iron_dagger_desc">Быстрый и лёгкий железный кинжал.</string>
+
+    <!-- Melee weapons — steel -->
+    <string name="item_steel_sword_name">Стальной меч</string>
+    <string name="item_steel_sword_desc">Одноручный стальной клинок.</string>
+    <string name="item_steel_scimitar_name">Стальной ятаган</string>
+    <string name="item_steel_scimitar_desc">Изогнутый одноручный стальной клинок с хорошим бонусом силы.</string>
+    <string name="item_steel_2h_sword_name">Стальной двуручный меч</string>
+    <string name="item_steel_2h_sword_desc">Двуручный стальной меч.</string>
+    <string name="item_steel_warhammer_name">Стальной молот войны</string>
+    <string name="item_steel_warhammer_desc">Тяжёлый одноручный стальной молот.</string>
+    <string name="item_steel_battleaxe_name">Стальная секира</string>
+    <string name="item_steel_battleaxe_desc">Грозный одноручный стальной топор.</string>
+
+    <!-- Melee weapons — mithril -->
+    <string name="item_mithril_sword_name">Мифриловый меч</string>
+    <string name="item_mithril_sword_desc">Легковесный магический одноручный меч.</string>
+    <string name="item_mithril_scimitar_name">Мифриловый ятаган</string>
+    <string name="item_mithril_scimitar_desc">Изогнутый мифриловый клинок, сверхъестественно острый.</string>
+    <string name="item_mithril_2h_sword_name">Мифриловый двуручный меч</string>
+    <string name="item_mithril_2h_sword_desc">Двуручный мифриловый меч.</string>
+    <string name="item_mithril_warhammer_name">Мифриловый молот войны</string>
+    <string name="item_mithril_warhammer_desc">Легковесный магический молот войны.</string>
+    <string name="item_mithril_battleaxe_name">Мифриловая секира</string>
+    <string name="item_mithril_battleaxe_desc">Мифриловая секира исключительного качества.</string>
+
+    <!-- Melee weapons — adamantite -->
+    <string name="item_adamantite_sword_name">Адамантитовый меч</string>
+    <string name="item_adamantite_sword_desc">Экстремально твёрдый одноручный меч.</string>
+    <string name="item_adamantite_scimitar_name">Адамантитовый ятаган</string>
+    <string name="item_adamantite_scimitar_desc">Невероятно твёрдый изогнутый клинок с отличным бонусом силы.</string>
+    <string name="item_adamantite_2h_sword_name">Адамантитовый двуручный меч</string>
+    <string name="item_adamantite_2h_sword_desc">Двуручный меч, выкованный из адамантита.</string>
+    <string name="item_adamantite_warhammer_name">Адамантитовый молот войны</string>
+    <string name="item_adamantite_warhammer_desc">Экстремально тяжёлый и твёрдый молот войны.</string>
+    <string name="item_adamantite_battleaxe_name">Адамантитовая секира</string>
+    <string name="item_adamantite_battleaxe_desc">Разрушительная адамантитовая секира.</string>
+
+    <!-- Melee weapons — runite -->
+    <string name="item_runite_sword_name">Рунитовый меч</string>
+    <string name="item_runite_sword_desc">Лучший доступный одноручный меч.</string>
+    <string name="item_runite_scimitar_name">Рунитовый ятаган</string>
+    <string name="item_runite_scimitar_desc">Лучший доступный ятаган с исключительным бонусом силы.</string>
+    <string name="item_runite_2h_sword_name">Рунитовый двуручный меч</string>
+    <string name="item_runite_2h_sword_desc">Лучший доступный двуручный меч.</string>
+    <string name="item_runite_warhammer_name">Рунитовый молот войны</string>
+    <string name="item_runite_warhammer_desc">Лучший доступный молот войны.</string>
+    <string name="item_runite_battleaxe_name">Рунитовая секира</string>
+    <string name="item_runite_battleaxe_desc">Лучшая доступная секира.</string>
+
+    <!-- ===== Ranged weapons ===== -->
+    <string name="item_wooden_bow_name">Деревянный лук</string>
+    <string name="item_wooden_bow_desc">Простой деревянный лук. Подходит для тренировки Стрельбы.</string>
+    <string name="item_oak_bow_name">Дубовый лук</string>
+    <string name="item_oak_bow_desc">Надёжный лук, сделанный из дуба.</string>
+
+    <!-- ===== Magic weapons ===== -->
+    <string name="item_basic_staff_name">Базовый посох</string>
+    <string name="item_basic_staff_desc">Простой магический посох для магов-учеников.</string>
+    <string name="item_apprentice_staff_name">Посох ученика</string>
+    <string name="item_apprentice_staff_desc">Улучшенный посох для развивающихся магов.</string>
+    <string name="item_staff_of_air_name">Посох воздуха</string>
+    <string name="item_staff_of_air_desc">Элементальный посох, наделённый силой воздуха.</string>
+    <string name="item_staff_of_water_name">Посох воды</string>
+    <string name="item_staff_of_water_desc">Элементальный посох, наделённый силой воды.</string>
+    <string name="item_staff_of_earth_name">Посох земли</string>
+    <string name="item_staff_of_earth_desc">Элементальный посох, наделённый силой земли.</string>
+    <string name="item_staff_of_fire_name">Посох огня</string>
+    <string name="item_staff_of_fire_desc">Элементальный посох, наделённый силой огня.</string>
+    <string name="item_staff_of_mind_name">Посох разума</string>
+    <string name="item_staff_of_mind_desc">Посох, наделённый психической энергией.</string>
+    <string name="item_staff_of_chaos_name">Посох хаоса</string>
+    <string name="item_staff_of_chaos_desc">Хаотический посох, пульсирующий дикой магической энергией.</string>
+    <string name="item_staff_of_death_name">Посох смерти</string>
+    <string name="item_staff_of_death_desc">Тёмный посох, окутанный силой смерти.</string>
+    <string name="item_staff_of_blood_name">Посох крови</string>
+    <string name="item_staff_of_blood_desc">Могущественный посох, питаемый магией крови.</string>
+
+    <!-- ===== Armour — bronze ===== -->
+    <string name="item_bronze_helmet_name">Бронзовый шлем</string>
+    <string name="item_bronze_helmet_desc">Базовая бронзовая защита головы.</string>
+    <string name="item_bronze_platebody_name">Бронзовый нагрудник</string>
+    <string name="item_bronze_platebody_desc">Базовая бронзовая броня тела.</string>
+    <string name="item_bronze_platelegs_name">Бронзовые поножи</string>
+    <string name="item_bronze_platelegs_desc">Базовая бронзовая защита ног.</string>
+    <string name="item_bronze_shield_name">Бронзовый щит</string>
+    <string name="item_bronze_shield_desc">Базовый бронзовый щит.</string>
+
+    <!-- Armour — iron -->
+    <string name="item_iron_helmet_name">Железный шлем</string>
+    <string name="item_iron_helmet_desc">Железная защита головы.</string>
+    <string name="item_iron_platebody_name">Железный нагрудник</string>
+    <string name="item_iron_platebody_desc">Железная броня тела.</string>
+    <string name="item_iron_platelegs_name">Железные поножи</string>
+    <string name="item_iron_platelegs_desc">Железная защита ног.</string>
+    <string name="item_iron_shield_name">Железный щит</string>
+    <string name="item_iron_shield_desc">Железный щит.</string>
+
+    <!-- Armour — steel -->
+    <string name="item_steel_helmet_name">Стальной шлем</string>
+    <string name="item_steel_helmet_desc">Прочная стальная защита головы.</string>
+    <string name="item_steel_platebody_name">Стальной нагрудник</string>
+    <string name="item_steel_platebody_desc">Прочная стальная броня тела.</string>
+    <string name="item_steel_platelegs_name">Стальные поножи</string>
+    <string name="item_steel_platelegs_desc">Прочная стальная защита ног.</string>
+    <string name="item_steel_shield_name">Стальной щит</string>
+    <string name="item_steel_shield_desc">Прочный стальной щит.</string>
+
+    <!-- Armour — mithril -->
+    <string name="item_mithril_helmet_name">Мифриловый шлем</string>
+    <string name="item_mithril_helmet_desc">Легковесная магическая защита головы.</string>
+    <string name="item_mithril_platebody_name">Мифриловый нагрудник</string>
+    <string name="item_mithril_platebody_desc">Легковесная магическая броня тела.</string>
+    <string name="item_mithril_platelegs_name">Мифриловые поножи</string>
+    <string name="item_mithril_platelegs_desc">Легковесная магическая защита ног.</string>
+    <string name="item_mithril_shield_name">Мифриловый щит</string>
+    <string name="item_mithril_shield_desc">Легковесный магический щит.</string>
+
+    <!-- Armour — adamantite -->
+    <string name="item_adamantite_helmet_name">Адамантитовый шлем</string>
+    <string name="item_adamantite_helmet_desc">Экстремально твёрдая защита головы.</string>
+    <string name="item_adamantite_platebody_name">Адамантитовый нагрудник</string>
+    <string name="item_adamantite_platebody_desc">Экстремально твёрдая броня тела.</string>
+    <string name="item_adamantite_platelegs_name">Адамантитовые поножи</string>
+    <string name="item_adamantite_platelegs_desc">Экстремально твёрдая защита ног.</string>
+    <string name="item_adamantite_shield_name">Адамантитовый щит</string>
+    <string name="item_adamantite_shield_desc">Экстремально твёрдый щит.</string>
+
+    <!-- Armour — runite -->
+    <string name="item_runite_helmet_name">Рунитовый шлем</string>
+    <string name="item_runite_helmet_desc">Лучшая доступная защита головы.</string>
+    <string name="item_runite_platebody_name">Рунитовый нагрудник</string>
+    <string name="item_runite_platebody_desc">Лучшая доступная броня тела.</string>
+    <string name="item_runite_platelegs_name">Рунитовые поножи</string>
+    <string name="item_runite_platelegs_desc">Лучшая доступная защита ног.</string>
+    <string name="item_runite_shield_name">Рунитовый щит</string>
+    <string name="item_runite_shield_desc">Лучший доступный щит.</string>
+
+    <!-- ===== Tools — pickaxes ===== -->
+    <string name="item_bronze_pickaxe_name">Бронзовая кирка</string>
+    <string name="item_bronze_pickaxe_desc">Базовая кирка для Добычи руды.</string>
+    <string name="item_iron_pickaxe_name">Железная кирка</string>
+    <string name="item_iron_pickaxe_desc">Надёжная кирка для Добычи руды.</string>
+    <string name="item_steel_pickaxe_name">Стальная кирка</string>
+    <string name="item_steel_pickaxe_desc">Прочная кирка для Добычи руды.</string>
+    <string name="item_mithril_pickaxe_name">Мифриловая кирка</string>
+    <string name="item_mithril_pickaxe_desc">Легковесная магическая кирка для Добычи руды.</string>
+    <string name="item_adamantite_pickaxe_name">Адамантитовая кирка</string>
+    <string name="item_adamantite_pickaxe_desc">Экстремально твёрдая кирка для Добычи руды.</string>
+    <string name="item_runite_pickaxe_name">Рунитовая кирка</string>
+    <string name="item_runite_pickaxe_desc">Лучшая доступная кирка для Добычи руды.</string>
+
+    <!-- Tools — axes -->
+    <string name="item_bronze_axe_name">Бронзовый топор</string>
+    <string name="item_bronze_axe_desc">Базовый топор для Рубки леса.</string>
+    <string name="item_iron_axe_name">Железный топор</string>
+    <string name="item_iron_axe_desc">Надёжный топор для Рубки леса.</string>
+    <string name="item_steel_axe_name">Стальной топор</string>
+    <string name="item_steel_axe_desc">Прочный топор для Рубки леса.</string>
+    <string name="item_mithril_axe_name">Мифриловый топор</string>
+    <string name="item_mithril_axe_desc">Легковесный магический топор для Рубки леса.</string>
+    <string name="item_adamantite_axe_name">Адамантитовый топор</string>
+    <string name="item_adamantite_axe_desc">Экстремально твёрдый топор для Рубки леса.</string>
+    <string name="item_runite_axe_name">Рунитовый топор</string>
+    <string name="item_runite_axe_desc">Лучший доступный топор для Рубки леса.</string>
+
+    <!-- Tools — fishing rods -->
+    <string name="item_bronze_fishing_rod_name">Бронзовая удочка</string>
+    <string name="item_bronze_fishing_rod_desc">Базовая удочка.</string>
+    <string name="item_iron_fishing_rod_name">Железная удочка</string>
+    <string name="item_iron_fishing_rod_desc">Надёжная удочка.</string>
+    <string name="item_steel_fishing_rod_name">Стальная удочка</string>
+    <string name="item_steel_fishing_rod_desc">Прочная удочка.</string>
+    <string name="item_mithril_fishing_rod_name">Мифриловая удочка</string>
+    <string name="item_mithril_fishing_rod_desc">Легковесная магическая удочка.</string>
+    <string name="item_adamantite_fishing_rod_name">Адамантитовая удочка</string>
+    <string name="item_adamantite_fishing_rod_desc">Экстремально прочная удочка.</string>
+    <string name="item_runite_fishing_rod_name">Рунитовая удочка</string>
+    <string name="item_runite_fishing_rod_desc">Лучшая доступная удочка.</string>
+
+    <!-- ===== Arrows ===== -->
+    <string name="item_bronze_arrow_name">Бронзовые стрелы</string>
+    <string name="item_bronze_arrow_desc">Базовые стрелы для дальнего боя.</string>
+    <string name="item_iron_arrow_name">Железные стрелы</string>
+    <string name="item_iron_arrow_desc">Железные стрелы для дальнего боя.</string>
+    <string name="item_steel_arrow_name">Стальные стрелы</string>
+    <string name="item_steel_arrow_desc">Стальные стрелы для дальнего боя.</string>
+    <string name="item_mithril_arrow_name">Мифриловые стрелы</string>
+    <string name="item_mithril_arrow_desc">Мифриловые стрелы для дальнего боя.</string>
+    <string name="item_adamantite_arrow_name">Адамантитовые стрелы</string>
+    <string name="item_adamantite_arrow_desc">Адамантитовые стрелы для дальнего боя.</string>
+    <string name="item_runite_arrow_name">Рунитовые стрелы</string>
+    <string name="item_runite_arrow_desc">Лучшие доступные стрелы.</string>
+
+    <!-- Arrow components -->
+    <string name="item_arrow_shaft_name">Древки стрел</string>
+    <string name="item_arrow_shaft_desc">Деревянные древки для создания стрел.</string>
+    <string name="item_bronze_arrow_tips_name">Бронзовые наконечники</string>
+    <string name="item_bronze_arrow_tips_desc">Бронзовые наконечники для создания бронзовых стрел.</string>
+    <string name="item_iron_arrow_tips_name">Железные наконечники</string>
+    <string name="item_iron_arrow_tips_desc">Железные наконечники для создания железных стрел.</string>
+    <string name="item_steel_arrow_tips_name">Стальные наконечники</string>
+    <string name="item_steel_arrow_tips_desc">Стальные наконечники для создания стальных стрел.</string>
+    <string name="item_mithril_arrow_tips_name">Мифриловые наконечники</string>
+    <string name="item_mithril_arrow_tips_desc">Мифриловые наконечники для создания мифриловых стрел.</string>
+    <string name="item_adamantite_arrow_tips_name">Адамантитовые наконечники</string>
+    <string name="item_adamantite_arrow_tips_desc">Адамантитовые наконечники для создания адамантитовых стрел.</string>
+    <string name="item_runite_arrow_tips_name">Рунитовые наконечники</string>
+    <string name="item_runite_arrow_tips_desc">Рунитовые наконечники для создания рунитовых стрел.</string>
+
+    <!-- ===== Jewellery — plain ===== -->
+    <string name="item_silver_ring_name">Серебряное кольцо</string>
+    <string name="item_silver_ring_desc">Простое серебряное кольцо.</string>
+    <string name="item_silver_necklace_name">Серебряное ожерелье</string>
+    <string name="item_silver_necklace_desc">Простое серебряное ожерелье.</string>
+    <string name="item_gold_ring_name">Золотое кольцо</string>
+    <string name="item_gold_ring_desc">Простое золотое кольцо.</string>
+    <string name="item_gold_necklace_name">Золотое ожерелье</string>
+    <string name="item_gold_necklace_desc">Простое золотое ожерелье.</string>
+    <string name="item_platinum_ring_name">Платиновое кольцо</string>
+    <string name="item_platinum_ring_desc">Простое платиновое кольцо.</string>
+    <string name="item_platinum_necklace_name">Платиновое ожерелье</string>
+    <string name="item_platinum_necklace_desc">Простое платиновое ожерелье.</string>
+
+    <!-- Jewellery — sapphire -->
+    <string name="item_silver_sapphire_ring_name">Серебряное кольцо с сапфиром</string>
+    <string name="item_silver_sapphire_ring_desc">Серебряное кольцо с сапфиром.</string>
+    <string name="item_silver_sapphire_necklace_name">Серебряное ожерелье с сапфиром</string>
+    <string name="item_silver_sapphire_necklace_desc">Серебряное ожерелье с сапфиром.</string>
+    <string name="item_gold_sapphire_ring_name">Золотое кольцо с сапфиром</string>
+    <string name="item_gold_sapphire_ring_desc">Золотое кольцо с сапфиром.</string>
+    <string name="item_gold_sapphire_necklace_name">Золотое ожерелье с сапфиром</string>
+    <string name="item_gold_sapphire_necklace_desc">Золотое ожерелье с сапфиром.</string>
+    <string name="item_platinum_sapphire_ring_name">Платиновое кольцо с сапфиром</string>
+    <string name="item_platinum_sapphire_ring_desc">Платиновое кольцо с сапфиром.</string>
+    <string name="item_platinum_sapphire_necklace_name">Платиновое ожерелье с сапфиром</string>
+    <string name="item_platinum_sapphire_necklace_desc">Платиновое ожерелье с сапфиром.</string>
+
+    <!-- Jewellery — emerald -->
+    <string name="item_gold_emerald_ring_name">Золотое кольцо с изумрудом</string>
+    <string name="item_gold_emerald_ring_desc">Золотое кольцо с изумрудом.</string>
+    <string name="item_gold_emerald_necklace_name">Золотое ожерелье с изумрудом</string>
+    <string name="item_gold_emerald_necklace_desc">Золотое ожерелье с изумрудом.</string>
+    <string name="item_platinum_emerald_ring_name">Платиновое кольцо с изумрудом</string>
+    <string name="item_platinum_emerald_ring_desc">Платиновое кольцо с изумрудом.</string>
+    <string name="item_platinum_emerald_necklace_name">Платиновое ожерелье с изумрудом</string>
+    <string name="item_platinum_emerald_necklace_desc">Платиновое ожерелье с изумрудом.</string>
+
+    <!-- Jewellery — ruby -->
+    <string name="item_gold_ruby_ring_name">Золотое кольцо с рубином</string>
+    <string name="item_gold_ruby_ring_desc">Золотое кольцо с рубином.</string>
+    <string name="item_gold_ruby_necklace_name">Золотое ожерелье с рубином</string>
+    <string name="item_gold_ruby_necklace_desc">Золотое ожерелье с рубином.</string>
+    <string name="item_platinum_ruby_ring_name">Платиновое кольцо с рубином</string>
+    <string name="item_platinum_ruby_ring_desc">Платиновое кольцо с рубином.</string>
+    <string name="item_platinum_ruby_necklace_name">Платиновое ожерелье с рубином</string>
+    <string name="item_platinum_ruby_necklace_desc">Платиновое ожерелье с рубином.</string>
+
+    <!-- Jewellery — diamond -->
+    <string name="item_gold_diamond_ring_name">Золотое кольцо с алмазом</string>
+    <string name="item_gold_diamond_ring_desc">Золотое кольцо с алмазом.</string>
+    <string name="item_gold_diamond_necklace_name">Золотое ожерелье с алмазом</string>
+    <string name="item_gold_diamond_necklace_desc">Золотое ожерелье с алмазом.</string>
+    <string name="item_platinum_diamond_ring_name">Платиновое кольцо с алмазом</string>
+    <string name="item_platinum_diamond_ring_desc">Платиновое кольцо с алмазом.</string>
+    <string name="item_platinum_diamond_necklace_name">Платиновое ожерелье с алмазом</string>
+    <string name="item_platinum_diamond_necklace_desc">Платиновое ожерелье с алмазом.</string>
+
+    <!-- ===== Miscellaneous drops ===== -->
+    <string name="item_ashes_name">Пепел</string>
+    <string name="item_ashes_desc">Пепел от обычных брёвен. Развейте в навыке Молитвы для бонусного опыта Молитвы.</string>
+    <string name="item_oak_ashes_name">Дубовый пепел</string>
+    <string name="item_oak_ashes_desc">Пепел от дубовых брёвен. Развейте для большего опыта Молитвы, чем обычный пепел.</string>
+    <string name="item_willow_ashes_name">Ивовый пепел</string>
+    <string name="item_willow_ashes_desc">Пепел от ивовых брёвен. Развейте для опыта Молитвы.</string>
+    <string name="item_maple_ashes_name">Кленовый пепел</string>
+    <string name="item_maple_ashes_desc">Пепел от кленовых брёвен. Развейте для опыта Молитвы.</string>
+    <string name="item_yew_ashes_name">Тисовый пепел</string>
+    <string name="item_yew_ashes_desc">Пепел от тисовых брёвен. Развейте для значительного опыта Молитвы.</string>
+    <string name="item_magic_ashes_name">Магический пепел</string>
+    <string name="item_magic_ashes_desc">Пепел от магических брёвен. Развейте для существенного опыта Молитвы.</string>
+    <string name="item_redwood_ashes_name">Пепел секвойи</string>
+    <string name="item_redwood_ashes_desc">Пепел от брёвен секвойи. Развейте для наибольшего опыта Молитвы из всех видов пепла.</string>
+    <string name="item_bones_name">Кости</string>
+    <string name="item_bones_desc">Кости мелкого существа. Захороните для опыта Молитвы.</string>
+    <string name="item_big_bones_name">Большие кости</string>
+    <string name="item_big_bones_desc">Кости побольше. Дают больше опыта Молитвы при захоронении.</string>
+    <string name="item_giant_bones_name">Гигантские кости</string>
+    <string name="item_giant_bones_desc">Огромные кости от могучих врагов. Дают значительный опыт Молитвы.</string>
+    <string name="item_dragon_bone_name">Кость дракона</string>
+    <string name="item_dragon_bone_desc">Древние кости дракона. Дают наибольший опыт Молитвы при захоронении.</string>
+    <string name="item_dragon_scale_name">Чешуя дракона</string>
+    <string name="item_dragon_scale_desc">Прочная чешуя зелёного дракона. Редкая и ценная.</string>
+    <string name="item_coins_name">Монеты</string>
+    <string name="item_coins_desc">Валюта королевства. Тратьте в магазине.</string>
+    <string name="item_goblin_mail_name">Почта гоблинов</string>
+    <string name="item_goblin_mail_desc">Побитая броня, выпадающая из гоблинов. Хорошо продаётся.</string>
+    <string name="item_imp_hide_name">Шкура беса</string>
+    <string name="item_imp_hide_desc">Кожистая шкура беса.</string>
+    <string name="item_spider_silk_name">Паучий шёлк</string>
+    <string name="item_spider_silk_desc">Тонкий шёлк, сплетённый гигантскими пауками. Ценится ремесленниками.</string>
+    <string name="item_spider_fang_name">Паучий клык</string>
+    <string name="item_spider_fang_desc">Ядовитый клык гигантского паука.</string>
+    <string name="item_cowhide_name">Коровья шкура</string>
+    <string name="item_cowhide_desc">Грубая шкура коровы. Используется в кожевенном ремесле.</string>
+    <string name="item_wool_name">Шерсть</string>
+    <string name="item_wool_desc">Мягкая шерсть овцы.</string>
+    <string name="item_feather_name">Перо</string>
+    <string name="item_feather_desc">Перо, используемое при создании стрел.</string>
+    <string name="item_rotten_flesh_name">Гнилая плоть</string>
+    <string name="item_rotten_flesh_desc">Гниющая плоть нежити. Ужасно пахнет.</string>
+    <string name="item_lockpick_name">Отмычка</string>
+    <string name="item_lockpick_desc">Отмычка, выпадающая из бродяг.</string>
+    <string name="item_magic_bean_name">Магический боб</string>
+    <string name="item_magic_bean_desc">Магический боб с загадочными свойствами.</string>
+    <string name="item_hellhound_fang_name">Клык адской гончей</string>
+    <string name="item_hellhound_fang_desc">Обожжённый клык адской гончей.</string>
+    <string name="item_demon_horn_name">Рог демона</string>
+    <string name="item_demon_horn_desc">Зазубренный рог, оторванный от малого демона.</string>
+    <string name="item_troll_bone_name">Кость тролля</string>
+    <string name="item_troll_bone_desc">Огромная, узловатая кость горного тролля.</string>
+
+    <!-- ===== Runes ===== -->
+    <string name="item_air_rune_name">Руна воздуха</string>
+    <string name="item_air_rune_desc">Руна, наделённая силой воздуха. Используется в заклинаниях воздуха.</string>
+    <string name="item_water_rune_name">Руна воды</string>
+    <string name="item_water_rune_desc">Руна, наделённая силой воды.</string>
+    <string name="item_earth_rune_name">Руна земли</string>
+    <string name="item_earth_rune_desc">Руна, наделённая силой земли.</string>
+    <string name="item_fire_rune_name">Руна огня</string>
+    <string name="item_fire_rune_desc">Руна, наделённая силой огня.</string>
+    <string name="item_mind_rune_name">Руна разума</string>
+    <string name="item_mind_rune_desc">Руна, направляющая психическую энергию.</string>
+    <string name="item_chaos_rune_name">Руна хаоса</string>
+    <string name="item_chaos_rune_desc">Руна дикой, хаотичной магии.</string>
+    <string name="item_death_rune_name">Руна смерти</string>
+    <string name="item_death_rune_desc">Руна, наполненная силой смерти.</string>
+    <string name="item_blood_rune_name">Руна крови</string>
+    <string name="item_blood_rune_desc">Редкая руна, питаемая магией крови.</string>
+
+    <!-- ===== Crops ===== -->
+    <string name="crop_potato_name">Картофель</string>
+    <string name="crop_onion_name">Лук</string>
+    <string name="crop_cabbage_name">Капуста</string>
+    <string name="crop_carrot_name">Морковь</string>
+    <string name="crop_tomato_name">Томат</string>
+    <string name="crop_corn_name">Кукуруза</string>
+    <string name="crop_pumpkin_name">Тыква</string>
+    <string name="crop_watermelon_name">Арбуз</string>
+    <string name="crop_strawberry_name">Клубника</string>
+    <string name="crop_magic_herb_name">Магическая трава</string>
+    <string name="crop_dragon_fruit_name">Драконий фрукт</string>
+    <string name="crop_golden_wheat_name">Золотая пшеница</string>
+    <string name="crop_spirit_herb_name">Духовная трава</string>
+    <string name="crop_celestial_bloom_name">Небесный цветок</string>
+    <string name="crop_starfruit_name">Звёздный плод</string>
+    <string name="crop_void_lotus_name">Лотос пустоты</string>
+
+    <!-- ===== Spells ===== -->
+    <string name="spell_wind_strike_name">Ветряной удар</string>
+    <string name="spell_wind_bolt_name">Ветряной заряд</string>
+    <string name="spell_wind_blast_name">Ветряной взрыв</string>
+    <string name="spell_wind_wave_name">Ветряная волна</string>
+    <string name="spell_water_strike_name">Водяной удар</string>
+    <string name="spell_water_bolt_name">Водяной заряд</string>
+    <string name="spell_water_blast_name">Водяной взрыв</string>
+    <string name="spell_water_wave_name">Водяная волна</string>
+    <string name="spell_earth_strike_name">Земляной удар</string>
+    <string name="spell_earth_bolt_name">Земляной заряд</string>
+    <string name="spell_earth_blast_name">Земляной взрыв</string>
+    <string name="spell_earth_wave_name">Земляная волна</string>
+    <string name="spell_fire_strike_name">Огненный удар</string>
+    <string name="spell_fire_bolt_name">Огненный заряд</string>
+    <string name="spell_fire_blast_name">Огненный взрыв</string>
+    <string name="spell_fire_wave_name">Огненная волна</string>
+    <string name="spell_mind_strike_name">Удар разума</string>
+    <string name="spell_mind_bolt_name">Заряд разума</string>
+    <string name="spell_mind_blast_name">Взрыв разума</string>
+    <string name="spell_mind_wave_name">Волна разума</string>
+    <string name="spell_chaos_strike_name">Удар хаоса</string>
+    <string name="spell_chaos_bolt_name">Заряд хаоса</string>
+    <string name="spell_chaos_blast_name">Взрыв хаоса</string>
+    <string name="spell_chaos_wave_name">Волна хаоса</string>
+    <string name="spell_death_strike_name">Удар смерти</string>
+    <string name="spell_death_bolt_name">Заряд смерти</string>
+    <string name="spell_death_blast_name">Взрыв смерти</string>
+    <string name="spell_death_wave_name">Волна смерти</string>
+    <string name="spell_blood_strike_name">Удар крови</string>
+    <string name="spell_blood_bolt_name">Заряд крови</string>
+    <string name="spell_blood_blast_name">Взрыв крови</string>
+    <string name="spell_blood_wave_name">Волна крови</string>
+
+    <!-- ===== Hoes ===== -->
+    <string name="item_bronze_hoe_name">Бронзовая мотыга</string>
+    <string name="item_iron_hoe_name">Железная мотыга</string>
+    <string name="item_steel_hoe_name">Стальная мотыга</string>
+    <string name="item_mithril_hoe_name">Мифриловая мотыга</string>
+    <string name="item_adamantite_hoe_name">Адамантитовая мотыга</string>
+    <string name="item_runite_hoe_name">Рунитовая мотыга</string>
+
+    <!-- Herblore potions -->
+    <string name="item_attack_brew_name">Отвар атаки</string>
+    <string name="item_defense_brew_name">Отвар защиты</string>
+    <string name="item_attack_potion_name">Зелье атаки</string>
+    <string name="item_defense_potion_name">Зелье защиты</string>
+    <string name="item_onion_brew_name">Луковый отвар</string>
+    <string name="item_carrot_brew_name">Морковный отвар</string>
+    <string name="item_strength_brew_name">Отвар силы</string>
+    <string name="item_strength_potion_name">Зелье силы</string>
+    <string name="item_ranging_potion_name">Зелье стрельбы</string>
+    <string name="item_magic_potion_name">Зелье магии</string>
+    <string name="item_super_strength_potion_name">Супер-зелье силы</string>
+    <string name="item_super_attack_potion_name">Супер-зелье атаки</string>
+    <string name="item_super_defense_potion_name">Супер-зелье защиты</string>
+    <string name="item_super_ranging_potion_name">Супер-зелье стрельбы</string>
+    <string name="item_super_magic_potion_name">Супер-зелье магии</string>
+    <string name="item_overload_potion_name">Зелье перегрузки</string>
+
+    <!-- Enhanced potions -->
+    <string name="item_enhanced_attack_brew_name">Отвар атаки</string>
+    <string name="item_enhanced_defense_brew_name">Отвар защиты</string>
+    <string name="item_enhanced_attack_potion_name">Зелье атаки</string>
+    <string name="item_enhanced_defense_potion_name">Зелье защиты</string>
+    <string name="item_enhanced_onion_brew_name">Луковый отвар</string>
+    <string name="item_enhanced_carrot_brew_name">Морковный отвар</string>
+    <string name="item_enhanced_strength_brew_name">Отвар силы</string>
+    <string name="item_enhanced_strength_potion_name">Зелье силы</string>
+    <string name="item_enhanced_ranging_potion_name">Зелье стрельбы</string>
+    <string name="item_enhanced_magic_potion_name">Зелье магии</string>
+    <string name="item_enhanced_super_strength_potion_name">Супер-зелье силы</string>
+    <string name="item_enhanced_super_attack_potion_name">Супер-зелье атаки</string>
+    <string name="item_enhanced_super_defense_potion_name">Супер-зелье защиты</string>
+    <string name="item_enhanced_super_ranging_potion_name">Супер-зелье стрельбы</string>
+    <string name="item_enhanced_super_magic_potion_name">Супер-зелье магии</string>
+    <string name="item_enhanced_overload_potion_name">Зелье перегрузки</string>
+</resources>

--- a/app/src/main/res/values-ru/strings_notifications.xml
+++ b/app/src/main/res/values-ru/strings_notifications.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- ===== Notification channel metadata ===== -->
+    <string name="notif_channel_sessions_name">Оповещения сессий</string>
+    <string name="notif_channel_sessions_desc">Уведомления о завершении сессий навыков</string>
+    <string name="notif_channel_farming_name">Оповещения фермерства</string>
+    <string name="notif_channel_farming_desc">Уведомления о готовности урожая к сбору</string>
+
+    <!-- ===== Session complete ===== -->
+    <string name="notif_session_complete_title">Сессия завершена!</string>
+    <!-- Translator note: %1$s = localised skill name (e.g. "Mining") -->
+    <string name="notif_session_complete_body">Ваша сессия %1$s завершена. Нажмите, чтобы получить награды.</string>
+
+    <!-- ===== Farming ready ===== -->
+    <string name="notif_farming_ready_title">Урожай готов!</string>
+    <!-- Translator note: %1$s = localised crop name (e.g. "Wheat"). Adjust grammar as needed for your language. -->
+    <string name="notif_farming_ready_body">Ваш %1$s готов к сбору.</string>
+    <!-- Plural variant used when multiple patches are ready -->
+    <!-- Translator note: %1$d = number of patches ready -->
+    <string name="notif_farming_ready_body_multi">%1$d участков готовы к сбору.</string>
+</resources>

--- a/app/src/main/res/values-ru/strings_quests.xml
+++ b/app/src/main/res/values-ru/strings_quests.xml
@@ -1,0 +1,422 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- ===== Quest names and objectives ===== -->
+    <!-- Translator note: quest names are short titles; objectives are action sentences. -->
+
+    <!-- Mining -->
+    <string name="quest_mining_1_name">Добыча руды I</string>
+    <string name="quest_mining_1_objective">Добудьте 500 медной руды</string>
+    <string name="quest_mining_2_name">Добыча руды II</string>
+    <string name="quest_mining_2_objective">Добудьте 750 железной руды</string>
+    <string name="quest_mining_3_name">Добыча руды III</string>
+    <string name="quest_mining_3_objective">Добудьте 1100 угля</string>
+    <string name="quest_mining_4_name">Добыча руды IV</string>
+    <string name="quest_mining_4_objective">Добудьте 1650 мифриловой руды</string>
+    <string name="quest_mining_5_name">Добыча руды V</string>
+    <string name="quest_mining_5_objective">Добудьте 2450 адамантитовой руды</string>
+    <string name="quest_mining_6_name">Добыча руды VI</string>
+    <string name="quest_mining_6_objective">Добудьте 3650 рунитовой руды</string>
+
+    <!-- Woodcutting -->
+    <string name="quest_woodcutting_1_name">Рубка леса I</string>
+    <string name="quest_woodcutting_1_objective">Срубите 500 брёвен</string>
+    <string name="quest_woodcutting_2_name">Рубка леса II</string>
+    <string name="quest_woodcutting_2_objective">Срубите 750 дубовых брёвен</string>
+    <string name="quest_woodcutting_3_name">Рубка леса III</string>
+    <string name="quest_woodcutting_3_objective">Срубите 1100 ивовых брёвен</string>
+    <string name="quest_woodcutting_4_name">Рубка леса IV</string>
+    <string name="quest_woodcutting_4_objective">Срубите 1650 кленовых брёвен</string>
+    <string name="quest_woodcutting_5_name">Рубка леса V</string>
+    <string name="quest_woodcutting_5_objective">Срубите 2450 тисовых брёвен</string>
+    <string name="quest_woodcutting_6_name">Рубка леса VI</string>
+    <string name="quest_woodcutting_6_objective">Срубите 3650 магических брёвен</string>
+
+    <!-- Fishing -->
+    <string name="quest_fishing_1_name">Рыбалка I</string>
+    <string name="quest_fishing_1_objective">Поймайте 500 рыб</string>
+    <string name="quest_fishing_2_name">Рыбалка II</string>
+    <string name="quest_fishing_2_objective">Поймайте 750 рыб</string>
+    <string name="quest_fishing_3_name">Рыбалка III</string>
+    <string name="quest_fishing_3_objective">Поймайте 1100 рыб</string>
+    <string name="quest_fishing_4_name">Рыбалка IV</string>
+    <string name="quest_fishing_4_objective">Поймайте 1650 рыб</string>
+    <string name="quest_fishing_5_name">Рыбалка V</string>
+    <string name="quest_fishing_5_objective">Поймайте 2450 рыб</string>
+    <string name="quest_fishing_6_name">Рыбалка VI</string>
+    <string name="quest_fishing_6_objective">Поймайте 3650 рыб</string>
+
+    <!-- Smithing -->
+    <string name="quest_smithing_1_name">Ковка I</string>
+    <string name="quest_smithing_1_objective">Выплавьте 500 бронзовых слитков</string>
+    <string name="quest_smithing_2_name">Ковка II</string>
+    <string name="quest_smithing_2_objective">Выплавьте 750 железных слитков</string>
+    <string name="quest_smithing_3_name">Ковка III</string>
+    <string name="quest_smithing_3_objective">Выплавьте 1100 стальных слитков</string>
+    <string name="quest_smithing_4_name">Ковка IV</string>
+    <string name="quest_smithing_4_objective">Выплавьте 1650 мифриловых слитков</string>
+    <string name="quest_smithing_5_name">Ковка V</string>
+    <string name="quest_smithing_5_objective">Выплавьте 2450 адамантитовых слитков</string>
+    <string name="quest_smithing_6_name">Ковка VI</string>
+    <string name="quest_smithing_6_objective">Выплавьте 3650 рунитовых слитков</string>
+
+    <!-- Cooking - Fish -->
+    <string name="quest_cooking_fish_1_name">Кулинария — Рыба I</string>
+    <string name="quest_cooking_fish_1_objective">Приготовьте 500 рыб</string>
+    <string name="quest_cooking_fish_2_name">Кулинария — Рыба II</string>
+    <string name="quest_cooking_fish_2_objective">Приготовьте 750 рыб</string>
+    <string name="quest_cooking_fish_3_name">Кулинария — Рыба III</string>
+    <string name="quest_cooking_fish_3_objective">Приготовьте 1100 рыб</string>
+    <string name="quest_cooking_fish_4_name">Кулинария — Рыба IV</string>
+    <string name="quest_cooking_fish_4_objective">Приготовьте 1650 рыб</string>
+    <string name="quest_cooking_fish_5_name">Кулинария — Рыба V</string>
+    <string name="quest_cooking_fish_5_objective">Приготовьте 2450 рыб</string>
+    <string name="quest_cooking_fish_6_name">Кулинария — Рыба VI</string>
+    <string name="quest_cooking_fish_6_objective">Приготовьте 3650 рыб</string>
+
+    <!-- Cooking - Beef -->
+    <string name="quest_cooking_beef_1_name">Кулинария — Говядина I</string>
+    <string name="quest_cooking_beef_1_objective">Приготовьте 100 говядины</string>
+    <string name="quest_cooking_beef_2_name">Кулинария — Говядина II</string>
+    <string name="quest_cooking_beef_2_objective">Приготовьте 250 говядины</string>
+    <string name="quest_cooking_beef_3_name">Кулинария — Говядина III</string>
+    <string name="quest_cooking_beef_3_objective">Приготовьте 500 говядины</string>
+
+    <!-- Cooking - Chicken -->
+    <string name="quest_cooking_chicken_1_name">Кулинария — Курица I</string>
+    <string name="quest_cooking_chicken_1_objective">Приготовьте 100 курицы</string>
+    <string name="quest_cooking_chicken_2_name">Кулинария — Курица II</string>
+    <string name="quest_cooking_chicken_2_objective">Приготовьте 250 курицы</string>
+    <string name="quest_cooking_chicken_3_name">Кулинария — Курица III</string>
+    <string name="quest_cooking_chicken_3_objective">Приготовьте 500 курицы</string>
+
+    <!-- Cooking - Mutton -->
+    <string name="quest_cooking_mutton_1_name">Кулинария — Баранина I</string>
+    <string name="quest_cooking_mutton_1_objective">Приготовьте 100 баранины</string>
+    <string name="quest_cooking_mutton_2_name">Кулинария — Баранина II</string>
+    <string name="quest_cooking_mutton_2_objective">Приготовьте 250 баранины</string>
+    <string name="quest_cooking_mutton_3_name">Кулинария — Баранина III</string>
+    <string name="quest_cooking_mutton_3_objective">Приготовьте 500 баранины</string>
+
+    <!-- Fletching -->
+    <string name="quest_fletching_1_name">Флетчинг I</string>
+    <string name="quest_fletching_1_objective">Создайте 500 бронзовых стрел</string>
+    <string name="quest_fletching_2_name">Флетчинг II</string>
+    <string name="quest_fletching_2_objective">Создайте 750 железных стрел</string>
+    <string name="quest_fletching_3_name">Флетчинг III</string>
+    <string name="quest_fletching_3_objective">Создайте 1100 стальных стрел</string>
+    <string name="quest_fletching_4_name">Флетчинг IV</string>
+    <string name="quest_fletching_4_objective">Создайте 1650 мифриловых стрел</string>
+    <string name="quest_fletching_5_name">Флетчинг V</string>
+    <string name="quest_fletching_5_objective">Создайте 2450 адамантитовых стрел</string>
+    <string name="quest_fletching_6_name">Флетчинг VI</string>
+    <string name="quest_fletching_6_objective">Создайте 3650 рунитовых стрел</string>
+
+    <!-- Prayer -->
+    <string name="quest_prayer_1_name">Молитва I</string>
+    <string name="quest_prayer_1_objective">Захороните 500 костей</string>
+    <string name="quest_prayer_2_name">Молитва II</string>
+    <string name="quest_prayer_2_objective">Захороните 750 костей</string>
+    <string name="quest_prayer_3_name">Молитва III</string>
+    <string name="quest_prayer_3_objective">Захороните 1100 костей</string>
+    <string name="quest_prayer_4_name">Молитва IV</string>
+    <string name="quest_prayer_4_objective">Захороните 1650 костей</string>
+    <string name="quest_prayer_5_name">Молитва V</string>
+    <string name="quest_prayer_5_objective">Захороните 2450 костей</string>
+    <string name="quest_prayer_6_name">Молитва VI</string>
+    <string name="quest_prayer_6_objective">Захороните 3650 костей</string>
+
+    <!-- Slayer -->
+    <string name="quest_combat_kills_1_name">Охотник на монстров I</string>
+    <string name="quest_combat_kills_1_objective">Победите 100 врагов</string>
+    <string name="quest_combat_kills_2_name">Охотник на монстров II</string>
+    <string name="quest_combat_kills_2_objective">Победите 150 врагов</string>
+    <string name="quest_combat_kills_3_name">Охотник на монстров III</string>
+    <string name="quest_combat_kills_3_objective">Победите 200 врагов</string>
+    <string name="quest_combat_kills_4_name">Охотник на монстров IV</string>
+    <string name="quest_combat_kills_4_objective">Победите 300 врагов</string>
+    <string name="quest_combat_kills_5_name">Охотник на монстров V</string>
+    <string name="quest_combat_kills_5_objective">Победите 450 врагов</string>
+    <string name="quest_combat_kills_6_name">Охотник на монстров VI</string>
+    <string name="quest_combat_kills_6_objective">Победите 650 врагов</string>
+
+    <!-- Dungeon exploration -->
+    <string name="quest_dungeon_farm_1_name">Исследователь подземелий I</string>
+    <string name="quest_dungeon_farm_1_objective">Пройдите подземелье Ферма 5 раз</string>
+    <string name="quest_dungeon_goblin_1_name">Исследователь подземелий II</string>
+    <string name="quest_dungeon_goblin_1_objective">Пройдите Пещеру гоблинов 5 раз</string>
+    <string name="quest_dungeon_spider_1_name">Исследователь подземелий III</string>
+    <string name="quest_dungeon_spider_1_objective">Пройдите Логово пауков 5 раз</string>
+    <string name="quest_dungeon_bandit_1_name">Исследователь подземелий IV</string>
+    <string name="quest_dungeon_bandit_1_objective">Пройдите Лагерь бандитов 5 раз</string>
+    <string name="quest_dungeon_undead_1_name">Исследователь подземелий V</string>
+    <string name="quest_dungeon_undead_1_objective">Пройдите Крипту нежити 5 раз</string>
+    <string name="quest_dungeon_fortress_1_name">Исследователь подземелий VI</string>
+    <string name="quest_dungeon_fortress_1_objective">Пройдите Руины крепости 5 раз</string>
+    <string name="quest_dungeon_orc_1_name">Мастер подземелий I</string>
+    <string name="quest_dungeon_orc_1_objective">Пройдите Крепость орков 5 раз</string>
+    <string name="quest_dungeon_volcanic_1_name">Мастер подземелий II</string>
+    <string name="quest_dungeon_volcanic_1_objective">Пройдите Вулканические глубины 5 раз</string>
+    <string name="quest_dungeon_dragon_1_name">Мастер подземелий III</string>
+    <string name="quest_dungeon_dragon_1_objective">Пройдите Логово дракона 5 раз</string>
+
+    <!-- Crafting -->
+    <string name="quest_crafting_1_name">Ремесло I</string>
+    <string name="quest_crafting_1_objective">Создайте 100 серебряных колец</string>
+    <string name="quest_crafting_2_name">Ремесло II</string>
+    <string name="quest_crafting_2_objective">Создайте 250 золотых колец</string>
+    <string name="quest_crafting_3_name">Ремесло III</string>
+    <string name="quest_crafting_3_objective">Создайте 500 платиновых колец</string>
+    <string name="quest_crafting_4_name">Ремесло IV</string>
+    <string name="quest_crafting_4_objective">Создайте 750 серебряных колец с сапфиром</string>
+    <string name="quest_crafting_5_name">Ремесло V</string>
+    <string name="quest_crafting_5_objective">Создайте 1000 золотых колец с сапфиром</string>
+    <string name="quest_crafting_6_name">Ремесло VI</string>
+    <string name="quest_crafting_6_objective">Создайте 1500 платиновых колец с алмазом</string>
+
+    <!-- Monster slayer chains -->
+    <string name="quest_goblin_slayer_1_name">Гоблинский убийца I</string>
+    <string name="quest_goblin_slayer_1_objective">Победите 50 гоблинов</string>
+    <string name="quest_goblin_slayer_2_name">Гоблинский убийца II</string>
+    <string name="quest_goblin_slayer_2_objective">Победите 100 гоблинов</string>
+    <string name="quest_spider_slayer_1_name">Паучий убийца I</string>
+    <string name="quest_spider_slayer_1_objective">Победите 40 гигантских пауков</string>
+    <string name="quest_spider_slayer_2_name">Паучий убийца II</string>
+    <string name="quest_spider_slayer_2_objective">Победите 80 гигантских пауков</string>
+    <string name="quest_skeleton_slayer_1_name">Скелетный убийца I</string>
+    <string name="quest_skeleton_slayer_1_objective">Победите 35 скелетов</string>
+    <string name="quest_skeleton_slayer_2_name">Скелетный убийца II</string>
+    <string name="quest_skeleton_slayer_2_objective">Победите 70 скелетов</string>
+    <string name="quest_bandit_hunter_1_name">Охотник на бандитов I</string>
+    <string name="quest_bandit_hunter_1_objective">Победите 30 бандитов</string>
+    <string name="quest_bandit_hunter_2_name">Охотник на бандитов II</string>
+    <string name="quest_bandit_hunter_2_objective">Победите 60 бандитов</string>
+    <string name="quest_orc_slayer_1_name">Орочий убийца I</string>
+    <string name="quest_orc_slayer_1_objective">Победите 25 орков-воинов</string>
+    <string name="quest_orc_slayer_2_name">Орочий убийца II</string>
+    <string name="quest_orc_slayer_2_objective">Победите 50 орков-воинов</string>
+    <string name="quest_demon_slayer_1_name">Убийца демонов I</string>
+    <string name="quest_demon_slayer_1_objective">Победите Повелителя демонов</string>
+    <string name="quest_demon_slayer_2_name">Убийца демонов II</string>
+    <string name="quest_demon_slayer_2_objective">Победите Повелителя демонов 5 раз</string>
+    <string name="quest_demon_slayer_3_name">Убийца демонов III</string>
+    <string name="quest_demon_slayer_3_objective">Победите Повелителя демонов 25 раз</string>
+    <string name="quest_dragon_slayer_1_name">Драконий убийца I</string>
+    <string name="quest_dragon_slayer_1_objective">Победите 10 зелёных драконов</string>
+    <string name="quest_dragon_slayer_2_name">Драконий убийца II</string>
+    <string name="quest_dragon_slayer_2_objective">Победите 25 зелёных драконов</string>
+
+    <!-- Combat style challenges -->
+    <string name="quest_melee_warrior_1_name">Воин ближнего боя I</string>
+    <string name="quest_melee_warrior_1_objective">Пройдите Пещеру гоблинов только ближним боем</string>
+    <string name="quest_melee_warrior_2_name">Воин ближнего боя II</string>
+    <string name="quest_melee_warrior_2_objective">Пройдите Лагерь бандитов только ближним боем</string>
+    <string name="quest_melee_warrior_3_name">Воин ближнего боя III</string>
+    <string name="quest_melee_warrior_3_objective">Пройдите Руины крепости только ближним боем</string>
+    <string name="quest_ranger_elite_1_name">Элитный стрелок I</string>
+    <string name="quest_ranger_elite_1_objective">Пройдите Пещеру гоблинов только дальним боем</string>
+    <string name="quest_ranger_elite_2_name">Элитный стрелок II</string>
+    <string name="quest_ranger_elite_2_objective">Пройдите Лагерь бандитов только дальним боем</string>
+    <string name="quest_ranger_elite_3_name">Элитный стрелок III</string>
+    <string name="quest_ranger_elite_3_objective">Пройдите Руины крепости только дальним боем</string>
+    <string name="quest_mage_master_1_name">Мастер магии I</string>
+    <string name="quest_mage_master_1_objective">Пройдите Пещеру гоблинов только магией</string>
+    <string name="quest_mage_master_2_name">Мастер магии II</string>
+    <string name="quest_mage_master_2_objective">Пройдите Лагерь бандитов только магией</string>
+    <string name="quest_mage_master_3_name">Мастер магии III</string>
+    <string name="quest_mage_master_3_objective">Пройдите Руины крепости только магией</string>
+
+    <!-- Iron Stomach (no food) challenges -->
+    <string name="quest_iron_stomach_1_name">Желудок из железа I</string>
+    <string name="quest_iron_stomach_1_objective">Пройдите Логово пауков без еды</string>
+    <string name="quest_iron_stomach_2_name">Желудок из железа II</string>
+    <string name="quest_iron_stomach_2_objective">Пройдите Крипту нежити без еды</string>
+    <string name="quest_iron_stomach_3_name">Желудок из железа III</string>
+    <string name="quest_iron_stomach_3_objective">Пройдите Крепость орков без еды</string>
+    <string name="quest_iron_stomach_4_name">Желудок из железа IV</string>
+    <string name="quest_iron_stomach_4_objective">Пройдите Логово дракона без еды</string>
+
+    <!-- Treasure Hunter -->
+    <string name="quest_treasure_hunter_1_name">Охотник за сокровищами I</string>
+    <string name="quest_treasure_hunter_1_objective">Соберите 20 паучьих шёлков из боя</string>
+    <string name="quest_treasure_hunter_2_name">Охотник за сокровищами II</string>
+    <string name="quest_treasure_hunter_2_objective">Соберите 10 почт гоблинов из боя</string>
+    <string name="quest_treasure_hunter_3_name">Охотник за сокровищами III</string>
+    <string name="quest_treasure_hunter_3_objective">Соберите 5 рогов демона из боя</string>
+    <string name="quest_treasure_hunter_4_name">Охотник за сокровищами IV</string>
+    <string name="quest_treasure_hunter_4_objective">Соберите 3 чешуи дракона из боя</string>
+
+    <!-- Firemaking -->
+    <string name="quest_firemaking_1_name">Разжигание огня I</string>
+    <string name="quest_firemaking_1_objective">Сожгите 500 брёвен</string>
+    <string name="quest_firemaking_2_name">Разжигание огня II</string>
+    <string name="quest_firemaking_2_objective">Сожгите 750 дубовых брёвен</string>
+    <string name="quest_firemaking_3_name">Разжигание огня III</string>
+    <string name="quest_firemaking_3_objective">Сожгите 1100 ивовых брёвен</string>
+    <string name="quest_firemaking_4_name">Разжигание огня IV</string>
+    <string name="quest_firemaking_4_objective">Сожгите 1650 кленовых брёвен</string>
+    <string name="quest_firemaking_5_name">Разжигание огня V</string>
+    <string name="quest_firemaking_5_objective">Сожгите 2450 тисовых брёвен</string>
+    <string name="quest_firemaking_6_name">Разжигание огня VI</string>
+    <string name="quest_firemaking_6_objective">Сожгите 3650 магических брёвен</string>
+
+    <!-- Runecrafting -->
+    <string name="quest_runecrafting_1_name">Руническое ремесло I</string>
+    <string name="quest_runecrafting_1_objective">Создайте 500 рун воздуха</string>
+    <string name="quest_runecrafting_2_name">Руническое ремесло II</string>
+    <string name="quest_runecrafting_2_objective">Создайте 750 рун воды</string>
+    <string name="quest_runecrafting_3_name">Руническое ремесло III</string>
+    <string name="quest_runecrafting_3_objective">Создайте 1100 рун земли</string>
+    <string name="quest_runecrafting_4_name">Руническое ремесло IV</string>
+    <string name="quest_runecrafting_4_objective">Создайте 1650 рун огня</string>
+    <string name="quest_runecrafting_5_name">Руническое ремесло V</string>
+    <string name="quest_runecrafting_5_objective">Создайте 2450 рун разума</string>
+    <string name="quest_runecrafting_6_name">Руническое ремесло VI</string>
+    <string name="quest_runecrafting_6_objective">Создайте 3650 рун хаоса</string>
+
+    <!-- Herblore -->
+    <string name="quest_herblore_1_name">Травничество I</string>
+    <string name="quest_herblore_1_objective">Сварите 100 отваров атаки</string>
+    <string name="quest_herblore_2_name">Травничество II</string>
+    <string name="quest_herblore_2_objective">Смешайте 250 зелий защиты</string>
+    <string name="quest_herblore_3_name">Травничество III</string>
+    <string name="quest_herblore_3_objective">Смешайте 500 зелий силы</string>
+    <string name="quest_herblore_4_name">Травничество IV</string>
+    <string name="quest_herblore_4_objective">Смешайте 750 зелий стрельбы</string>
+    <string name="quest_herblore_5_name">Травничество V</string>
+    <string name="quest_herblore_5_objective">Смешайте 1000 зелий магии</string>
+    <string name="quest_herblore_6_name">Травничество VI</string>
+    <string name="quest_herblore_6_objective">Смешайте 1500 супер-зелий силы</string>
+
+    <!-- Slayer extended -->
+    <string name="quest_combat_kills_7_name">Охотник на монстров VII</string>
+    <string name="quest_combat_kills_7_objective">Победите 1000 врагов</string>
+    <string name="quest_combat_kills_8_name">Охотник на монстров VIII</string>
+    <string name="quest_combat_kills_8_objective">Победите 1500 врагов</string>
+    <string name="quest_combat_kills_9_name">Охотник на монстров IX</string>
+    <string name="quest_combat_kills_9_objective">Победите 2250 врагов</string>
+    <string name="quest_combat_kills_10_name">Охотник на монстров X</string>
+    <string name="quest_combat_kills_10_objective">Победите 3400 врагов</string>
+    <string name="quest_combat_kills_11_name">Охотник на монстров XI</string>
+    <string name="quest_combat_kills_11_objective">Победите 5100 врагов</string>
+    <string name="quest_combat_kills_12_name">Охотник на монстров XII</string>
+    <string name="quest_combat_kills_12_objective">Победите 7650 врагов</string>
+
+    <!-- New monster slayer chains -->
+    <string name="quest_zombie_slayer_1_name">Убийца зомби I</string>
+    <string name="quest_zombie_slayer_1_objective">Победите 35 зомби</string>
+    <string name="quest_zombie_slayer_2_name">Убийца зомби II</string>
+    <string name="quest_zombie_slayer_2_objective">Победите 70 зомби</string>
+    <string name="quest_hellhound_slayer_1_name">Убийца адских гончих I</string>
+    <string name="quest_hellhound_slayer_1_objective">Победите 25 адских гончих</string>
+    <string name="quest_hellhound_slayer_2_name">Убийца адских гончих II</string>
+    <string name="quest_hellhound_slayer_2_objective">Победите 50 адских гончих</string>
+    <string name="quest_troll_slayer_1_name">Убийца троллей I</string>
+    <string name="quest_troll_slayer_1_objective">Победите 20 горных троллей</string>
+    <string name="quest_troll_slayer_2_name">Убийца троллей II</string>
+    <string name="quest_troll_slayer_2_objective">Победите 40 горных троллей</string>
+    <string name="quest_fire_giant_slayer_1_name">Убийца огненных великанов I</string>
+    <string name="quest_fire_giant_slayer_1_objective">Победите 15 огненных великанов</string>
+    <string name="quest_fire_giant_slayer_2_name">Убийца огненных великанов II</string>
+    <string name="quest_fire_giant_slayer_2_objective">Победите 30 огненных великанов</string>
+    <string name="quest_ancient_guardian_slayer_1_name">Убийца древних стражей I</string>
+    <string name="quest_ancient_guardian_slayer_1_objective">Победите 10 древних стражей</string>
+    <string name="quest_ancient_guardian_slayer_2_name">Убийца древних стражей II</string>
+    <string name="quest_ancient_guardian_slayer_2_objective">Победите 20 древних стражей</string>
+    <string name="quest_lich_slayer_1_name">Убийца личей I</string>
+    <string name="quest_lich_slayer_1_objective">Победите 10 личей</string>
+    <string name="quest_lich_slayer_2_name">Убийца личей II</string>
+    <string name="quest_lich_slayer_2_objective">Победите 20 личей</string>
+
+    <!-- Dungeon exploration extended -->
+    <string name="quest_dungeon_imp_1_name">Исследователь подземелий VII</string>
+    <string name="quest_dungeon_imp_1_objective">Пройдите Пещеру бесов 5 раз</string>
+    <string name="quest_dungeon_infernal_1_name">Мастер подземелий IV</string>
+    <string name="quest_dungeon_infernal_1_objective">Пройдите Инфернальную цитадель 5 раз</string>
+    <string name="quest_dungeon_ancient_1_name">Мастер подземелий V</string>
+    <string name="quest_dungeon_ancient_1_objective">Пройдите Древний храм 5 раз</string>
+
+    <!-- Boss extended -->
+    <string name="quest_kbd_slayer_1_objective">Победите Чёрного короля-дракона</string>
+    <string name="quest_kbd_slayer_2_objective">Победите Чёрного короля-дракона 5 раз</string>
+    <string name="quest_kbd_slayer_3_objective">Победите Чёрного короля-дракона 25 раз</string>
+    <string name="quest_kbd_slayer_4_name">Убийца Чёрного короля-дракона IV</string>
+    <string name="quest_kbd_slayer_4_objective">Победите Чёрного короля-дракона 50 раз</string>
+    <string name="quest_demon_slayer_4_name">Убийца демонов IV</string>
+    <string name="quest_demon_slayer_4_objective">Победите Повелителя демонов 50 раз</string>
+    <string name="quest_kraken_killer_1_name">Убийца кракена I</string>
+    <string name="quest_kraken_killer_1_objective">Победите Кракена</string>
+    <string name="quest_kraken_killer_2_name">Убийца кракена II</string>
+    <string name="quest_kraken_killer_2_objective">Победите Кракена 5 раз</string>
+    <string name="quest_kraken_killer_3_name">Убийца кракена III</string>
+    <string name="quest_kraken_killer_3_objective">Победите Кракена 25 раз</string>
+    <string name="quest_kraken_killer_4_name">Убийца кракена IV</string>
+    <string name="quest_kraken_killer_4_objective">Победите Кракена 50 раз</string>
+    <string name="quest_balrog_bane_1_name">Гибель Балрога I</string>
+    <string name="quest_balrog_bane_1_objective">Победите Балрога</string>
+    <string name="quest_balrog_bane_2_name">Гибель Балрога II</string>
+    <string name="quest_balrog_bane_2_objective">Победите Балрога 5 раз</string>
+    <string name="quest_balrog_bane_3_name">Гибель Балрога III</string>
+    <string name="quest_balrog_bane_3_objective">Победите Балрога 25 раз</string>
+    <string name="quest_balrog_bane_4_name">Гибель Балрога IV</string>
+    <string name="quest_balrog_bane_4_objective">Победите Балрога 50 раз</string>
+
+    <!-- Combat style challenges extended -->
+    <string name="quest_melee_warrior_4_name">Воин ближнего боя IV</string>
+    <string name="quest_melee_warrior_4_objective">Пройдите Крепость орков только ближним боем</string>
+    <string name="quest_melee_warrior_5_name">Воин ближнего боя V</string>
+    <string name="quest_melee_warrior_5_objective">Пройдите Логово дракона только ближним боем</string>
+    <string name="quest_ranger_elite_4_name">Элитный стрелок IV</string>
+    <string name="quest_ranger_elite_4_objective">Пройдите Крепость орков только дальним боем</string>
+    <string name="quest_ranger_elite_5_name">Элитный стрелок V</string>
+    <string name="quest_ranger_elite_5_objective">Пройдите Логово дракона только дальним боем</string>
+    <string name="quest_mage_master_4_name">Мастер магии IV</string>
+    <string name="quest_mage_master_4_objective">Пройдите Крепость орков только магией</string>
+    <string name="quest_mage_master_5_name">Мастер магии V</string>
+    <string name="quest_mage_master_5_objective">Пройдите Логово дракона только магией</string>
+
+    <!-- Iron Stomach extended -->
+    <string name="quest_iron_stomach_5_name">Желудок из железа V</string>
+    <string name="quest_iron_stomach_5_objective">Пройдите Инфернальную цитадель без еды</string>
+    <string name="quest_iron_stomach_6_name">Желудок из железа VI</string>
+    <string name="quest_iron_stomach_6_objective">Пройдите Древний храм без еды</string>
+
+    <!-- Treasure Hunter extended -->
+    <string name="quest_treasure_hunter_5_name">Охотник за сокровищами V</string>
+    <string name="quest_treasure_hunter_5_objective">Соберите 10 клыков адской гончей из боя</string>
+    <string name="quest_treasure_hunter_6_name">Охотник за сокровищами VI</string>
+    <string name="quest_treasure_hunter_6_objective">Соберите 15 костей тролля из боя</string>
+
+    <!-- Daily quest verbs -->
+    <string name="daily_verb_mining">Добудьте</string>
+    <string name="daily_verb_fishing">Поймайте</string>
+    <string name="daily_verb_woodcutting">Срубите</string>
+    <string name="daily_verb_smithing">Выкуйте</string>
+    <string name="daily_verb_cooking">Приготовьте</string>
+    <string name="daily_verb_combat">Победите</string>
+
+    <!-- Daily quest names -->
+    <string name="quest_daily_mine_iron_name">Железный рудокоп</string>
+    <string name="quest_daily_mine_coal_name">Угольщик</string>
+    <string name="quest_daily_mine_mithril_name">Мифриловый разведчик</string>
+    <string name="quest_daily_mine_runite_name">Рунитовая лихорадка</string>
+    <string name="quest_daily_fish_salmon_name">Лососёвый ход</string>
+    <string name="quest_daily_fish_lobster_name">Омарья добыча</string>
+    <string name="quest_daily_fish_swordfish_name">Охотник на рыбу-меч</string>
+    <string name="quest_daily_fish_shark_name">Укротитель акул</string>
+    <string name="quest_daily_wc_oak_name">Дуборуб</string>
+    <string name="quest_daily_wc_willow_name">Ивовый работник</string>
+    <string name="quest_daily_wc_yew_name">Тисовый лесоруб</string>
+    <string name="quest_daily_wc_magic_name">Магический лесоруб</string>
+    <string name="quest_daily_smith_iron_name">Железный кузнец</string>
+    <string name="quest_daily_smith_mithril_name">Мифриловый плавильщик</string>
+    <string name="quest_daily_smith_adamantite_name">Адамантитовый ремесленник</string>
+    <string name="quest_daily_smith_runite_name">Рунитовый плавильщик</string>
+    <string name="quest_daily_cook_trout_name">Повар форели</string>
+    <string name="quest_daily_cook_salmon_name">Грильщик лосося</string>
+    <string name="quest_daily_cook_lobster_name">Повар омаров</string>
+    <string name="quest_daily_cook_swordfish_name">Повар рыбы-меч</string>
+    <string name="quest_daily_kill_goblin_name">Гоблинский убийца</string>
+    <string name="quest_daily_kill_bandit_name">Истребитель бандитов</string>
+    <string name="quest_daily_kill_demon_name">Охотник на демонов</string>
+    <string name="quest_daily_kill_dragon_name">Драконий убийца</string>
+</resources>

--- a/app/src/main/res/values-ru/strings_skills.xml
+++ b/app/src/main/res/values-ru/strings_skills.xml
@@ -1,0 +1,89 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- ===== Skill names and descriptions ===== -->
+
+    <!-- Gathering skills -->
+    <string name="skill_mining_name">Добыча руды</string>
+    <string name="skill_mining_desc">Добывайте ценную руду и драгоценные камни из недр земли.</string>
+    <string name="skill_fishing_name">Рыбалка</string>
+    <string name="skill_fishing_desc">Ловите рыбу и водные сокровища из водоёмов.</string>
+    <string name="skill_woodcutting_name">Рубка леса</string>
+    <string name="skill_woodcutting_desc">Рубите деревья и собирайте различные виды древесины.</string>
+    <string name="skill_farming_name">Фермерство</string>
+    <string name="skill_farming_desc">Сажайте и собирайте урожай на своих участках.</string>
+    <string name="skill_firemaking_name">Разжигание огня</string>
+    <string name="skill_firemaking_desc">Сжигайте брёвна из инвентаря, чтобы получить опыт Разжигания огня. Каждое сожжённое бревно также даёт пепел, который можно развеять в навыке Молитвы для дополнительного опыта Молитвы.</string>
+    <string name="skill_agility_name">Ловкость</string>
+    <string name="skill_agility_desc">Тренируйте Ловкость, чтобы сократить время сессий всех навыков. Уровень 99 убирает 20 минут из часа (60 мин → 40 мин) с плавным линейным уменьшением по мере повышения уровня.</string>
+
+    <!-- Crafting skills -->
+    <string name="skill_smithing_name">Ковка</string>
+    <string name="skill_smithing_desc">Плавьте руду в слитки и куйте мощное металлическое снаряжение.</string>
+    <string name="skill_cooking_name">Кулинария</string>
+    <string name="skill_cooking_desc">Готовьте сырые ингредиенты в пищу, восстанавливающую HP в бою.</string>
+    <string name="skill_fletching_name">Флетчинг</string>
+    <string name="skill_fletching_desc">Создавайте луки и стрелы из брёвен и металлических компонентов.</string>
+    <string name="skill_crafting_name">Ремесло</string>
+    <string name="skill_crafting_desc">Создавайте украшения и другие ремесленные изделия из драгоценных материалов.</string>
+    <string name="skill_runecrafting_name">Руническое ремесло</string>
+    <string name="skill_runecrafting_desc">Создавайте магические руны из рунической эссенции для использования в заклинаниях.</string>
+    <string name="skill_herblore_name">Травничество</string>
+    <string name="skill_herblore_desc">Варите зелья из фермерских трав и реагентов из подземелий для усиления боевых характеристик.</string>
+
+    <!-- Combat skills -->
+    <string name="skill_attack_name">Атака</string>
+    <string name="skill_attack_desc">Повышает точность ближнего боя, увеличивая шанс попадания.</string>
+    <string name="skill_strength_name">Сила</string>
+    <string name="skill_strength_desc">Увеличивает максимальный урон ближнего боя за удар.</string>
+    <string name="skill_defense_name">Защита</string>
+    <string name="skill_defense_desc">Уменьшает урон, получаемый от вражеских атак.</string>
+    <string name="skill_ranged_name">Стрельба</string>
+    <string name="skill_ranged_desc">Атакуйте врагов с безопасного расстояния с помощью лука и стрел.</string>
+    <string name="skill_magic_name">Магия</string>
+    <string name="skill_magic_desc">Произносите могущественные заклинания с помощью рун. Более высокие уровни открывают сильнейшие заклинания.</string>
+    <string name="skill_hitpoints_name">Здоровье</string>
+    <string name="skill_hitpoints_desc">Ваше общее здоровье. Более высокие уровни позволяют дольше выживать в бою.</string>
+    <string name="skill_prayer_name">Молитва</string>
+    <string name="skill_prayer_desc">Хороните кости, выпадающие из боя, чтобы получать опыт Молитвы. Более высокие уровни увеличивают ваш боевой уровень.</string>
+
+    <!-- ===== Skill unlock sheet labels ===== -->
+    <string name="label_lv">Ур. %1$d</string>
+    <string name="skills_agility_course_detail">Ур. %1$d  •  %2$d опыта/круг</string>
+    <string name="label_hp_passive">Пассивный — увеличивает макс. HP</string>
+    <string name="label_hp_scales">Макс. HP растёт с каждым уровнем</string>
+    <string name="label_hp_max">Макс. HP: %1$d</string>
+    <string name="label_xp_per_bone">%1$s (%2$d опыта/кость)</string>
+    <string name="label_xp_per_kill">%1$s (%2$d опыта/убийство)</string>
+
+    <!-- ===== Agility course names and descriptions ===== -->
+    <string name="agility_beginner_course_name">Начальный маршрут</string>
+    <string name="agility_beginner_course_desc">Простая полоса препятствий для тех, кто только начинает тренировку ловкости.</string>
+    <string name="agility_novice_course_name">Новичковый маршрут</string>
+    <string name="agility_novice_course_desc">Немного более сложный маршрут с базовыми препятствиями.</string>
+    <string name="agility_apprentice_course_name">Ученический маршрут</string>
+    <string name="agility_apprentice_course_desc">Промежуточный маршрут, требующий некоторого мастерства.</string>
+    <string name="agility_intermediate_course_name">Промежуточный маршрут</string>
+    <string name="agility_intermediate_course_desc">Умеренно сложный маршрут с хитрыми препятствиями.</string>
+    <string name="agility_advanced_course_name">Продвинутый маршрут</string>
+    <string name="agility_advanced_course_desc">Сложный маршрут, проверяющий ваше мастерство ловкости.</string>
+    <string name="agility_expert_course_name">Экспертный маршрут</string>
+    <string name="agility_expert_course_desc">Маршрут экспертного уровня с опасными препятствиями.</string>
+    <string name="agility_elite_course_name">Элитный маршрут</string>
+    <string name="agility_elite_course_desc">Только самые ловкие смогут освоить этот элитный маршрут.</string>
+    <string name="agility_master_course_name">Мастерский маршрут</string>
+    <string name="agility_master_course_desc">Маршрут уровня мастера с экстремальными препятствиями.</string>
+    <string name="agility_veteran_course_name">Ветеранский маршрут</string>
+    <string name="agility_veteran_course_desc">Тренировочная площадка ветеранов с суровыми испытаниями.</string>
+    <string name="agility_champion_course_name">Маршрут чемпиона</string>
+    <string name="agility_champion_course_desc">Маршрут уровня чемпиона, испытывающий вас на пределе возможностей.</string>
+    <string name="agility_heroic_course_name">Героический маршрут</string>
+    <string name="agility_heroic_course_desc">Героический маршрут, где осмеливаются ходить только лучшие.</string>
+    <string name="agility_legendary_course_name">Легендарный маршрут</string>
+    <string name="agility_legendary_course_desc">Легендарный маршрут, о котором шёпотом говорят среди элиты ловкости.</string>
+    <string name="agility_mythic_course_name">Мифический маршрут</string>
+    <string name="agility_mythic_course_desc">Мифический маршрут, бросающий вызов законам физики.</string>
+    <string name="agility_divine_course_name">Божественный маршрут</string>
+    <string name="agility_divine_course_desc">Божественный маршрут, благословлённый богами ловкости.</string>
+    <string name="agility_transcendent_course_name">Трансцендентный маршрут</string>
+    <string name="agility_transcendent_course_desc">Высшее испытание ловкости, превосходящее смертные пределы.</string>
+</resources>

--- a/app/src/main/res/xml/locales_config.xml
+++ b/app/src/main/res/xml/locales_config.xml
@@ -7,4 +7,5 @@
     <locale android:name="tr"/>
     <locale android:name="it"/>
     <locale android:name="nl"/>
+    <locale android:name="ru"/>
 </locale-config>


### PR DESCRIPTION
## Russian Translation

Adds complete Russian locale support for Idle Fantasy.

### Changes
- **8 string resource files** in `values-ru/` covering all app modules:
  - `strings.xml` — core UI (1 005 lines): navigation, buttons, labels, format strings, Russian plurals (one/few/many/other), error messages, settings, home, combat, profile, skills, shop, crafting, farming, character setup, inn/workers, achievements, guild hall, mercantile, church & blessings, skilling dungeons, expeditions, slayer, prestige, shop categories, crafting categories & tiers, firemaking rework, trade routes
  - `strings_notifications.xml` — session & level-up notifications
  - `strings_game.xml` — game mechanic strings
  - `strings_skills.xml` — skill names & descriptions
  - `strings_enemies.xml` — enemy names
  - `strings_items.xml` — items & materials (610 lines)
  - `strings_quests.xml` — quest names & objectives (422 lines)
  - `strings_guild_quests.xml` — guild quest names (460 lines)
- **`locales_config.xml`** — registered `ru` locale
- **Language picker** — added Русский option

### Translation Notes
- Russian plural forms (one/few/many/other) used throughout
- Positional placeholders (`%1$s`, `%1$d`) preserved; reordered where Russian grammar requires it
- `translatable=false` entries left untouched
- Fantasy proper names (worker names Aldric–Yara) kept as-is
- Metal tier terms: бронза / железо / сталь / мифрил / адамантит / рунит
- Consistent glossary: Session→Сессия, XP→Опыт, Skill→Навык, Dungeon→Подземелье, Boss→Босс, Patch→Участок, Pet→Питомец

### Testing
- All XML files validated as well-formed
- Line counts match source files (+extra lines for Russian plural forms)

Closes #379