### PR TITLE
test: add JVM unit-test scaffolding

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -102,4 +102,8 @@ dependencies {
 
     // kotlinx.serialization
     implementation(libs.kotlinx.serialization.json)
+
+    // Unit testing (JVM, no device required)
+    testImplementation(libs.junit)
+    testImplementation(libs.kotlin.test.junit)
 }

--- a/app/src/test/kotlin/com/fantasyidler/ScaffoldingSanityTest.kt
+++ b/app/src/test/kotlin/com/fantasyidler/ScaffoldingSanityTest.kt
@@ -1,0 +1,19 @@
+package com.fantasyidler
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * Smoke test confirming the JVM unit-test source set is wired up and runs.
+ *
+ * This is intentionally trivial — it exists to validate the test toolchain
+ * (JUnit + kotlin-test on the `test` source set) introduced by the scaffolding
+ * PR. Real coverage of game logic is added in subsequent PRs.
+ */
+class ScaffoldingSanityTest {
+
+    @Test
+    fun `test toolchain runs`() {
+        assertEquals(4, 2 + 2)
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -13,6 +13,9 @@ room                = "2.6.1"
 appcompat           = "1.7.0"
 serialization       = "1.7.1"
 
+# Testing
+junit               = "4.13.2"
+
 [libraries]
 # Core
 androidx-core-ktx                   = { group = "androidx.core",      name = "core-ktx",                    version.ref = "coreKtx" }
@@ -48,6 +51,10 @@ androidx-appcompat                   = { group = "androidx.appcompat", name = "a
 
 # kotlinx.serialization
 kotlinx-serialization-json          = { group = "org.jetbrains.kotlinx", name = "kotlinx-serialization-json", version.ref = "serialization" }
+
+# Testing
+junit                               = { group = "junit",                 name = "junit",             version.ref = "junit" }
+kotlin-test-junit                   = { group = "org.jetbrains.kotlin",  name = "kotlin-test-junit", version.ref = "kotlin" }
 
 [plugins]
 android-application  = { id = "com.android.application",                    version.ref = "agp" }


### PR DESCRIPTION
## What
Stands up a JVM unit-test source set so the project can have automated tests. There are none today.

- Adds `junit` + `kotlin-test-junit` to the version catalog and `testImplementation` in `app/build.gradle.kts`
- Creates `app/src/test/kotlin/...` with a single smoke test validating the toolchain

## Why
A regression safety net is hard to add all at once, so this is the minimal first step: just the plumbing, no game-logic tests yet. Follow-up PRs add real coverage (pure logic, simulators, Room migrations) and CI.

## Verification
`./gradlew testDebugUnitTest` is green; `./gradlew assembleDebug` is unaffected. No production code is touched.

Related to #165 and #409.