### PR TITLE
test: cover pure game logic (XP table, extensions, skill estimates)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -102,4 +102,8 @@ dependencies {
 
     // kotlinx.serialization
     implementation(libs.kotlinx.serialization.json)
+
+    // Unit testing (JVM, no device required)
+    testImplementation(libs.junit)
+    testImplementation(libs.kotlin.test.junit)
 }

--- a/app/src/test/kotlin/com/fantasyidler/ScaffoldingSanityTest.kt
+++ b/app/src/test/kotlin/com/fantasyidler/ScaffoldingSanityTest.kt
@@ -1,0 +1,19 @@
+package com.fantasyidler
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * Smoke test confirming the JVM unit-test source set is wired up and runs.
+ *
+ * This is intentionally trivial — it exists to validate the test toolchain
+ * (JUnit + kotlin-test on the `test` source set) introduced by the scaffolding
+ * PR. Real coverage of game logic is added in subsequent PRs.
+ */
+class ScaffoldingSanityTest {
+
+    @Test
+    fun `test toolchain runs`() {
+        assertEquals(4, 2 + 2)
+    }
+}

--- a/app/src/test/kotlin/com/fantasyidler/simulator/SkillSimulatorPureTest.kt
+++ b/app/src/test/kotlin/com/fantasyidler/simulator/SkillSimulatorPureTest.kt
@@ -1,0 +1,66 @@
+package com.fantasyidler.simulator
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Unit tests for the deterministic (RNG-free) preview helpers of [SkillSimulator]:
+ * `estimateGatheringXp`, `estimateAgilityXp`, and `sessionDurationMs`. The
+ * RNG-driven `simulate*` functions are covered separately once a seedable
+ * Random seam is introduced.
+ */
+class SkillSimulatorPureTest {
+
+    @Test
+    fun `estimateGatheringXp multiplies per-action XP by efficiency over 60 frames`() {
+        assertEquals(600L, SkillSimulator.estimateGatheringXp(10, 1f))
+        assertEquals(420L, SkillSimulator.estimateGatheringXp(7, 1f))
+        assertEquals(900L, SkillSimulator.estimateGatheringXp(10, 1.5f))
+        assertEquals(0L, SkillSimulator.estimateGatheringXp(0, 1f))
+    }
+
+    @Test
+    fun `estimateAgilityXp grows with level then caps at the 0_95 success rate`() {
+        // At the minimum level the success rate is the base 0.80.
+        assertEquals(960L, SkillSimulator.estimateAgilityXp(10, 1, 1))
+        // Far above the requirement the rate is clamped to 0.95.
+        assertEquals(1140L, SkillSimulator.estimateAgilityXp(10, 1, 99))
+        // The capped value should equal any level past the cap threshold.
+        assertEquals(
+            SkillSimulator.estimateAgilityXp(10, 1, 99),
+            SkillSimulator.estimateAgilityXp(10, 1, 50),
+        )
+    }
+
+    @Test
+    fun `estimateAgilityXp is monotonically non-decreasing in current level`() {
+        var previous = Long.MIN_VALUE
+        for (level in 1..99) {
+            val xp = SkillSimulator.estimateAgilityXp(10, 1, level)
+            assertTrue("XP dropped at level $level", xp >= previous)
+            previous = xp
+        }
+    }
+
+    @Test
+    fun `sessionDurationMs scales linearly from 60 to 40 minutes`() {
+        assertEquals(60 * 60_000L, SkillSimulator.sessionDurationMs(1))
+        assertEquals(55 * 60_000L, SkillSimulator.sessionDurationMs(25))
+        assertEquals(50 * 60_000L, SkillSimulator.sessionDurationMs(50))
+        assertEquals(45 * 60_000L, SkillSimulator.sessionDurationMs(75))
+        assertEquals(40 * 60_000L, SkillSimulator.sessionDurationMs(99))
+    }
+
+    @Test
+    fun `sessionDurationMs clamps out-of-range levels and never increases with level`() {
+        assertEquals(SkillSimulator.sessionDurationMs(1), SkillSimulator.sessionDurationMs(0))
+        assertEquals(SkillSimulator.sessionDurationMs(99), SkillSimulator.sessionDurationMs(200))
+        var previous = Long.MAX_VALUE
+        for (level in 1..99) {
+            val ms = SkillSimulator.sessionDurationMs(level)
+            assertTrue("duration increased at level $level", ms <= previous)
+            previous = ms
+        }
+    }
+}

--- a/app/src/test/kotlin/com/fantasyidler/simulator/XpTableTest.kt
+++ b/app/src/test/kotlin/com/fantasyidler/simulator/XpTableTest.kt
@@ -1,0 +1,80 @@
+package com.fantasyidler.simulator
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Unit tests for [XpTable] — the level 1–99 XP progression table.
+ *
+ * Anchors are taken from the formula documented on [XpTable] and cross-checked
+ * against the classic idle-RPG table (verified against IdleApes xp_table.json).
+ */
+class XpTableTest {
+
+    @Test
+    fun `known anchor thresholds match the classic table`() {
+        assertEquals(0L, XpTable.xpForLevel(1))
+        assertEquals(83L, XpTable.xpForLevel(2))
+        assertEquals(101_333L, XpTable.xpForLevel(50))
+        assertEquals(13_034_431L, XpTable.xpForLevel(99))
+    }
+
+    @Test
+    fun `thresholds strictly increase across the whole range`() {
+        for (level in 2..99) {
+            assertTrue(
+                "xpForLevel($level) must exceed xpForLevel(${level - 1})",
+                XpTable.xpForLevel(level) > XpTable.xpForLevel(level - 1),
+            )
+        }
+    }
+
+    @Test
+    fun `xpForLevel clamps out-of-range levels into 1-99`() {
+        assertEquals(XpTable.xpForLevel(1), XpTable.xpForLevel(0))
+        assertEquals(XpTable.xpForLevel(1), XpTable.xpForLevel(-5))
+        assertEquals(XpTable.xpForLevel(99), XpTable.xpForLevel(200))
+    }
+
+    @Test
+    fun `levelForXp is the inverse of xpForLevel at every threshold`() {
+        for (level in 1..99) {
+            assertEquals(level, XpTable.levelForXp(XpTable.xpForLevel(level)))
+        }
+    }
+
+    @Test
+    fun `levelForXp maps boundary XP values to the correct level`() {
+        assertEquals(1, XpTable.levelForXp(0L))
+        assertEquals(1, XpTable.levelForXp(82L))          // one short of level 2
+        assertEquals(2, XpTable.levelForXp(83L))          // exactly level 2
+        assertEquals(99, XpTable.levelForXp(13_034_431L))
+        assertEquals(99, XpTable.levelForXp(Long.MAX_VALUE))
+    }
+
+    @Test
+    fun `xpToNextLevel is the gap to the next threshold and zero at max level`() {
+        assertEquals(83L, XpTable.xpToNextLevel(0L))
+        assertEquals(0L, XpTable.xpToNextLevel(XpTable.xpForLevel(99)))
+        assertEquals(0L, XpTable.xpToNextLevel(Long.MAX_VALUE))
+    }
+
+    @Test
+    fun `nextLevelThreshold returns the upcoming threshold`() {
+        assertEquals(83L, XpTable.nextLevelThreshold(0L))
+        assertEquals(XpTable.xpForLevel(99), XpTable.nextLevelThreshold(XpTable.xpForLevel(99)))
+    }
+
+    @Test
+    fun `progressFraction stays within 0 and 1 and is full at max level`() {
+        assertEquals(0f, XpTable.progressFraction(0L), 0.0001f)
+        assertEquals(1f, XpTable.progressFraction(XpTable.xpForLevel(99)), 0.0001f)
+        // Halfway through the level-1 band (0..83) should be roughly 0.5.
+        assertEquals(0.5f, XpTable.progressFraction(41L), 0.05f)
+        for (xp in longArrayOf(0L, 50L, 1_000L, 101_333L, 5_000_000L, 13_034_431L)) {
+            val f = XpTable.progressFraction(xp)
+            assertTrue("progressFraction($xp)=$f out of range", f in 0f..1f)
+        }
+    }
+}

--- a/app/src/test/kotlin/com/fantasyidler/util/ExtensionsTest.kt
+++ b/app/src/test/kotlin/com/fantasyidler/util/ExtensionsTest.kt
@@ -1,0 +1,81 @@
+package com.fantasyidler.util
+
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import java.util.Locale
+
+/**
+ * Unit tests for the pure formatting/clamping extensions in `Extensions.kt`.
+ *
+ * `formatXp`/`formatCoins` delegate to locale-default `String.format`, so the
+ * default locale is pinned to [Locale.US] for the duration of each test to keep
+ * the expected separators ("1,000", "1.5M") deterministic across machines and CI.
+ * (The time-relative helpers `toCountdown`/`toRelativeTime` are intentionally
+ * not covered here because they read the wall clock.)
+ */
+class ExtensionsTest {
+
+    private lateinit var originalLocale: Locale
+
+    @Before
+    fun pinLocale() {
+        originalLocale = Locale.getDefault()
+        Locale.setDefault(Locale.US)
+    }
+
+    @After
+    fun restoreLocale() {
+        Locale.setDefault(originalLocale)
+    }
+
+    @Test
+    fun `formatXp switches units at the thousand and million boundaries`() {
+        assertEquals("999", 999L.formatXp())
+        assertEquals("1,000", 1_000L.formatXp())
+        assertEquals("999,999", 999_999L.formatXp())
+        assertEquals("1.0M", 1_000_000L.formatXp())
+        assertEquals("1.5M", 1_500_000L.formatXp())
+        assertEquals("0", 0L.formatXp())
+    }
+
+    @Test
+    fun `formatCoins uses the same boundaries as formatXp`() {
+        assertEquals("500", 500L.formatCoins())
+        assertEquals("1,000", 1_000L.formatCoins())
+        assertEquals("2.5M", 2_500_000L.formatCoins())
+    }
+
+    @Test
+    fun `formatDurationMs renders hours minutes and seconds`() {
+        assertEquals("45s", 45_000L.formatDurationMs())
+        assertEquals("1m", 60_000L.formatDurationMs())
+        assertEquals("1m", 90_000L.formatDurationMs())     // sub-minute remainder dropped
+        assertEquals("1h", 3_600_000L.formatDurationMs())
+        assertEquals("1h 1m", 3_660_000L.formatDurationMs())
+        assertEquals("1h 30m", 5_400_000L.formatDurationMs())
+        assertEquals("0s", 0L.formatDurationMs())
+    }
+
+    @Test
+    fun `clampLevel constrains to the 1-99 skill range`() {
+        assertEquals(1, 0.clampLevel())
+        assertEquals(1, (-5).clampLevel())
+        assertEquals(1, 1.clampLevel())
+        assertEquals(50, 50.clampLevel())
+        assertEquals(99, 99.clampLevel())
+        assertEquals(99, 200.clampLevel())
+    }
+
+    @Test
+    fun `toSkillAbbrev maps known skills and falls back for unknown ones`() {
+        assertEquals("Atk", "attack".toSkillAbbrev())
+        assertEquals("Str", "strength".toSkillAbbrev())
+        assertEquals("HP", "hitpoints".toSkillAbbrev())
+        assertEquals("RC", "runecrafting".toSkillAbbrev())
+        // Unknown keys fall back to the capitalised first four characters.
+        assertEquals("Herb", "herblore".toSkillAbbrev())
+        assertEquals("Slay", "slayer".toSkillAbbrev())
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -13,6 +13,9 @@ room                = "2.6.1"
 appcompat           = "1.7.0"
 serialization       = "1.7.1"
 
+# Testing
+junit               = "4.13.2"
+
 [libraries]
 # Core
 androidx-core-ktx                   = { group = "androidx.core",      name = "core-ktx",                    version.ref = "coreKtx" }
@@ -48,6 +51,10 @@ androidx-appcompat                   = { group = "androidx.appcompat", name = "a
 
 # kotlinx.serialization
 kotlinx-serialization-json          = { group = "org.jetbrains.kotlinx", name = "kotlinx-serialization-json", version.ref = "serialization" }
+
+# Testing
+junit                               = { group = "junit",                 name = "junit",             version.ref = "junit" }
+kotlin-test-junit                   = { group = "org.jetbrains.kotlin",  name = "kotlin-test-junit", version.ref = "kotlin" }
 
 [plugins]
 android-application  = { id = "com.android.application",                    version.ref = "agp" }


### PR DESCRIPTION
## What
Adds 18 unit tests for the deterministic, RNG-free surface, with no **no production code changes**:

- `XpTableTest`: anchor thresholds (L1/L2/L50/L99), strict monotonicity, `levelForXp`/`xpForLevel` inverse, `xpToNextLevel`, `nextLevelThreshold`, `progressFraction` bounds, out-of-range clamping
- `ExtensionsTest`: `formatXp`/`formatCoins`/`formatDurationMs` boundaries, `clampLevel`, `toSkillAbbrev` (locale pinned to US so separators are deterministic on any machine/CI)
- `SkillSimulatorPureTest`: `estimateGatheringXp`, `estimateAgilityXp` (rate cap + monotonicity), `sessionDurationMs` scaling/clamping

## Why
Locks down the core progression math that everything else depends on, with fast pure-JVM tests and zero risk to the shipping app.

## Notes
Stacked on #412 (test scaffolding); please review/merge after it. Until #412 merges, the diff here also shows its commit.

## Verification
`./gradlew testDebugUnitTest` all test pass.
