### PR TITLE
test: seedable RNG seam + deterministic simulator tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,52 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+# Cancel superseded runs on the same ref to save CI minutes.
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  build-and-test:
+    name: Unit tests, lint, debug build
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "17"
+
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Unit tests
+        run: ./gradlew testDebugUnitTest --stacktrace
+
+      - name: Android lint
+        run: ./gradlew lintDebug --stacktrace
+
+      - name: Assemble debug APK
+        run: ./gradlew assembleDebug --stacktrace
+
+      - name: Upload reports
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: build-reports
+          path: |
+            app/build/reports/tests/
+            app/build/reports/lint-results-*.html
+          if-no-files-found: ignore
+          retention-days: 7

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -57,6 +57,15 @@ android {
         compose = true
         buildConfig = true
     }
+
+    lint {
+        // Existing issues are captured in lint-baseline.xml so CI fails only on
+        // NEW problems introduced by future changes, without forcing a cleanup of
+        // the pre-existing backlog. Regenerate by deleting the baseline and
+        // running `./gradlew lintDebug`.
+        baseline = file("lint-baseline.xml")
+        warningsAsErrors = false
+    }
 }
 
 // Export Room schema files so migrations can be verified and reviewed in version control.

--- a/app/lint-baseline.xml
+++ b/app/lint-baseline.xml
@@ -1,0 +1,20489 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<issues format="6" by="lint 8.6.1" type="baseline" client="gradle" dependencies="false" name="AGP (8.6.1)" variant="all" version="8.6.1">
+
+    <issue
+        id="NewApi"
+        message="`android:windowSplashScreenBackground` requires API level 31 (current min is 26)"
+        errorLine1="        &lt;item name=&quot;android:windowSplashScreenBackground&quot;>@color/ic_launcher_background&lt;/item>"
+        errorLine2="              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/themes.xml"
+            line="5"
+            column="15"/>
+    </issue>
+
+    <issue
+        id="AndroidGradlePluginVersion"
+        message="A newer version of com.android.application than 8.6.1 is available: 9.2.1"
+        errorLine1="agp                 = &quot;8.6.1&quot;"
+        errorLine2="                      ~~~~~~~">
+        <location
+            file="$HOME/Documents/dev/ho/IdleFantasy/gradle/libs.versions.toml"
+            line="2"
+            column="23"/>
+    </issue>
+
+    <issue
+        id="AndroidGradlePluginVersion"
+        message="A newer version of com.android.application than 8.6.1 is available: 9.2.1"
+        errorLine1="agp                 = &quot;8.6.1&quot;"
+        errorLine2="                      ~~~~~~~">
+        <location
+            file="$HOME/Documents/dev/ho/IdleFantasy/gradle/libs.versions.toml"
+            line="2"
+            column="23"/>
+    </issue>
+
+    <issue
+        id="AndroidGradlePluginVersion"
+        message="A newer version of com.android.application than 8.6.1 is available: 9.2.1"
+        errorLine1="agp                 = &quot;8.6.1&quot;"
+        errorLine2="                      ~~~~~~~">
+        <location
+            file="$HOME/Documents/dev/ho/IdleFantasy/gradle/libs.versions.toml"
+            line="2"
+            column="23"/>
+    </issue>
+
+    <issue
+        id="GradleDependency"
+        message="A newer version of androidx.compose:compose-bom than 2024.06.00 is available: 2026.05.01"
+        errorLine1="composeBom          = &quot;2024.06.00&quot;"
+        errorLine2="                      ~~~~~~~~~~~~">
+        <location
+            file="$HOME/Documents/dev/ho/IdleFantasy/gradle/libs.versions.toml"
+            line="5"
+            column="23"/>
+    </issue>
+
+    <issue
+        id="GradleDependency"
+        message="A newer version of androidx.compose:compose-bom than 2024.06.00 is available: 2026.05.01"
+        errorLine1="composeBom          = &quot;2024.06.00&quot;"
+        errorLine2="                      ~~~~~~~~~~~~">
+        <location
+            file="$HOME/Documents/dev/ho/IdleFantasy/gradle/libs.versions.toml"
+            line="5"
+            column="23"/>
+    </issue>
+
+    <issue
+        id="GradleDependency"
+        message="A newer version of androidx.compose:compose-bom than 2024.06.00 is available: 2026.05.01"
+        errorLine1="composeBom          = &quot;2024.06.00&quot;"
+        errorLine2="                      ~~~~~~~~~~~~">
+        <location
+            file="$HOME/Documents/dev/ho/IdleFantasy/gradle/libs.versions.toml"
+            line="5"
+            column="23"/>
+    </issue>
+
+    <issue
+        id="GradleDependency"
+        message="A newer version of androidx.core:core-ktx than 1.13.1 is available: 1.19.0"
+        errorLine1="coreKtx             = &quot;1.13.1&quot;"
+        errorLine2="                      ~~~~~~~~">
+        <location
+            file="$HOME/Documents/dev/ho/IdleFantasy/gradle/libs.versions.toml"
+            line="6"
+            column="23"/>
+    </issue>
+
+    <issue
+        id="GradleDependency"
+        message="A newer version of androidx.core:core-ktx than 1.13.1 is available: 1.19.0"
+        errorLine1="coreKtx             = &quot;1.13.1&quot;"
+        errorLine2="                      ~~~~~~~~">
+        <location
+            file="$HOME/Documents/dev/ho/IdleFantasy/gradle/libs.versions.toml"
+            line="6"
+            column="23"/>
+    </issue>
+
+    <issue
+        id="GradleDependency"
+        message="A newer version of androidx.core:core-ktx than 1.13.1 is available: 1.19.0"
+        errorLine1="coreKtx             = &quot;1.13.1&quot;"
+        errorLine2="                      ~~~~~~~~">
+        <location
+            file="$HOME/Documents/dev/ho/IdleFantasy/gradle/libs.versions.toml"
+            line="6"
+            column="23"/>
+    </issue>
+
+    <issue
+        id="GradleDependency"
+        message="A newer version of androidx.lifecycle:lifecycle-runtime-ktx than 2.8.2 is available: 2.10.0"
+        errorLine1="lifecycleRuntime    = &quot;2.8.2&quot;"
+        errorLine2="                      ~~~~~~~">
+        <location
+            file="$HOME/Documents/dev/ho/IdleFantasy/gradle/libs.versions.toml"
+            line="7"
+            column="23"/>
+    </issue>
+
+    <issue
+        id="GradleDependency"
+        message="A newer version of androidx.lifecycle:lifecycle-runtime-ktx than 2.8.2 is available: 2.10.0"
+        errorLine1="lifecycleRuntime    = &quot;2.8.2&quot;"
+        errorLine2="                      ~~~~~~~">
+        <location
+            file="$HOME/Documents/dev/ho/IdleFantasy/gradle/libs.versions.toml"
+            line="7"
+            column="23"/>
+    </issue>
+
+    <issue
+        id="GradleDependency"
+        message="A newer version of androidx.lifecycle:lifecycle-runtime-ktx than 2.8.2 is available: 2.10.0"
+        errorLine1="lifecycleRuntime    = &quot;2.8.2&quot;"
+        errorLine2="                      ~~~~~~~">
+        <location
+            file="$HOME/Documents/dev/ho/IdleFantasy/gradle/libs.versions.toml"
+            line="7"
+            column="23"/>
+    </issue>
+
+    <issue
+        id="GradleDependency"
+        message="A newer version of androidx.lifecycle:lifecycle-viewmodel-compose than 2.8.2 is available: 2.10.0"
+        errorLine1="lifecycleRuntime    = &quot;2.8.2&quot;"
+        errorLine2="                      ~~~~~~~">
+        <location
+            file="$HOME/Documents/dev/ho/IdleFantasy/gradle/libs.versions.toml"
+            line="7"
+            column="23"/>
+    </issue>
+
+    <issue
+        id="GradleDependency"
+        message="A newer version of androidx.lifecycle:lifecycle-viewmodel-compose than 2.8.2 is available: 2.10.0"
+        errorLine1="lifecycleRuntime    = &quot;2.8.2&quot;"
+        errorLine2="                      ~~~~~~~">
+        <location
+            file="$HOME/Documents/dev/ho/IdleFantasy/gradle/libs.versions.toml"
+            line="7"
+            column="23"/>
+    </issue>
+
+    <issue
+        id="GradleDependency"
+        message="A newer version of androidx.lifecycle:lifecycle-viewmodel-compose than 2.8.2 is available: 2.10.0"
+        errorLine1="lifecycleRuntime    = &quot;2.8.2&quot;"
+        errorLine2="                      ~~~~~~~">
+        <location
+            file="$HOME/Documents/dev/ho/IdleFantasy/gradle/libs.versions.toml"
+            line="7"
+            column="23"/>
+    </issue>
+
+    <issue
+        id="GradleDependency"
+        message="A newer version of androidx.activity:activity-compose than 1.9.0 is available: 1.13.0"
+        errorLine1="activityCompose     = &quot;1.9.0&quot;"
+        errorLine2="                      ~~~~~~~">
+        <location
+            file="$HOME/Documents/dev/ho/IdleFantasy/gradle/libs.versions.toml"
+            line="8"
+            column="23"/>
+    </issue>
+
+    <issue
+        id="GradleDependency"
+        message="A newer version of androidx.activity:activity-compose than 1.9.0 is available: 1.13.0"
+        errorLine1="activityCompose     = &quot;1.9.0&quot;"
+        errorLine2="                      ~~~~~~~">
+        <location
+            file="$HOME/Documents/dev/ho/IdleFantasy/gradle/libs.versions.toml"
+            line="8"
+            column="23"/>
+    </issue>
+
+    <issue
+        id="GradleDependency"
+        message="A newer version of androidx.activity:activity-compose than 1.9.0 is available: 1.13.0"
+        errorLine1="activityCompose     = &quot;1.9.0&quot;"
+        errorLine2="                      ~~~~~~~">
+        <location
+            file="$HOME/Documents/dev/ho/IdleFantasy/gradle/libs.versions.toml"
+            line="8"
+            column="23"/>
+    </issue>
+
+    <issue
+        id="GradleDependency"
+        message="A newer version of androidx.navigation:navigation-compose than 2.8.0 is available: 2.9.8"
+        errorLine1="navigationCompose   = &quot;2.8.0&quot;"
+        errorLine2="                      ~~~~~~~">
+        <location
+            file="$HOME/Documents/dev/ho/IdleFantasy/gradle/libs.versions.toml"
+            line="9"
+            column="23"/>
+    </issue>
+
+    <issue
+        id="GradleDependency"
+        message="A newer version of androidx.navigation:navigation-compose than 2.8.0 is available: 2.9.8"
+        errorLine1="navigationCompose   = &quot;2.8.0&quot;"
+        errorLine2="                      ~~~~~~~">
+        <location
+            file="$HOME/Documents/dev/ho/IdleFantasy/gradle/libs.versions.toml"
+            line="9"
+            column="23"/>
+    </issue>
+
+    <issue
+        id="GradleDependency"
+        message="A newer version of androidx.navigation:navigation-compose than 2.8.0 is available: 2.9.8"
+        errorLine1="navigationCompose   = &quot;2.8.0&quot;"
+        errorLine2="                      ~~~~~~~">
+        <location
+            file="$HOME/Documents/dev/ho/IdleFantasy/gradle/libs.versions.toml"
+            line="9"
+            column="23"/>
+    </issue>
+
+    <issue
+        id="GradleDependency"
+        message="A newer version of androidx.hilt:hilt-compiler than 1.2.0 is available: 1.3.0"
+        errorLine1="hiltExt             = &quot;1.2.0&quot;"
+        errorLine2="                      ~~~~~~~">
+        <location
+            file="$HOME/Documents/dev/ho/IdleFantasy/gradle/libs.versions.toml"
+            line="11"
+            column="23"/>
+    </issue>
+
+    <issue
+        id="GradleDependency"
+        message="A newer version of androidx.hilt:hilt-compiler than 1.2.0 is available: 1.3.0"
+        errorLine1="hiltExt             = &quot;1.2.0&quot;"
+        errorLine2="                      ~~~~~~~">
+        <location
+            file="$HOME/Documents/dev/ho/IdleFantasy/gradle/libs.versions.toml"
+            line="11"
+            column="23"/>
+    </issue>
+
+    <issue
+        id="GradleDependency"
+        message="A newer version of androidx.hilt:hilt-compiler than 1.2.0 is available: 1.3.0"
+        errorLine1="hiltExt             = &quot;1.2.0&quot;"
+        errorLine2="                      ~~~~~~~">
+        <location
+            file="$HOME/Documents/dev/ho/IdleFantasy/gradle/libs.versions.toml"
+            line="11"
+            column="23"/>
+    </issue>
+
+    <issue
+        id="GradleDependency"
+        message="A newer version of androidx.hilt:hilt-navigation-compose than 1.2.0 is available: 1.3.0"
+        errorLine1="hiltExt             = &quot;1.2.0&quot;"
+        errorLine2="                      ~~~~~~~">
+        <location
+            file="$HOME/Documents/dev/ho/IdleFantasy/gradle/libs.versions.toml"
+            line="11"
+            column="23"/>
+    </issue>
+
+    <issue
+        id="GradleDependency"
+        message="A newer version of androidx.hilt:hilt-navigation-compose than 1.2.0 is available: 1.3.0"
+        errorLine1="hiltExt             = &quot;1.2.0&quot;"
+        errorLine2="                      ~~~~~~~">
+        <location
+            file="$HOME/Documents/dev/ho/IdleFantasy/gradle/libs.versions.toml"
+            line="11"
+            column="23"/>
+    </issue>
+
+    <issue
+        id="GradleDependency"
+        message="A newer version of androidx.hilt:hilt-navigation-compose than 1.2.0 is available: 1.3.0"
+        errorLine1="hiltExt             = &quot;1.2.0&quot;"
+        errorLine2="                      ~~~~~~~">
+        <location
+            file="$HOME/Documents/dev/ho/IdleFantasy/gradle/libs.versions.toml"
+            line="11"
+            column="23"/>
+    </issue>
+
+    <issue
+        id="GradleDependency"
+        message="A newer version of androidx.hilt:hilt-work than 1.2.0 is available: 1.3.0"
+        errorLine1="hiltExt             = &quot;1.2.0&quot;"
+        errorLine2="                      ~~~~~~~">
+        <location
+            file="$HOME/Documents/dev/ho/IdleFantasy/gradle/libs.versions.toml"
+            line="11"
+            column="23"/>
+    </issue>
+
+    <issue
+        id="GradleDependency"
+        message="A newer version of androidx.hilt:hilt-work than 1.2.0 is available: 1.3.0"
+        errorLine1="hiltExt             = &quot;1.2.0&quot;"
+        errorLine2="                      ~~~~~~~">
+        <location
+            file="$HOME/Documents/dev/ho/IdleFantasy/gradle/libs.versions.toml"
+            line="11"
+            column="23"/>
+    </issue>
+
+    <issue
+        id="GradleDependency"
+        message="A newer version of androidx.hilt:hilt-work than 1.2.0 is available: 1.3.0"
+        errorLine1="hiltExt             = &quot;1.2.0&quot;"
+        errorLine2="                      ~~~~~~~">
+        <location
+            file="$HOME/Documents/dev/ho/IdleFantasy/gradle/libs.versions.toml"
+            line="11"
+            column="23"/>
+    </issue>
+
+    <issue
+        id="GradleDependency"
+        message="A newer version of androidx.room:room-compiler than 2.6.1 is available: 2.8.4"
+        errorLine1="room                = &quot;2.6.1&quot;"
+        errorLine2="                      ~~~~~~~">
+        <location
+            file="$HOME/Documents/dev/ho/IdleFantasy/gradle/libs.versions.toml"
+            line="12"
+            column="23"/>
+    </issue>
+
+    <issue
+        id="GradleDependency"
+        message="A newer version of androidx.room:room-compiler than 2.6.1 is available: 2.8.4"
+        errorLine1="room                = &quot;2.6.1&quot;"
+        errorLine2="                      ~~~~~~~">
+        <location
+            file="$HOME/Documents/dev/ho/IdleFantasy/gradle/libs.versions.toml"
+            line="12"
+            column="23"/>
+    </issue>
+
+    <issue
+        id="GradleDependency"
+        message="A newer version of androidx.room:room-compiler than 2.6.1 is available: 2.8.4"
+        errorLine1="room                = &quot;2.6.1&quot;"
+        errorLine2="                      ~~~~~~~">
+        <location
+            file="$HOME/Documents/dev/ho/IdleFantasy/gradle/libs.versions.toml"
+            line="12"
+            column="23"/>
+    </issue>
+
+    <issue
+        id="GradleDependency"
+        message="A newer version of androidx.room:room-ktx than 2.6.1 is available: 2.8.4"
+        errorLine1="room                = &quot;2.6.1&quot;"
+        errorLine2="                      ~~~~~~~">
+        <location
+            file="$HOME/Documents/dev/ho/IdleFantasy/gradle/libs.versions.toml"
+            line="12"
+            column="23"/>
+    </issue>
+
+    <issue
+        id="GradleDependency"
+        message="A newer version of androidx.room:room-ktx than 2.6.1 is available: 2.8.4"
+        errorLine1="room                = &quot;2.6.1&quot;"
+        errorLine2="                      ~~~~~~~">
+        <location
+            file="$HOME/Documents/dev/ho/IdleFantasy/gradle/libs.versions.toml"
+            line="12"
+            column="23"/>
+    </issue>
+
+    <issue
+        id="GradleDependency"
+        message="A newer version of androidx.room:room-ktx than 2.6.1 is available: 2.8.4"
+        errorLine1="room                = &quot;2.6.1&quot;"
+        errorLine2="                      ~~~~~~~">
+        <location
+            file="$HOME/Documents/dev/ho/IdleFantasy/gradle/libs.versions.toml"
+            line="12"
+            column="23"/>
+    </issue>
+
+    <issue
+        id="GradleDependency"
+        message="A newer version of androidx.room:room-runtime than 2.6.1 is available: 2.8.4"
+        errorLine1="room                = &quot;2.6.1&quot;"
+        errorLine2="                      ~~~~~~~">
+        <location
+            file="$HOME/Documents/dev/ho/IdleFantasy/gradle/libs.versions.toml"
+            line="12"
+            column="23"/>
+    </issue>
+
+    <issue
+        id="GradleDependency"
+        message="A newer version of androidx.room:room-runtime than 2.6.1 is available: 2.8.4"
+        errorLine1="room                = &quot;2.6.1&quot;"
+        errorLine2="                      ~~~~~~~">
+        <location
+            file="$HOME/Documents/dev/ho/IdleFantasy/gradle/libs.versions.toml"
+            line="12"
+            column="23"/>
+    </issue>
+
+    <issue
+        id="GradleDependency"
+        message="A newer version of androidx.room:room-runtime than 2.6.1 is available: 2.8.4"
+        errorLine1="room                = &quot;2.6.1&quot;"
+        errorLine2="                      ~~~~~~~">
+        <location
+            file="$HOME/Documents/dev/ho/IdleFantasy/gradle/libs.versions.toml"
+            line="12"
+            column="23"/>
+    </issue>
+
+    <issue
+        id="GradleDependency"
+        message="A newer version of androidx.appcompat:appcompat than 1.7.0 is available: 1.7.1"
+        errorLine1="appcompat           = &quot;1.7.0&quot;"
+        errorLine2="                      ~~~~~~~">
+        <location
+            file="$HOME/Documents/dev/ho/IdleFantasy/gradle/libs.versions.toml"
+            line="13"
+            column="23"/>
+    </issue>
+
+    <issue
+        id="GradleDependency"
+        message="A newer version of androidx.appcompat:appcompat than 1.7.0 is available: 1.7.1"
+        errorLine1="appcompat           = &quot;1.7.0&quot;"
+        errorLine2="                      ~~~~~~~">
+        <location
+            file="$HOME/Documents/dev/ho/IdleFantasy/gradle/libs.versions.toml"
+            line="13"
+            column="23"/>
+    </issue>
+
+    <issue
+        id="GradleDependency"
+        message="A newer version of androidx.appcompat:appcompat than 1.7.0 is available: 1.7.1"
+        errorLine1="appcompat           = &quot;1.7.0&quot;"
+        errorLine2="                      ~~~~~~~">
+        <location
+            file="$HOME/Documents/dev/ho/IdleFantasy/gradle/libs.versions.toml"
+            line="13"
+            column="23"/>
+    </issue>
+
+    <issue
+        id="ModifierParameter"
+        message="Modifier parameter should be the first optional parameter"
+        errorLine1="    modifier: Modifier = Modifier,"
+        errorLine2="    ~~~~~~~~">
+        <location
+            file="src/main/kotlin/com/fantasyidler/ui/screen/CombatScreen.kt"
+            line="415"
+            column="5"/>
+    </issue>
+
+    <issue
+        id="DiscouragedApi"
+        message="Use of this function is discouraged because resource reflection makes it harder to perform build optimizations and compile-time verification of code. It is much more efficient to retrieve resources by identifier (e.g. `R.foo.bar`) than by name (e.g. `getIdentifier(&quot;bar&quot;, &quot;foo&quot;, null)`)."
+        errorLine1="            val nameResId = context.resources.getIdentifier("
+        errorLine2="                                              ~~~~~~~~~~~~~">
+        <location
+            file="src/main/kotlin/com/fantasyidler/ui/screen/ChurchScreen.kt"
+            line="74"
+            column="47"/>
+    </issue>
+
+    <issue
+        id="DiscouragedApi"
+        message="Use of this function is discouraged because resource reflection makes it harder to perform build optimizations and compile-time verification of code. It is much more efficient to retrieve resources by identifier (e.g. `R.foo.bar`) than by name (e.g. `getIdentifier(&quot;bar&quot;, &quot;foo&quot;, null)`)."
+        errorLine1="    val nameResId = context.resources.getIdentifier("
+        errorLine2="                                      ~~~~~~~~~~~~~">
+        <location
+            file="src/main/kotlin/com/fantasyidler/ui/screen/ChurchScreen.kt"
+            line="193"
+            column="39"/>
+    </issue>
+
+    <issue
+        id="DiscouragedApi"
+        message="Use of this function is discouraged because resource reflection makes it harder to perform build optimizations and compile-time verification of code. It is much more efficient to retrieve resources by identifier (e.g. `R.foo.bar`) than by name (e.g. `getIdentifier(&quot;bar&quot;, &quot;foo&quot;, null)`)."
+        errorLine1="    val nameResId = context.resources.getIdentifier("
+        errorLine2="                                      ~~~~~~~~~~~~~">
+        <location
+            file="src/main/kotlin/com/fantasyidler/ui/screen/ChurchScreen.kt"
+            line="240"
+            column="39"/>
+    </issue>
+
+    <issue
+        id="DiscouragedApi"
+        message="Use of this function is discouraged because resource reflection makes it harder to perform build optimizations and compile-time verification of code. It is much more efficient to retrieve resources by identifier (e.g. `R.foo.bar`) than by name (e.g. `getIdentifier(&quot;bar&quot;, &quot;foo&quot;, null)`)."
+        errorLine1="        val resId = context.resources.getIdentifier("
+        errorLine2="                                      ~~~~~~~~~~~~~">
+        <location
+            file="src/main/kotlin/com/fantasyidler/util/GameStrings.kt"
+            line="80"
+            column="39"/>
+    </issue>
+
+    <issue
+        id="DiscouragedApi"
+        message="Use of this function is discouraged because resource reflection makes it harder to perform build optimizations and compile-time verification of code. It is much more efficient to retrieve resources by identifier (e.g. `R.foo.bar`) than by name (e.g. `getIdentifier(&quot;bar&quot;, &quot;foo&quot;, null)`)."
+        errorLine1="        val resId = context.resources.getIdentifier("
+        errorLine2="                                      ~~~~~~~~~~~~~">
+        <location
+            file="src/main/kotlin/com/fantasyidler/util/GameStrings.kt"
+            line="86"
+            column="39"/>
+    </issue>
+
+    <issue
+        id="DiscouragedApi"
+        message="Use of this function is discouraged because resource reflection makes it harder to perform build optimizations and compile-time verification of code. It is much more efficient to retrieve resources by identifier (e.g. `R.foo.bar`) than by name (e.g. `getIdentifier(&quot;bar&quot;, &quot;foo&quot;, null)`)."
+        errorLine1="    val id = resources.getIdentifier(name, &quot;string&quot;, packageName)"
+        errorLine2="                       ~~~~~~~~~~~~~">
+        <location
+            file="src/main/kotlin/com/fantasyidler/util/GameStrings.kt"
+            line="133"
+            column="24"/>
+    </issue>
+
+    <issue
+        id="DiscouragedApi"
+        message="Use of this function is discouraged because resource reflection makes it harder to perform build optimizations and compile-time verification of code. It is much more efficient to retrieve resources by identifier (e.g. `R.foo.bar`) than by name (e.g. `getIdentifier(&quot;bar&quot;, &quot;foo&quot;, null)`)."
+        errorLine1="                        val nameResId = context.resources.getIdentifier("
+        errorLine2="                                                          ~~~~~~~~~~~~~">
+        <location
+            file="src/main/kotlin/com/fantasyidler/ui/screen/HomeScreen.kt"
+            line="528"
+            column="59"/>
+    </issue>
+
+    <issue
+        id="DiscouragedApi"
+        message="Use of this function is discouraged because resource reflection makes it harder to perform build optimizations and compile-time verification of code. It is much more efficient to retrieve resources by identifier (e.g. `R.foo.bar`) than by name (e.g. `getIdentifier(&quot;bar&quot;, &quot;foo&quot;, null)`)."
+        errorLine1="        val id = context.resources.getIdentifier(&quot;daily_verb_$skill&quot;, &quot;string&quot;, context.packageName)"
+        errorLine2="                                   ~~~~~~~~~~~~~">
+        <location
+            file="src/main/kotlin/com/fantasyidler/ui/screen/QuestsScreen.kt"
+            line="264"
+            column="36"/>
+    </issue>
+
+    <issue
+        id="MissingQuantity"
+        message="For locale &quot;es&quot; (Spanish) the following quantity should also be defined: `many`"
+        errorLine1="    &lt;plurals name=&quot;plural_level_ups&quot;>"
+        errorLine2="    ^">
+        <location
+            file="src/main/res/values-es/strings.xml"
+            line="169"
+            column="5"/>
+    </issue>
+
+    <issue
+        id="MissingQuantity"
+        message="For locale &quot;fr&quot; (French) the following quantity should also be defined: `many` (e.g. &quot;1000000 de jours&quot;)"
+        errorLine1="    &lt;plurals name=&quot;plural_level_ups&quot;>"
+        errorLine2="    ^">
+        <location
+            file="src/main/res/values-fr/strings.xml"
+            line="169"
+            column="5"/>
+    </issue>
+
+    <issue
+        id="MissingQuantity"
+        message="For locale &quot;es&quot; (Spanish) the following quantity should also be defined: `many`"
+        errorLine1="    &lt;plurals name=&quot;plural_items&quot;>"
+        errorLine2="    ^">
+        <location
+            file="src/main/res/values-es/strings.xml"
+            line="173"
+            column="5"/>
+    </issue>
+
+    <issue
+        id="MissingQuantity"
+        message="For locale &quot;fr&quot; (French) the following quantity should also be defined: `many` (e.g. &quot;1000000 de jours&quot;)"
+        errorLine1="    &lt;plurals name=&quot;plural_items&quot;>"
+        errorLine2="    ^">
+        <location
+            file="src/main/res/values-fr/strings.xml"
+            line="173"
+            column="5"/>
+    </issue>
+
+    <issue
+        id="MissingQuantity"
+        message="For locale &quot;es&quot; (Spanish) the following quantity should also be defined: `many`"
+        errorLine1="    &lt;plurals name=&quot;plural_minutes&quot;>"
+        errorLine2="    ^">
+        <location
+            file="src/main/res/values-es/strings.xml"
+            line="177"
+            column="5"/>
+    </issue>
+
+    <issue
+        id="MissingQuantity"
+        message="For locale &quot;fr&quot; (French) the following quantity should also be defined: `many` (e.g. &quot;1000000 de jours&quot;)"
+        errorLine1="    &lt;plurals name=&quot;plural_minutes&quot;>"
+        errorLine2="    ^">
+        <location
+            file="src/main/res/values-fr/strings.xml"
+            line="177"
+            column="5"/>
+    </issue>
+
+    <issue
+        id="MissingQuantity"
+        message="For locale &quot;it&quot; (Italian) the following quantity should also be defined: `many`"
+        errorLine1="    &lt;plurals name=&quot;plural_level_ups&quot;>"
+        errorLine2="    ^">
+        <location
+            file="src/main/res/values-it/strings.xml"
+            line="179"
+            column="5"/>
+    </issue>
+
+    <issue
+        id="MissingQuantity"
+        message="For locale &quot;es&quot; (Spanish) the following quantity should also be defined: `many`"
+        errorLine1="    &lt;plurals name=&quot;plural_hours&quot;>"
+        errorLine2="    ^">
+        <location
+            file="src/main/res/values-es/strings.xml"
+            line="181"
+            column="5"/>
+    </issue>
+
+    <issue
+        id="MissingQuantity"
+        message="For locale &quot;fr&quot; (French) the following quantity should also be defined: `many` (e.g. &quot;1000000 de jours&quot;)"
+        errorLine1="    &lt;plurals name=&quot;plural_hours&quot;>"
+        errorLine2="    ^">
+        <location
+            file="src/main/res/values-fr/strings.xml"
+            line="181"
+            column="5"/>
+    </issue>
+
+    <issue
+        id="MissingQuantity"
+        message="For locale &quot;it&quot; (Italian) the following quantity should also be defined: `many`"
+        errorLine1="    &lt;plurals name=&quot;plural_items&quot;>"
+        errorLine2="    ^">
+        <location
+            file="src/main/res/values-it/strings.xml"
+            line="183"
+            column="5"/>
+    </issue>
+
+    <issue
+        id="MissingQuantity"
+        message="For locale &quot;es&quot; (Spanish) the following quantity should also be defined: `many`"
+        errorLine1="    &lt;plurals name=&quot;plural_patches&quot;>"
+        errorLine2="    ^">
+        <location
+            file="src/main/res/values-es/strings.xml"
+            line="185"
+            column="5"/>
+    </issue>
+
+    <issue
+        id="MissingQuantity"
+        message="For locale &quot;fr&quot; (French) the following quantity should also be defined: `many` (e.g. &quot;1000000 de jours&quot;)"
+        errorLine1="    &lt;plurals name=&quot;plural_patches&quot;>"
+        errorLine2="    ^">
+        <location
+            file="src/main/res/values-fr/strings.xml"
+            line="185"
+            column="5"/>
+    </issue>
+
+    <issue
+        id="MissingQuantity"
+        message="For locale &quot;it&quot; (Italian) the following quantity should also be defined: `many`"
+        errorLine1="    &lt;plurals name=&quot;plural_minutes&quot;>"
+        errorLine2="    ^">
+        <location
+            file="src/main/res/values-it/strings.xml"
+            line="187"
+            column="5"/>
+    </issue>
+
+    <issue
+        id="MissingQuantity"
+        message="For locale &quot;es&quot; (Spanish) the following quantity should also be defined: `many`"
+        errorLine1="    &lt;plurals name=&quot;plural_kills&quot;>"
+        errorLine2="    ^">
+        <location
+            file="src/main/res/values-es/strings.xml"
+            line="189"
+            column="5"/>
+    </issue>
+
+    <issue
+        id="MissingQuantity"
+        message="For locale &quot;fr&quot; (French) the following quantity should also be defined: `many` (e.g. &quot;1000000 de jours&quot;)"
+        errorLine1="    &lt;plurals name=&quot;plural_kills&quot;>"
+        errorLine2="    ^">
+        <location
+            file="src/main/res/values-fr/strings.xml"
+            line="189"
+            column="5"/>
+    </issue>
+
+    <issue
+        id="MissingQuantity"
+        message="For locale &quot;it&quot; (Italian) the following quantity should also be defined: `many`"
+        errorLine1="    &lt;plurals name=&quot;plural_hours&quot;>"
+        errorLine2="    ^">
+        <location
+            file="src/main/res/values-it/strings.xml"
+            line="191"
+            column="5"/>
+    </issue>
+
+    <issue
+        id="MissingQuantity"
+        message="For locale &quot;es&quot; (Spanish) the following quantity should also be defined: `many`"
+        errorLine1="    &lt;plurals name=&quot;plural_quests_completed&quot;>"
+        errorLine2="    ^">
+        <location
+            file="src/main/res/values-es/strings.xml"
+            line="193"
+            column="5"/>
+    </issue>
+
+    <issue
+        id="MissingQuantity"
+        message="For locale &quot;fr&quot; (French) the following quantity should also be defined: `many` (e.g. &quot;1000000 de jours&quot;)"
+        errorLine1="    &lt;plurals name=&quot;plural_quests_completed&quot;>"
+        errorLine2="    ^">
+        <location
+            file="src/main/res/values-fr/strings.xml"
+            line="193"
+            column="5"/>
+    </issue>
+
+    <issue
+        id="MissingQuantity"
+        message="For locale &quot;it&quot; (Italian) the following quantity should also be defined: `many`"
+        errorLine1="    &lt;plurals name=&quot;plural_patches&quot;>"
+        errorLine2="    ^">
+        <location
+            file="src/main/res/values-it/strings.xml"
+            line="195"
+            column="5"/>
+    </issue>
+
+    <issue
+        id="MissingQuantity"
+        message="For locale &quot;it&quot; (Italian) the following quantity should also be defined: `many`"
+        errorLine1="    &lt;plurals name=&quot;plural_kills&quot;>"
+        errorLine2="    ^">
+        <location
+            file="src/main/res/values-it/strings.xml"
+            line="199"
+            column="5"/>
+    </issue>
+
+    <issue
+        id="MissingQuantity"
+        message="For locale &quot;it&quot; (Italian) the following quantity should also be defined: `many`"
+        errorLine1="    &lt;plurals name=&quot;plural_quests_completed&quot;>"
+        errorLine2="    ^">
+        <location
+            file="src/main/res/values-it/strings.xml"
+            line="203"
+            column="5"/>
+    </issue>
+
+    <issue
+        id="MissingQuantity"
+        message="For locale &quot;es&quot; (Spanish) the following quantity should also be defined: `many`"
+        errorLine1="    &lt;plurals name=&quot;plural_collect_sessions&quot;>"
+        errorLine2="    ^">
+        <location
+            file="src/main/res/values-es/strings.xml"
+            line="330"
+            column="5"/>
+    </issue>
+
+    <issue
+        id="MissingQuantity"
+        message="For locale &quot;fr&quot; (French) the following quantity should also be defined: `many` (e.g. &quot;1000000 de jours&quot;)"
+        errorLine1="    &lt;plurals name=&quot;plural_collect_sessions&quot;>"
+        errorLine2="    ^">
+        <location
+            file="src/main/res/values-fr/strings.xml"
+            line="351"
+            column="5"/>
+    </issue>
+
+    <issue
+        id="MissingQuantity"
+        message="For locale &quot;it&quot; (Italian) the following quantity should also be defined: `many`"
+        errorLine1="    &lt;plurals name=&quot;plural_collect_sessions&quot;>"
+        errorLine2="    ^">
+        <location
+            file="src/main/res/values-it/strings.xml"
+            line="388"
+            column="5"/>
+    </issue>
+
+    <issue
+        id="MissingTranslation"
+        message="&quot;settings_changelog_title&quot; is not translated in &quot;nl&quot; (Dutch)"
+        errorLine1="    &lt;string name=&quot;settings_changelog_title&quot;>What\&apos;s New&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="288"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="MissingTranslation"
+        message="&quot;settings_changelog_desc&quot; is not translated in &quot;nl&quot; (Dutch)"
+        errorLine1="    &lt;string name=&quot;settings_changelog_desc&quot;>View the latest update changes&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="289"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="MissingTranslation"
+        message="&quot;settings_changelog_btn&quot; is not translated in &quot;nl&quot; (Dutch)"
+        errorLine1="    &lt;string name=&quot;settings_changelog_btn&quot;>View&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="290"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="MissingTranslation"
+        message="&quot;guild_quest_gate_blocked&quot; is not translated in &quot;nl&quot; (Dutch)"
+        errorLine1="    &lt;string name=&quot;guild_quest_gate_blocked&quot;>Complete quests to advance your rank&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="370"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="MissingTranslation"
+        message="&quot;guild_quest_required&quot; is not translated in &quot;nl&quot; (Dutch)"
+        errorLine1="    &lt;string name=&quot;guild_quest_required&quot;>Quest required to advance&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="371"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="MissingTranslation"
+        message="&quot;home_xp_boost_active&quot; is not translated in &quot;nl&quot; (Dutch)"
+        errorLine1="    &lt;string name=&quot;home_xp_boost_active&quot;>2× XP Boost active — %1$s remaining&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="374"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="MissingTranslation"
+        message="&quot;combat_arrow_auto&quot; is not translated in &quot;nl&quot; (Dutch)"
+        errorLine1="    &lt;string name=&quot;combat_arrow_auto&quot;>Auto (best available)&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="420"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="MissingTranslation"
+        message="&quot;combat_label_arrow&quot; is not translated in &quot;nl&quot; (Dutch)"
+        errorLine1="    &lt;string name=&quot;combat_label_arrow&quot;>Arrow&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="421"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="MissingTranslation"
+        message="&quot;profile_view_combat_gear&quot; is not translated in &quot;nl&quot; (Dutch)"
+        errorLine1="    &lt;string name=&quot;profile_view_combat_gear&quot;>View Combat Gear&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="445"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="MissingTranslation"
+        message="&quot;inn_slot1_header&quot; is not translated in &quot;nl&quot; (Dutch)"
+        errorLine1="    &lt;string name=&quot;inn_slot1_header&quot;>Long Laborer&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="643"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="MissingTranslation"
+        message="&quot;inn_slot2_header&quot; is not translated in &quot;nl&quot; (Dutch)"
+        errorLine1="    &lt;string name=&quot;inn_slot2_header&quot;>Skilled Worker&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="644"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="MissingTranslation"
+        message="&quot;inn_buy_qty&quot; is not translated in &quot;nl&quot; (Dutch)"
+        errorLine1="    &lt;string name=&quot;inn_buy_qty&quot;>Quantity&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="710"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="MissingTranslation"
+        message="&quot;inn_buy_total&quot; is not translated in &quot;nl&quot; (Dutch)"
+        errorLine1="    &lt;string name=&quot;inn_buy_total&quot;>Total: %1$s&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="711"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="MissingTranslation"
+        message="&quot;skill_slayer_name&quot; is not translated in &quot;nl&quot; (Dutch)"
+        errorLine1="    &lt;string name=&quot;skill_slayer_name&quot;>Slayer&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="861"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="MissingTranslation"
+        message="&quot;skill_slayer_desc&quot; is not translated in &quot;nl&quot; (Dutch)"
+        errorLine1="    &lt;string name=&quot;skill_slayer_desc&quot;>Receive tasks from the Slayer Master in Town.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="862"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="MissingTranslation"
+        message="&quot;slayer_title&quot; is not translated in &quot;nl&quot; (Dutch)"
+        errorLine1="    &lt;string name=&quot;slayer_title&quot;>Slayer Master&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="863"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="MissingTranslation"
+        message="&quot;slayer_card_desc&quot; is not translated in &quot;nl&quot; (Dutch)"
+        errorLine1="    &lt;string name=&quot;slayer_card_desc&quot;>Tasks and rewards for slayers&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="864"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="MissingTranslation"
+        message="&quot;slayer_desc&quot; is not translated in &quot;nl&quot; (Dutch)"
+        errorLine1="    &lt;string name=&quot;slayer_desc&quot;>Complete tasks to earn Slayer XP and points. Spend points in the shop for exclusive gear.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="865"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="MissingTranslation"
+        message="&quot;slayer_level_label&quot; is not translated in &quot;nl&quot; (Dutch)"
+        errorLine1="    &lt;string name=&quot;slayer_level_label&quot;>Level %1$d&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="866"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="MissingTranslation"
+        message="&quot;slayer_xp_label&quot; is not translated in &quot;nl&quot; (Dutch)"
+        errorLine1="    &lt;string name=&quot;slayer_xp_label&quot;>%1$s XP&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="867"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="MissingTranslation"
+        message="&quot;slayer_points&quot; is not translated in &quot;nl&quot; (Dutch)"
+        errorLine1="    &lt;string name=&quot;slayer_points&quot;>%1$d pts&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="868"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="MissingTranslation"
+        message="&quot;slayer_active_task&quot; is not translated in &quot;nl&quot; (Dutch)"
+        errorLine1="    &lt;string name=&quot;slayer_active_task&quot;>Active Task&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="869"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="MissingTranslation"
+        message="&quot;slayer_kills_remaining&quot; is not translated in &quot;nl&quot; (Dutch)"
+        errorLine1="    &lt;string name=&quot;slayer_kills_remaining&quot;>%1$d / %2$d kills&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="870"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="MissingTranslation"
+        message="&quot;slayer_get_task&quot; is not translated in &quot;nl&quot; (Dutch)"
+        errorLine1="    &lt;string name=&quot;slayer_get_task&quot;>Get New Task&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="871"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="MissingTranslation"
+        message="&quot;slayer_skip_task&quot; is not translated in &quot;nl&quot; (Dutch)"
+        errorLine1="    &lt;string name=&quot;slayer_skip_task&quot;>Skip (30 pts)&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="872"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="MissingTranslation"
+        message="&quot;slayer_no_task&quot; is not translated in &quot;nl&quot; (Dutch)"
+        errorLine1="    &lt;string name=&quot;slayer_no_task&quot;>No active task. Tap Get New Task.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="873"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="MissingTranslation"
+        message="&quot;slayer_task_stuck&quot; is not translated in &quot;nl&quot; (Dutch)"
+        errorLine1="    &lt;string name=&quot;slayer_task_stuck&quot;>This enemy is only found in an Expeditions dungeon you haven\&apos;t discovered yet. Reroll for free.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="874"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="MissingTranslation"
+        message="&quot;slayer_reroll_free&quot; is not translated in &quot;nl&quot; (Dutch)"
+        errorLine1="    &lt;string name=&quot;slayer_reroll_free&quot;>Reroll (free)&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="875"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="MissingTranslation"
+        message="&quot;slayer_no_eligible_tasks&quot; is not translated in &quot;nl&quot; (Dutch)"
+        errorLine1="    &lt;string name=&quot;slayer_no_eligible_tasks&quot;>No eligible tasks at your Slayer level.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="876"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="MissingTranslation"
+        message="&quot;slayer_task_complete&quot; is not translated in &quot;nl&quot; (Dutch)"
+        errorLine1="    &lt;string name=&quot;slayer_task_complete&quot;>Task complete! Visit the Slayer Master for a new one.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="877"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="MissingTranslation"
+        message="&quot;slayer_xp_per_kill&quot; is not translated in &quot;nl&quot; (Dutch)"
+        errorLine1="    &lt;string name=&quot;slayer_xp_per_kill&quot;>%1$d XP/kill&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="878"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="MissingTranslation"
+        message="&quot;slayer_points_on_complete&quot; is not translated in &quot;nl&quot; (Dutch)"
+        errorLine1="    &lt;string name=&quot;slayer_points_on_complete&quot;>+%1$d pts on completion&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="879"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="MissingTranslation"
+        message="&quot;slayer_shop_title&quot; is not translated in &quot;nl&quot; (Dutch)"
+        errorLine1="    &lt;string name=&quot;slayer_shop_title&quot;>Slayer Shop&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="880"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="MissingTranslation"
+        message="&quot;slayer_shop_cost&quot; is not translated in &quot;nl&quot; (Dutch)"
+        errorLine1="    &lt;string name=&quot;slayer_shop_cost&quot;>%1$d pts&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="881"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="MissingTranslation"
+        message="&quot;slayer_not_enough_points&quot; is not translated in &quot;nl&quot; (Dutch)"
+        errorLine1="    &lt;string name=&quot;slayer_not_enough_points&quot;>Not enough Slayer points.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="882"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="MissingTranslation"
+        message="&quot;slayer_already_owned&quot; is not translated in &quot;nl&quot; (Dutch)"
+        errorLine1="    &lt;string name=&quot;slayer_already_owned&quot;>Already owned.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="883"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="MissingTranslation"
+        message="&quot;slayer_purchased&quot; is not translated in &quot;nl&quot; (Dutch)"
+        errorLine1="    &lt;string name=&quot;slayer_purchased&quot;>Added to inventory.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="884"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="MissingTranslation"
+        message="&quot;slayer_owned&quot; is not translated in &quot;nl&quot; (Dutch)"
+        errorLine1="    &lt;string name=&quot;slayer_owned&quot;>Owned&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="885"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="MissingTranslation"
+        message="&quot;slayer_lamp_purchased&quot; is not translated in &quot;nl&quot; (Dutch)"
+        errorLine1="    &lt;string name=&quot;slayer_lamp_purchased&quot;>XP added to %1$s!&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="886"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="MissingTranslation"
+        message="&quot;slayer_lamp_pick_skill&quot; is not translated in &quot;nl&quot; (Dutch)"
+        errorLine1="    &lt;string name=&quot;slayer_lamp_pick_skill&quot;>Choose a skill&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="887"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="MissingTranslation"
+        message="&quot;slayer_lamp_small&quot; is not translated in &quot;nl&quot; (Dutch)"
+        errorLine1="    &lt;string name=&quot;slayer_lamp_small&quot;>XP Lamp (Small)&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="888"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="MissingTranslation"
+        message="&quot;slayer_lamp_large&quot; is not translated in &quot;nl&quot; (Dutch)"
+        errorLine1="    &lt;string name=&quot;slayer_lamp_large&quot;>XP Lamp (Large)&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="889"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="MissingTranslation"
+        message="&quot;slayer_lamp_small_desc&quot; is not translated in &quot;nl&quot; (Dutch)"
+        errorLine1="    &lt;string name=&quot;slayer_lamp_small_desc&quot;>+10,000 XP to any skill&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="890"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="MissingTranslation"
+        message="&quot;slayer_lamp_large_desc&quot; is not translated in &quot;nl&quot; (Dutch)"
+        errorLine1="    &lt;string name=&quot;slayer_lamp_large_desc&quot;>+50,000 XP to any skill&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="891"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="MissingTranslation"
+        message="&quot;slayer_found_in&quot; is not translated in &quot;nl&quot; (Dutch)"
+        errorLine1="    &lt;string name=&quot;slayer_found_in&quot;>Found in: %1$s&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="892"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="MissingTranslation"
+        message="&quot;slayer_requires&quot; is not translated in &quot;nl&quot; (Dutch)"
+        errorLine1="    &lt;string name=&quot;slayer_requires&quot;>Requires: %1$s&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="893"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="MissingTranslation"
+        message="&quot;item_slayer_helm_name&quot; is not translated in &quot;nl&quot; (Dutch)"
+        errorLine1="    &lt;string name=&quot;item_slayer_helm_name&quot;>Slayer Helm&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="913"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="MissingTranslation"
+        message="&quot;item_slayer_helm_desc&quot; is not translated in &quot;nl&quot; (Dutch)"
+        errorLine1="    &lt;string name=&quot;item_slayer_helm_desc&quot;>A sturdy helm worn by veteran slayers.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="914"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="MissingTranslation"
+        message="&quot;item_abyssal_whip_name&quot; is not translated in &quot;nl&quot; (Dutch)"
+        errorLine1="    &lt;string name=&quot;item_abyssal_whip_name&quot;>Abyssal Whip&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="915"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="MissingTranslation"
+        message="&quot;item_abyssal_whip_desc&quot; is not translated in &quot;nl&quot; (Dutch)"
+        errorLine1="    &lt;string name=&quot;item_abyssal_whip_desc&quot;>A whip forged from abyssal energy. Excellent for strength training.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="916"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="MissingTranslation"
+        message="&quot;item_slayer_platebody_name&quot; is not translated in &quot;nl&quot; (Dutch)"
+        errorLine1="    &lt;string name=&quot;item_slayer_platebody_name&quot;>Slayer Platebody&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="917"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="MissingTranslation"
+        message="&quot;item_slayer_platebody_desc&quot; is not translated in &quot;nl&quot; (Dutch)"
+        errorLine1="    &lt;string name=&quot;item_slayer_platebody_desc&quot;>Heavy armour etched with slayer runes.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="918"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="MissingTranslation"
+        message="&quot;item_slayer_platelegs_name&quot; is not translated in &quot;nl&quot; (Dutch)"
+        errorLine1="    &lt;string name=&quot;item_slayer_platelegs_name&quot;>Slayer Platelegs&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="919"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="MissingTranslation"
+        message="&quot;item_slayer_platelegs_desc&quot; is not translated in &quot;nl&quot; (Dutch)"
+        errorLine1="    &lt;string name=&quot;item_slayer_platelegs_desc&quot;>Protective legs crafted for extended dungeon runs.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="920"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="Typos"
+        message="Repeated word &quot;değerli&quot; in message: possible typo"
+        errorLine1="    &lt;string name=&quot;item_diamond_desc&quot;>En nadir ve en değerli değerli taş.&lt;/string>"
+        errorLine2="                                                    ^">
+        <location
+            file="src/main/res/values-tr/strings_items.xml"
+            line="53"
+            column="53"/>
+    </issue>
+
+    <issue
+        id="Typos"
+        message="&quot;Istakoz&quot; is usually capitalized as &quot;ıstakoz&quot;"
+        errorLine1="    &lt;string name=&quot;item_raw_lobster_name&quot;>Çiğ Istakoz&lt;/string>"
+        errorLine2="                                             ^">
+        <location
+            file="src/main/res/values-tr/strings_items.xml"
+            line="86"
+            column="46"/>
+    </issue>
+
+    <issue
+        id="Typos"
+        message="&quot;Istakoz&quot; is usually capitalized as &quot;ıstakoz&quot;"
+        errorLine1="    &lt;string name=&quot;item_lobster_name&quot;>Istakoz&lt;/string>"
+        errorLine2="                                     ^">
+        <location
+            file="src/main/res/values-tr/strings_items.xml"
+            line="114"
+            column="38"/>
+    </issue>
+
+    <issue
+        id="Typos"
+        message="&quot;Istakoz&quot; is usually capitalized as &quot;ıstakoz&quot;"
+        errorLine1="    &lt;string name=&quot;quest_daily_fish_lobster_name&quot;>Istakoz Avı&lt;/string>"
+        errorLine2="                                                 ^">
+        <location
+            file="src/main/res/values-tr/strings_quests.xml"
+            line="384"
+            column="50"/>
+    </issue>
+
+    <issue
+        id="Typos"
+        message="&quot;Istakoz&quot; is usually capitalized as &quot;ıstakoz&quot;"
+        errorLine1="    &lt;string name=&quot;quest_daily_cook_lobster_name&quot;>Istakoz Aşçısı&lt;/string>"
+        errorLine2="                                                 ^">
+        <location
+            file="src/main/res/values-tr/strings_quests.xml"
+            line="397"
+            column="50"/>
+    </issue>
+
+    <issue
+        id="Typos"
+        message="Repeated word &quot;ekin&quot; in message: possible typo"
+        errorLine1="    &lt;string name=&quot;skill_farming_desc&quot;>Tarım alanlarınızda ekin ekin ve hasat edin.&lt;/string>"
+        errorLine2="                                                          ^">
+        <location
+            file="src/main/res/values-tr/strings_skills.xml"
+            line="13"
+            column="59"/>
+    </issue>
+
+    <issue
+        id="Typos"
+        message="Repeated word &quot;die&quot; in message: possible typo"
+        errorLine1="    &lt;string name=&quot;agility_transcendent_course_desc&quot;>Die ultimative Prüfung der Geschicklichkeit, die die Grenzen des Menschenmöglichen überschreitet.&lt;/string>"
+        errorLine2="                                                                                                 ^">
+        <location
+            file="src/main/res/values-de/strings_skills.xml"
+            line="88"
+            column="98"/>
+    </issue>
+
+    <issue
+        id="Untranslatable"
+        message="The resource string &quot;settings_source_url&quot; is marked as translatable=&quot;false&quot;, but is translated to &quot;nl&quot; (Dutch) here"
+        errorLine1="    &lt;string name=&quot;settings_source_url&quot; translatable=&quot;false&quot;>github.com/tristinbaker/IdleFantasy&lt;/string>"
+        errorLine2="                                       ~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values-nl/strings.xml"
+            line="342"
+            column="40"/>
+    </issue>
+
+    <issue
+        id="Untranslatable"
+        message="The resource string &quot;settings_source_url&quot; is marked as translatable=&quot;false&quot;, but is translated to &quot;ru&quot; (Russian) here"
+        errorLine1="    &lt;string name=&quot;settings_source_url&quot; translatable=&quot;false&quot;>github.com/tristinbaker/IdleFantasy&lt;/string>"
+        errorLine2="                                       ~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values-ru/strings.xml"
+            line="359"
+            column="40"/>
+    </issue>
+
+    <issue
+        id="ImpliedQuantity"
+        message="The quantity `&apos;one&apos;` matches more than one specific number in this locale (0, 1), but the message did not include a formatting argument (such as `%d`). This is usually an internationalization error. See full issue explanation for more."
+        errorLine1="        &lt;item quantity=&quot;one&quot;>Récupérer le butin de la session&lt;/item>"
+        errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values-fr/strings.xml"
+            line="353"
+            column="9"/>
+    </issue>
+
+    <issue
+        id="PluralsCandidate"
+        message="Formatting %d followed by words (&quot;coins&quot;): This should probably be a plural rather than a string"
+        errorLine1="    &lt;string name=&quot;format_price_coins&quot;>%1$d coins&lt;/string>"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="158"
+            column="5"/>
+    </issue>
+
+    <issue
+        id="PluralsCandidate"
+        message="Formatting %d followed by words (&quot;wins&quot;): This should probably be a plural rather than a string"
+        errorLine1="    &lt;string name=&quot;format_arena_record&quot;>%1$d wins / %2$d losses&lt;/string>"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="166"
+            column="5"/>
+    </issue>
+
+    <issue
+        id="PluralsCandidate"
+        message="Formatting %d followed by words (&quot;metres&quot;): This should probably be a plural rather than a string"
+        errorLine1="    &lt;string name=&quot;dig_depth_format&quot;>The hole is %1$d metres deep.&lt;/string>"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="311"
+            column="5"/>
+    </issue>
+
+    <issue
+        id="PluralsCandidate"
+        message="Formatting %d followed by words (&quot;runs&quot;): This should probably be a plural rather than a string"
+        errorLine1="    &lt;string name=&quot;combat_dungeon_runs&quot;>%1$d runs&lt;/string>"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="398"
+            column="5"/>
+    </issue>
+
+    <issue
+        id="PluralsCandidate"
+        message="Formatting %d followed by words (&quot;gear&quot;): This should probably be a plural rather than a string"
+        errorLine1="    &lt;string name=&quot;combat_gear_bonus&quot;>+%1$d gear&lt;/string>"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="435"
+            column="5"/>
+    </issue>
+
+    <issue
+        id="PluralsCandidate"
+        message="Formatting %d followed by words (&quot;available&quot;): This should probably be a plural rather than a string"
+        errorLine1="    &lt;string name=&quot;skills_bone_selected&quot;>%1$d XP each  •  %2$d available&lt;/string>"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="484"
+            column="5"/>
+    </issue>
+
+    <issue
+        id="PluralsCandidate"
+        message="Formatting %d followed by words (&quot;Rune&quot;): This should probably be a plural rather than a string"
+        errorLine1="    &lt;string name=&quot;skills_essence_qty&quot;>%1$d Rune Essence in inventory&lt;/string>"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="490"
+            column="5"/>
+    </issue>
+
+    <issue
+        id="PluralsCandidate"
+        message="Formatting %d followed by words (&quot;essence&quot;): This should probably be a plural rather than a string"
+        errorLine1="    &lt;string name=&quot;skills_rune_selected&quot;>%1$d XP/rune  •  %2$d essence available&lt;/string>"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="494"
+            column="5"/>
+    </issue>
+
+    <issue
+        id="PluralsCandidate"
+        message="Formatting %d followed by words (&quot;reached&quot;): This should probably be a plural rather than a string"
+        errorLine1="    &lt;string name=&quot;skills_level_reached&quot;>Level %1$d reached!&lt;/string>"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="496"
+            column="5"/>
+    </issue>
+
+    <issue
+        id="PluralsCandidate"
+        message="Formatting %d followed by words (&quot;patches&quot;): This should probably be a plural rather than a string"
+        errorLine1="    &lt;string name=&quot;farming_patches&quot;>%1$d patches unlocked&lt;/string>"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="544"
+            column="5"/>
+    </issue>
+
+    <issue
+        id="PluralsCandidate"
+        message="Formatting %d followed by words (&quot;available&quot;): This should probably be a plural rather than a string"
+        errorLine1="    &lt;string name=&quot;guild_contribute_inventory&quot;>Contribute from inventory (%1$d available)&lt;/string>"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="729"
+            column="5"/>
+    </issue>
+
+    <issue
+        id="PluralsCandidate"
+        message="Formatting %d followed by words (&quot;enemies&quot;): This should probably be a plural rather than a string"
+        errorLine1="    &lt;string name=&quot;guild_quest_desc_kill&quot;>Defeat %1$d enemies using %2$s combat.&lt;/string>"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="732"
+            column="5"/>
+    </issue>
+
+    <issue
+        id="PluralsCandidate"
+        message="Formatting %d followed by words (&quot;bones&quot;): This should probably be a plural rather than a string"
+        errorLine1="    &lt;string name=&quot;guild_quest_desc_prayer&quot;>Bury %1$d bones for the %2$s.&lt;/string>"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="733"
+            column="5"/>
+    </issue>
+
+    <issue
+        id="PluralsCandidate"
+        message="Formatting %d followed by words (&quot;trade&quot;): This should probably be a plural rather than a string"
+        errorLine1="    &lt;string name=&quot;guild_quest_desc_trade&quot;>Complete %1$d trade routes for the %2$s.&lt;/string>"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="735"
+            column="5"/>
+    </issue>
+
+    <issue
+        id="PluralsCandidate"
+        message="Formatting %d followed by words (&quot;rep&quot;): This should probably be a plural rather than a string"
+        errorLine1="    &lt;string name=&quot;guild_rep_label&quot;>%1$d / %2$d rep&lt;/string>"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="740"
+            column="5"/>
+    </issue>
+
+    <issue
+        id="PluralsCandidate"
+        message="Formatting %d followed by words (&quot;Mercantile&quot;): This should probably be a plural rather than a string"
+        errorLine1="    &lt;string name=&quot;mercantile_level_label&quot;>Level %1$d Mercantile&lt;/string>"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="765"
+            column="5"/>
+    </issue>
+
+    <issue
+        id="PluralsCandidate"
+        message="Formatting %d followed by words (&quot;Defense&quot;): This should probably be a plural rather than a string"
+        errorLine1="    &lt;string name=&quot;church_effect_def&quot;>+%1$d Defense for 24 hours&lt;/string>"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="789"
+            column="5"/>
+    </issue>
+
+    <issue
+        id="PluralsCandidate"
+        message="Formatting %d followed by words (&quot;bones&quot;): This should probably be a plural rather than a string"
+        errorLine1="    &lt;string name=&quot;church_cost_bones&quot;>Costs %1$d bones&lt;/string>"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="791"
+            column="5"/>
+    </issue>
+
+    <issue
+        id="PluralsCandidate"
+        message="Formatting %d followed by words (&quot;bones&quot;): This should probably be a plural rather than a string"
+        errorLine1="    &lt;string name=&quot;church_bones_available&quot;>You have %1$d bones (all types)&lt;/string>"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="793"
+            column="5"/>
+    </issue>
+
+    <issue
+        id="PluralsCandidate"
+        message="Formatting %d followed by words (&quot;lore&quot;): This should probably be a plural rather than a string"
+        errorLine1="    &lt;string name=&quot;expedition_lore_notes&quot;>%1$d / %2$d lore notes&lt;/string>"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="854"
+            column="5"/>
+    </issue>
+
+    <issue
+        id="PluralsCandidate"
+        message="Formatting %d followed by words (&quot;kills&quot;): This should probably be a plural rather than a string"
+        errorLine1="    &lt;string name=&quot;slayer_kills_remaining&quot;>%1$d / %2$d kills&lt;/string>"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="870"
+            column="5"/>
+    </issue>
+
+    <issue
+        id="PluralsCandidate"
+        message="Formatting %d followed by words (&quot;bonus&quot;): This should probably be a plural rather than a string"
+        errorLine1="    &lt;string name=&quot;prestige_confirm_message_stat&quot;>Your %1$s level will reset to 1, but you\&apos;ll earn a permanent +%2$d bonus to your stats.&lt;/string>"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="900"
+            column="5"/>
+    </issue>
+
+    <issue
+        id="PluralsCandidate"
+        message="Formatting %d followed by words (&quot;per&quot;): This should probably be a plural rather than a string"
+        errorLine1="    &lt;string name=&quot;crafting_per_craft&quot;>×%1$d per craft&lt;/string>"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="937"
+            column="5"/>
+    </issue>
+
+    <issue
+        id="PluralsCandidate"
+        message="Formatting %d followed by words (&quot;buried&quot;): This should probably be a plural rather than a string"
+        errorLine1="    &lt;string name=&quot;bone_altar_buried_count&quot;>%d buried&lt;/string>"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="992"
+            column="5"/>
+    </issue>
+
+    <issue
+        id="PluralsCandidate"
+        message="Formatting %d followed by words (&quot;runes&quot;): This should probably be a plural rather than a string"
+        errorLine1="    &lt;string name=&quot;catalyst_rune_bonus&quot;>%1$d runes per essence&lt;/string>"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="1006"
+            column="5"/>
+    </issue>
+
+    <issue
+        id="PluralsCandidate"
+        message="Formatting %d followed by words (&quot;level&quot;): This should probably be a plural rather than a string"
+        errorLine1="    &lt;string name=&quot;game_session_level_up_count&quot;>%1$d level up!&lt;/string>"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_game.xml"
+            line="19"
+            column="5"/>
+    </issue>
+
+    <issue
+        id="PluralsCandidate"
+        message="Formatting %d followed by words (&quot;damage&quot;): This should probably be a plural rather than a string"
+        errorLine1="    &lt;string name=&quot;game_combat_hit&quot;>%1$s hits for %2$d damage.&lt;/string>"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_game.xml"
+            line="23"
+            column="5"/>
+    </issue>
+
+    <issue
+        id="PluralsCandidate"
+        message="Formatting %d followed by words (&quot;coins&quot;): This should probably be a plural rather than a string"
+        errorLine1="    &lt;string name=&quot;game_shop_purchased&quot;>Bought %1$d %2$s for %3$d coins.&lt;/string>"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_game.xml"
+            line="53"
+            column="5"/>
+    </issue>
+
+    <issue
+        id="PluralsCandidate"
+        message="Formatting %d followed by words (&quot;coins&quot;): This should probably be a plural rather than a string"
+        errorLine1="    &lt;string name=&quot;game_shop_sold&quot;>Sold %1$d %2$s for %3$d coins.&lt;/string>"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_game.xml"
+            line="55"
+            column="5"/>
+    </issue>
+
+    <issue
+        id="PluralsCandidate"
+        message="Formatting %d followed by words (&quot;coins&quot;): This should probably be a plural rather than a string"
+        errorLine1="    &lt;string name=&quot;game_arena_coins_won&quot;>Won %1$d coins.&lt;/string>"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_game.xml"
+            line="81"
+            column="5"/>
+    </issue>
+
+    <issue
+        id="PluralsCandidate"
+        message="Formatting %d followed by words (&quot;metres&quot;): This should probably be a plural rather than a string"
+        errorLine1="    &lt;string name=&quot;game_dig_depth&quot;>The hole is %1$d metres deep.&lt;/string>"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_game.xml"
+            line="89"
+            column="5"/>
+    </issue>
+
+    <issue
+        id="PluralsCandidate"
+        message="Formatting %d followed by words (&quot;patches&quot;): This should probably be a plural rather than a string"
+        errorLine1="    &lt;string name=&quot;notif_farming_ready_body_multi&quot;>%1$d patches are ready to harvest.&lt;/string>"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_notifications.xml"
+            line="20"
+            column="5"/>
+    </issue>
+
+    <issue
+        id="PluralsCandidate"
+        message="Formatting %d followed by words (&quot;bones&quot;): This should probably be a plural rather than a string"
+        errorLine1="    &lt;string name=&quot;quest_obj_prayer&quot;>Bury %1$d bones of any type&lt;/string>"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="434"
+            column="5"/>
+    </issue>
+
+    <issue
+        id="PluralsCandidate"
+        message="Formatting %d followed by words (&quot;enemies&quot;): This should probably be a plural rather than a string"
+        errorLine1="    &lt;string name=&quot;quest_obj_kill&quot;>Defeat %1$d enemies&lt;/string>"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="435"
+            column="5"/>
+    </issue>
+
+    <issue
+        id="PluralsCandidate"
+        message="Formatting %d followed by words (&quot;times&quot;): This should probably be a plural rather than a string"
+        errorLine1="    &lt;string name=&quot;quest_obj_dungeon&quot;>Complete the %1$s %2$d times&lt;/string>"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="437"
+            column="5"/>
+    </issue>
+
+    <issue
+        id="PluralsCandidate"
+        message="Formatting %d followed by words (&quot;times&quot;): This should probably be a plural rather than a string"
+        errorLine1="    &lt;string name=&quot;quest_obj_boss&quot;>Defeat the %1$s %2$d times&lt;/string>"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="439"
+            column="5"/>
+    </issue>
+
+    <issue
+        id="PluralsCandidate"
+        message="Formatting %d followed by words (&quot;Slayer&quot;): This should probably be a plural rather than a string"
+        errorLine1="    &lt;string name=&quot;quest_obj_slayer_task&quot;>Complete %1$d Slayer tasks&lt;/string>"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="446"
+            column="5"/>
+    </issue>
+
+    <issue
+        id="StringFormatCount"
+        message="Inconsistent number of arguments in formatting string `combat_died_reward`; found both 0 here and 1 in values/strings.xml"
+        errorLine1="    &lt;string name=&quot;combat_died_reward&quot;>Ödüllerin %10\&apos;unu aldın.&lt;/string>"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values-tr/strings.xml"
+            line="381"
+            column="5"/>
+        <location
+            file="src/main/res/values/strings.xml"
+            line="433"
+            column="5"
+            message="Conflicting number of arguments (1) here"/>
+    </issue>
+
+    <issue
+        id="StringFormatCount"
+        message="Inconsistent number of arguments in formatting string `combat_died_reward`; found both 0 here and 1 in values/strings.xml"
+        errorLine1="    &lt;string name=&quot;combat_died_reward&quot;>Вы получили 10% наград.&lt;/string>"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values-ru/strings.xml"
+            line="449"
+            column="5"/>
+        <location
+            file="src/main/res/values/strings.xml"
+            line="433"
+            column="5"
+            message="Conflicting number of arguments (1) here"/>
+    </issue>
+
+    <issue
+        id="StringFormatCount"
+        message="Inconsistent number of arguments in formatting string `crafting_produces`; found both 1 here and 2 in values/strings.xml"
+        errorLine1="    &lt;string name=&quot;crafting_produces&quot;>Produce %1$d× por craft&lt;/string>"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values-es/strings.xml"
+            line="461"
+            column="5"/>
+        <location
+            file="src/main/res/values/strings.xml"
+            line="527"
+            column="5"
+            message="Conflicting number of arguments (2) here"/>
+    </issue>
+
+    <issue
+        id="StringFormatCount"
+        message="Inconsistent number of arguments in formatting string `crafting_produces`; found both 1 here and 2 in values/strings.xml"
+        errorLine1="    &lt;string name=&quot;crafting_produces&quot;>Her üretimde %1$d× üretir&lt;/string>"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values-tr/strings.xml"
+            line="473"
+            column="5"/>
+        <location
+            file="src/main/res/values/strings.xml"
+            line="527"
+            column="5"
+            message="Conflicting number of arguments (2) here"/>
+    </issue>
+
+    <issue
+        id="StringFormatCount"
+        message="Inconsistent number of arguments in formatting string `crafting_produces`; found both 1 here and 2 in values/strings.xml"
+        errorLine1="    &lt;string name=&quot;crafting_produces&quot;>Produit %1$d× par fabrication&lt;/string>"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values-fr/strings.xml"
+            line="487"
+            column="5"/>
+        <location
+            file="src/main/res/values/strings.xml"
+            line="527"
+            column="5"
+            message="Conflicting number of arguments (2) here"/>
+    </issue>
+
+    <issue
+        id="StringFormatCount"
+        message="Inconsistent number of arguments in formatting string `crafting_produces`; found both 1 here and 2 in values/strings.xml"
+        errorLine1="    &lt;string name=&quot;crafting_produces&quot;>Produceert %1$d× per craft&lt;/string>"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values-nl/strings.xml"
+            line="518"
+            column="5"/>
+        <location
+            file="src/main/res/values/strings.xml"
+            line="527"
+            column="5"
+            message="Conflicting number of arguments (2) here"/>
+    </issue>
+
+    <issue
+        id="StringFormatCount"
+        message="Inconsistent number of arguments in formatting string `crafting_produces`; found both 1 here and 2 in values/strings.xml"
+        errorLine1="    &lt;string name=&quot;crafting_produces&quot;>Produce %1$d× per modello&lt;/string>"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values-it/strings.xml"
+            line="527"
+            column="5"/>
+        <location
+            file="src/main/res/values/strings.xml"
+            line="527"
+            column="5"
+            message="Conflicting number of arguments (2) here"/>
+    </issue>
+
+    <issue
+        id="StringFormatCount"
+        message="Inconsistent number of arguments in formatting string `game_quest_abandoned`; found both 1 here and 0 in values/strings_game.xml"
+        errorLine1="    &lt;string name=&quot;game_quest_abandoned&quot;>Quest gestopt: %1$s&lt;/string>"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values-nl/strings_game.xml"
+            line="65"
+            column="5"/>
+        <location
+            file="src/main/res/values/strings_game.xml"
+            line="65"
+            column="5"
+            message="Conflicting number of arguments (0) here"/>
+    </issue>
+
+    <issue
+        id="ObsoleteSdkInt"
+        message="This folder configuration (`v26`) is unnecessary; `minSdkVersion` is 26. Merge all the resources in this folder into `mipmap-anydpi`.">
+        <location
+            file="src/main/res/mipmap-anydpi-v26"/>
+    </issue>
+
+    <issue
+        id="FrequentlyChangedStateReadInComposition"
+        message="Frequently changing state should not be directly read in composable function"
+        errorLine1="            LaunchedEffect(scrollState.firstVisibleItemIndex) {"
+        errorLine2="                           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/kotlin/com/fantasyidler/ui/screen/CraftingScreen.kt"
+            line="127"
+            column="28"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.btn_start` appears to be unused"
+        errorLine1="    &lt;string name=&quot;btn_start&quot;>Start&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="14"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.btn_collect` appears to be unused"
+        errorLine1="    &lt;string name=&quot;btn_collect&quot;>Collect Rewards&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="23"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.btn_harvest_all` appears to be unused"
+        errorLine1="    &lt;string name=&quot;btn_harvest_all&quot;>Harvest All&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="30"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.btn_clear_all` appears to be unused"
+        errorLine1="    &lt;string name=&quot;btn_clear_all&quot;>Clear All&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="32"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.btn_inspect` appears to be unused"
+        errorLine1="    &lt;string name=&quot;btn_inspect&quot;>Inspect&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="33"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.btn_view_drops` appears to be unused"
+        errorLine1="    &lt;string name=&quot;btn_view_drops&quot;>View Drops&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="34"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.btn_start_quest` appears to be unused"
+        errorLine1="    &lt;string name=&quot;btn_start_quest&quot;>Start Quest&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="35"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.btn_abandon_quest` appears to be unused"
+        errorLine1="    &lt;string name=&quot;btn_abandon_quest&quot;>Abandon Quest&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="36"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.btn_enter_arena` appears to be unused"
+        errorLine1="    &lt;string name=&quot;btn_enter_arena&quot;>Enter Arena&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="38"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.btn_activate` appears to be unused"
+        errorLine1="    &lt;string name=&quot;btn_activate&quot;>Activate&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="39"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.btn_deactivate` appears to be unused"
+        errorLine1="    &lt;string name=&quot;btn_deactivate&quot;>Deactivate&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="40"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.btn_back` appears to be unused"
+        errorLine1="    &lt;string name=&quot;btn_back&quot;>Back&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="42"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.label_level` appears to be unused"
+        errorLine1="    &lt;string name=&quot;label_level&quot;>Level&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="45"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.label_attack` appears to be unused"
+        errorLine1="    &lt;string name=&quot;label_attack&quot;>Attack&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="49"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.label_strength` appears to be unused"
+        errorLine1="    &lt;string name=&quot;label_strength&quot;>Strength&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="50"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.label_defense` appears to be unused"
+        errorLine1="    &lt;string name=&quot;label_defense&quot;>Defense&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="51"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.label_ranged` appears to be unused"
+        errorLine1="    &lt;string name=&quot;label_ranged&quot;>Ranged&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="52"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.label_magic` appears to be unused"
+        errorLine1="    &lt;string name=&quot;label_magic&quot;>Magic&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="53"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.label_hitpoints` appears to be unused"
+        errorLine1="    &lt;string name=&quot;label_hitpoints&quot;>Hitpoints&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="55"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.label_time_remaining` appears to be unused"
+        errorLine1="    &lt;string name=&quot;label_time_remaining&quot;>Time remaining&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="69"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.label_requirements` appears to be unused"
+        errorLine1="    &lt;string name=&quot;label_requirements&quot;>Requirements&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="74"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.label_rewards` appears to be unused"
+        errorLine1="    &lt;string name=&quot;label_rewards&quot;>Rewards&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="75"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.label_your_level` appears to be unused"
+        errorLine1="    &lt;string name=&quot;label_your_level&quot;>Your Level&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="76"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.label_xp_to_next` appears to be unused"
+        errorLine1="    &lt;string name=&quot;label_xp_to_next&quot;>XP to next level&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="77"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.label_total_xp` appears to be unused"
+        errorLine1="    &lt;string name=&quot;label_total_xp&quot;>Total XP&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="78"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.label_quantity` appears to be unused"
+        errorLine1="    &lt;string name=&quot;label_quantity&quot;>Quantity&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="79"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.label_price` appears to be unused"
+        errorLine1="    &lt;string name=&quot;label_price&quot;>Price&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="80"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.label_available` appears to be unused"
+        errorLine1="    &lt;string name=&quot;label_available&quot;>Available&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="81"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.label_patch` appears to be unused"
+        errorLine1="    &lt;string name=&quot;label_patch&quot;>Patch&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="82"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.label_growth_time` appears to be unused"
+        errorLine1="    &lt;string name=&quot;label_growth_time&quot;>Growth time&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="83"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.label_active_spell` appears to be unused"
+        errorLine1="    &lt;string name=&quot;label_active_spell&quot;>Active Spell&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="96"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.label_difficulty` appears to be unused"
+        errorLine1="    &lt;string name=&quot;label_difficulty&quot;>Difficulty&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="100"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.label_in_progress` appears to be unused"
+        errorLine1="    &lt;string name=&quot;label_in_progress&quot;>In Progress&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="102"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.label_available_quests` appears to be unused"
+        errorLine1="    &lt;string name=&quot;label_available_quests&quot;>Available&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="103"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.label_stats` appears to be unused"
+        errorLine1="    &lt;string name=&quot;label_stats&quot;>Stats&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="104"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.label_sell_items` appears to be unused"
+        errorLine1="    &lt;string name=&quot;label_sell_items&quot;>Sell Items&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="107"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.label_wins` appears to be unused"
+        errorLine1="    &lt;string name=&quot;label_wins&quot;>Wins&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="109"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.label_losses` appears to be unused"
+        errorLine1="    &lt;string name=&quot;label_losses&quot;>Losses&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="110"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.label_active` appears to be unused"
+        errorLine1="    &lt;string name=&quot;label_active&quot;>Active&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="111"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.label_inactive` appears to be unused"
+        errorLine1="    &lt;string name=&quot;label_inactive&quot;>Inactive&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="112"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.label_boost` appears to be unused"
+        errorLine1="    &lt;string name=&quot;label_boost&quot;>Boost&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="113"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.label_xp_boost` appears to be unused"
+        errorLine1="    &lt;string name=&quot;label_xp_boost&quot;>XP Boost&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="114"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.label_weapon` appears to be unused"
+        errorLine1="    &lt;string name=&quot;label_weapon&quot;>Weapon&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="115"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.label_armour` appears to be unused"
+        errorLine1="    &lt;string name=&quot;label_armour&quot;>Armour&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="116"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.label_arrows` appears to be unused"
+        errorLine1="    &lt;string name=&quot;label_arrows&quot;>Arrows&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="122"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.label_runes` appears to be unused"
+        errorLine1="    &lt;string name=&quot;label_runes&quot;>Runes&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="123"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.label_melee` appears to be unused"
+        errorLine1="    &lt;string name=&quot;label_melee&quot;>Melee&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="126"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.label_ranged_style` appears to be unused"
+        errorLine1="    &lt;string name=&quot;label_ranged_style&quot;>Ranged&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="127"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.label_magic_style` appears to be unused"
+        errorLine1="    &lt;string name=&quot;label_magic_style&quot;>Magic&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="128"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.label_recipe` appears to be unused"
+        errorLine1="    &lt;string name=&quot;label_recipe&quot;>Recipe&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="133"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.label_recipes` appears to be unused"
+        errorLine1="    &lt;string name=&quot;label_recipes&quot;>Recipes&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="134"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.label_output` appears to be unused"
+        errorLine1="    &lt;string name=&quot;label_output&quot;>Output&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="136"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.label_xp_per_action` appears to be unused"
+        errorLine1="    &lt;string name=&quot;label_xp_per_action&quot;>XP per action&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="137"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.label_unlocked_at` appears to be unused"
+        errorLine1="    &lt;string name=&quot;label_unlocked_at&quot;>Unlocked at level&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="138"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.label_personal_best` appears to be unused"
+        errorLine1="    &lt;string name=&quot;label_personal_best&quot;>Personal Best&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="140"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.label_daily_dig` appears to be unused"
+        errorLine1="    &lt;string name=&quot;label_daily_dig&quot;>Daily Dig&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="141"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.label_dig_depth` appears to be unused"
+        errorLine1="    &lt;string name=&quot;label_dig_depth&quot;>Hole Depth&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="142"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.label_version` appears to be unused"
+        errorLine1="    &lt;string name=&quot;label_version&quot;>Version&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="143"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.label_open_source` appears to be unused"
+        errorLine1="    &lt;string name=&quot;label_open_source&quot;>Open Source&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="144"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.format_level_xp` appears to be unused"
+        errorLine1="    &lt;string name=&quot;format_level_xp&quot;>Level %1$d — %2$s XP&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="148"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.format_xp_to_next` appears to be unused"
+        errorLine1="    &lt;string name=&quot;format_xp_to_next&quot;>%1$s XP to level %2$d&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="150"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.format_time_remaining` appears to be unused"
+        errorLine1="    &lt;string name=&quot;format_time_remaining&quot;>%1$s remaining&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="152"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.format_started_ago` appears to be unused"
+        errorLine1="    &lt;string name=&quot;format_started_ago&quot;>Started %1$s ago&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="154"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.format_item_quantity` appears to be unused"
+        errorLine1="    &lt;string name=&quot;format_item_quantity&quot;>%1$s ×%2$d&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="156"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.format_price_coins` appears to be unused"
+        errorLine1="    &lt;string name=&quot;format_price_coins&quot;>%1$d coins&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="158"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.format_level_requirement` appears to be unused"
+        errorLine1="    &lt;string name=&quot;format_level_requirement&quot;>Requires level %1$d %2$s&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="160"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.format_xp_per_action` appears to be unused"
+        errorLine1="    &lt;string name=&quot;format_xp_per_action&quot;>%1$s XP per action&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="162"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.format_arena_record` appears to be unused"
+        errorLine1="    &lt;string name=&quot;format_arena_record&quot;>%1$d wins / %2$d losses&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="166"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.format_skill_level` appears to be unused"
+        errorLine1="    &lt;string name=&quot;format_skill_level&quot;>%1$s: Level %2$d&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="168"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.format_drop_chance` appears to be unused"
+        errorLine1="    &lt;string name=&quot;format_drop_chance&quot;>%1$s: %2$d&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="172"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.format_minutes_remaining` appears to be unused"
+        errorLine1="    &lt;string name=&quot;format_minutes_remaining&quot;>%1$d min remaining&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="174"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.plurals.plural_level_ups` appears to be unused"
+        errorLine1="    &lt;plurals name=&quot;plural_level_ups&quot;>"
+        errorLine2="             ~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="179"
+            column="14"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.plurals.plural_items` appears to be unused"
+        errorLine1="    &lt;plurals name=&quot;plural_items&quot;>"
+        errorLine2="             ~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="183"
+            column="14"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.plurals.plural_minutes` appears to be unused"
+        errorLine1="    &lt;plurals name=&quot;plural_minutes&quot;>"
+        errorLine2="             ~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="187"
+            column="14"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.plurals.plural_hours` appears to be unused"
+        errorLine1="    &lt;plurals name=&quot;plural_hours&quot;>"
+        errorLine2="             ~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="191"
+            column="14"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.plurals.plural_patches` appears to be unused"
+        errorLine1="    &lt;plurals name=&quot;plural_patches&quot;>"
+        errorLine2="             ~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="195"
+            column="14"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.plurals.plural_kills` appears to be unused"
+        errorLine1="    &lt;plurals name=&quot;plural_kills&quot;>"
+        errorLine2="             ~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="199"
+            column="14"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.plurals.plural_quests_completed` appears to be unused"
+        errorLine1="    &lt;plurals name=&quot;plural_quests_completed&quot;>"
+        errorLine2="             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="203"
+            column="14"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.error_no_player` appears to be unused"
+        errorLine1="    &lt;string name=&quot;error_no_player&quot;>Could not load player data. Please restart the app.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="209"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.error_session_already_active` appears to be unused"
+        errorLine1="    &lt;string name=&quot;error_session_already_active&quot;>You already have an active session. Complete or abandon it first.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="210"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.error_not_enough_items` appears to be unused"
+        errorLine1="    &lt;string name=&quot;error_not_enough_items&quot;>Not enough %1$s.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="213"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.error_level_too_low` appears to be unused"
+        errorLine1="    &lt;string name=&quot;error_level_too_low&quot;>Your %1$s level is too low.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="215"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.error_inventory_required` appears to be unused"
+        errorLine1="    &lt;string name=&quot;error_inventory_required&quot;>You need %1$s to do this.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="217"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.error_patch_occupied` appears to be unused"
+        errorLine1="    &lt;string name=&quot;error_patch_occupied&quot;>This patch is already planted.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="218"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.error_patch_empty` appears to be unused"
+        errorLine1="    &lt;string name=&quot;error_patch_empty&quot;>This patch is empty.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="219"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.error_crop_not_ready` appears to be unused"
+        errorLine1="    &lt;string name=&quot;error_crop_not_ready&quot;>This crop is not ready yet.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="220"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.error_quest_active` appears to be unused"
+        errorLine1="    &lt;string name=&quot;error_quest_active&quot;>You already have an active quest.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="221"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.error_quest_requirements_not_met` appears to be unused"
+        errorLine1="    &lt;string name=&quot;error_quest_requirements_not_met&quot;>You don\&apos;t meet the requirements for this quest.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="222"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.error_dungeon_level_too_low` appears to be unused"
+        errorLine1="    &lt;string name=&quot;error_dungeon_level_too_low&quot;>Your combat level is too low for this dungeon.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="223"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.error_unknown` appears to be unused"
+        errorLine1="    &lt;string name=&quot;error_unknown&quot;>Something went wrong. Please try again.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="224"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.onboarding_welcome_body` appears to be unused"
+        errorLine1="    &lt;string name=&quot;onboarding_welcome_body&quot;>Start a skill session and watch your character grow. Sessions run for one hour, even when the app is closed.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="232"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.onboarding_first_session_hint` appears to be unused"
+        errorLine1="    &lt;string name=&quot;onboarding_first_session_hint&quot;>Tap any skill to get started.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="233"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.settings_battery_optimization` appears to be unused"
+        errorLine1="    &lt;string name=&quot;settings_battery_optimization&quot;>Battery Optimization&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="239"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.settings_battery_optimization_desc` appears to be unused"
+        errorLine1="    &lt;string name=&quot;settings_battery_optimization_desc&quot;>Disable battery optimization for Idle Fantasy to receive timely session alerts&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="240"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.settings_battery_optimization_btn` appears to be unused"
+        errorLine1="    &lt;string name=&quot;settings_battery_optimization_btn&quot;>Adjust Setting&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="241"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.settings_open_source_licenses` appears to be unused"
+        errorLine1="    &lt;string name=&quot;settings_open_source_licenses&quot;>Open Source Licenses&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="244"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.label_daily_quests` appears to be unused"
+        errorLine1="    &lt;string name=&quot;label_daily_quests&quot;>Daily Quests&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="269"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.msg_daily_claimed_coins` appears to be unused"
+        errorLine1="    &lt;string name=&quot;msg_daily_claimed_coins&quot;>Daily quest complete! +2,000 coins.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="272"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.msg_daily_claimed_dwarven` appears to be unused"
+        errorLine1="    &lt;string name=&quot;msg_daily_claimed_dwarven&quot;>Daily quest complete! You found %1$s!&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="273"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.settings_performance_header` appears to be unused"
+        errorLine1="    &lt;string name=&quot;settings_performance_header&quot;>Performance&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="283"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.battery_prompt_title` appears to be unused"
+        errorLine1="    &lt;string name=&quot;battery_prompt_title&quot;>Keep sessions running&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="302"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.battery_prompt_body` appears to be unused"
+        errorLine1="    &lt;string name=&quot;battery_prompt_body&quot;>For the best experience, allow Idle Fantasy to run in the background so you receive timely session notifications.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="303"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.battery_prompt_open_settings` appears to be unused"
+        errorLine1="    &lt;string name=&quot;battery_prompt_open_settings&quot;>Open Settings&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="304"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.battery_prompt_dismiss` appears to be unused"
+        errorLine1="    &lt;string name=&quot;battery_prompt_dismiss&quot;>Not now&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="305"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.dig_action` appears to be unused"
+        errorLine1="    &lt;string name=&quot;dig_action&quot;>Dig&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="308"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.dig_result` appears to be unused"
+        errorLine1="    &lt;string name=&quot;dig_result&quot;>You dig deeper into the earth…&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="309"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.dig_depth_format` appears to be unused"
+        errorLine1="    &lt;string name=&quot;dig_depth_format&quot;>The hole is %1$d metres deep.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="311"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.home_bones_buried` appears to be unused"
+        errorLine1="    &lt;string name=&quot;home_bones_buried&quot;>Bones buried&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="377"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.combat_log_you_hit` appears to be unused"
+        errorLine1="    &lt;string name=&quot;combat_log_you_hit&quot;>You hit&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="406"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.combat_log_hit_you` appears to be unused"
+        errorLine1="    &lt;string name=&quot;combat_log_hit_you&quot;>hit you&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="407"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.combat_log_missed` appears to be unused"
+        errorLine1="    &lt;string name=&quot;combat_log_missed&quot;>missed&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="409"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.combat_log_you_missed` appears to be unused"
+        errorLine1="    &lt;string name=&quot;combat_log_you_missed&quot;>You missed&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="410"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.combat_no_strength_bonus` appears to be unused"
+        errorLine1="    &lt;string name=&quot;combat_no_strength_bonus&quot;>None (no strength bonus)&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="418"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.combat_best_arrow` appears to be unused"
+        errorLine1="    &lt;string name=&quot;combat_best_arrow&quot;>Best arrow&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="419"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.skills_fishing_desc` appears to be unused"
+        errorLine1="    &lt;string name=&quot;skills_fishing_desc&quot;>Level %1$d  •  Level-appropriate catches&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="477"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.skills_xp_total` appears to be unused"
+        errorLine1="    &lt;string name=&quot;skills_xp_total&quot;>+%1$d XP total&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="486"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.crafting_xp_total` appears to be unused"
+        errorLine1="    &lt;string name=&quot;crafting_xp_total&quot;>+%1$d XP total&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="530"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.worker_idle` appears to be unused"
+        errorLine1="    &lt;string name=&quot;worker_idle&quot;>Worker is idle — queued sessions start automatically&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="636"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.inn_laborers_header` appears to be unused"
+        errorLine1="    &lt;string name=&quot;inn_laborers_header&quot;>Laborers&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="642"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_kbd_slayer_1_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_kbd_slayer_1_name&quot;>King Black Dragon Slayer I&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="704"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_kbd_slayer_2_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_kbd_slayer_2_name&quot;>King Black Dragon Slayer II&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="705"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_kbd_slayer_3_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_kbd_slayer_3_name&quot;>King Black Dragon Slayer III&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="706"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.inn_buy_qty` appears to be unused"
+        errorLine1="    &lt;string name=&quot;inn_buy_qty&quot;>Quantity&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="710"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.guild_quest_complete` appears to be unused"
+        errorLine1="    &lt;string name=&quot;guild_quest_complete&quot;>Quest complete: %1$s&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="741"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.guild_daily_complete` appears to be unused"
+        errorLine1="    &lt;string name=&quot;guild_daily_complete&quot;>Daily reward claimed!&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="742"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.church_blessing_active_fmt` appears to be unused"
+        errorLine1="    &lt;string name=&quot;church_blessing_active_fmt&quot;>%1$s • %2$s left&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="779"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.church_blessing_suffix` appears to be unused"
+        errorLine1="    &lt;string name=&quot;church_blessing_suffix&quot;>from blessing&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="787"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.blessing_blessed_focus_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;blessing_blessed_focus_name&quot;>Blessed Focus&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="798"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.blessing_stone_skin_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;blessing_stone_skin_name&quot;>Stone Skin&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="799"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.blessing_blessed_focus_ii_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;blessing_blessed_focus_ii_name&quot;>Blessed Focus II&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="800"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.blessing_stone_skin_ii_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;blessing_stone_skin_ii_name&quot;>Stone Skin II&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="801"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.blessing_blessed_focus_iii_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;blessing_blessed_focus_iii_name&quot;>Blessed Focus III&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="802"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.blessing_stone_skin_iii_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;blessing_stone_skin_iii_name&quot;>Stone Skin III&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="803"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.blessing_tithe_blessing_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;blessing_tithe_blessing_name&quot;>Tithe Blessing&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="804"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.blessing_stone_skin_iv_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;blessing_stone_skin_iv_name&quot;>Stone Skin IV&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="805"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.blessing_fortune_i_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;blessing_fortune_i_name&quot;>Fortune I&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="806"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.blessing_tithe_blessing_ii_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;blessing_tithe_blessing_ii_name&quot;>Tithe Blessing II&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="807"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.blessing_iron_ward_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;blessing_iron_ward_name&quot;>Iron Ward&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="808"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.blessing_fortune_ii_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;blessing_fortune_ii_name&quot;>Fortune II&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="809"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.blessing_tithe_blessing_iii_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;blessing_tithe_blessing_iii_name&quot;>Tithe Blessing III&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="810"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.blessing_iron_ward_ii_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;blessing_iron_ward_ii_name&quot;>Iron Ward II&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="811"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.blessing_fortune_iii_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;blessing_fortune_iii_name&quot;>Fortune III&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="812"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.blessing_divine_focus_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;blessing_divine_focus_name&quot;>Divine Focus&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="813"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.blessing_diamond_skin_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;blessing_diamond_skin_name&quot;>Diamond Skin&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="814"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.blessing_fortune_iv_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;blessing_fortune_iv_name&quot;>Fortune IV&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="815"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.blessing_divine_focus_ii_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;blessing_divine_focus_ii_name&quot;>Divine Focus II&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="816"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.blessing_diamond_skin_ii_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;blessing_diamond_skin_ii_name&quot;>Diamond Skin II&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="817"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.blessing_fortune_v_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;blessing_fortune_v_name&quot;>Fortune V&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="818"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.blessing_divine_grace_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;blessing_divine_grace_name&quot;>Divine Grace&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="819"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.blessing_holy_shield_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;blessing_holy_shield_name&quot;>Holy Shield&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="820"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.blessing_abundance_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;blessing_abundance_name&quot;>Abundance&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="821"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.blessing_divine_grace_ii_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;blessing_divine_grace_ii_name&quot;>Divine Grace II&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="822"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.blessing_holy_shield_ii_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;blessing_holy_shield_ii_name&quot;>Holy Shield II&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="823"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.blessing_abundance_ii_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;blessing_abundance_ii_name&quot;>Abundance II&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="824"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.blessing_sacred_grace_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;blessing_sacred_grace_name&quot;>Sacred Grace&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="825"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.blessing_aegis_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;blessing_aegis_name&quot;>Aegis&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="826"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.blessing_abundance_iii_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;blessing_abundance_iii_name&quot;>Abundance III&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="827"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.skilling_dungeon_copper_caverns_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;skilling_dungeon_copper_caverns_name&quot;>Copper Caverns&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="830"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.skilling_dungeon_copper_caverns_desc` appears to be unused"
+        errorLine1="    &lt;string name=&quot;skilling_dungeon_copper_caverns_desc&quot;>A long-abandoned mine beneath the foothills. Its copper veins still glitter in the dark.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="831"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.skilling_dungeon_dwarven_depths_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;skilling_dungeon_dwarven_depths_name&quot;>Dwarven Depths&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="832"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.skilling_dungeon_dwarven_depths_desc` appears to be unused"
+        errorLine1="    &lt;string name=&quot;skilling_dungeon_dwarven_depths_desc&quot;>The deepest level of an ancient dwarven excavation. Rich veins of rare metal hide behind the bones of its builders.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="833"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.skilling_dungeon_whispering_grove_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;skilling_dungeon_whispering_grove_name&quot;>Whispering Grove&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="834"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.skilling_dungeon_whispering_grove_desc` appears to be unused"
+        errorLine1="    &lt;string name=&quot;skilling_dungeon_whispering_grove_desc&quot;>A primeval forest where the trees have grown for thousands of years undisturbed. Something speaks between the branches.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="835"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.skilling_dungeon_corrupted_canopy_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;skilling_dungeon_corrupted_canopy_name&quot;>Corrupted Canopy&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="836"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.skilling_dungeon_corrupted_canopy_desc` appears to be unused"
+        errorLine1="    &lt;string name=&quot;skilling_dungeon_corrupted_canopy_desc&quot;>A forest where shadow has replaced sunlight. The trees bleed black sap and the air tastes of old magic.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="837"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.skilling_dungeon_sunken_grotto_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;skilling_dungeon_sunken_grotto_name&quot;>Sunken Grotto&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="838"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.skilling_dungeon_sunken_grotto_desc` appears to be unused"
+        errorLine1="    &lt;string name=&quot;skilling_dungeon_sunken_grotto_desc&quot;>A sea cave carved by centuries of tides. Strange stone pillars rise from the water.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="839"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.skilling_dungeon_abyssal_lagoon_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;skilling_dungeon_abyssal_lagoon_name&quot;>Abyssal Lagoon&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="840"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.skilling_dungeon_abyssal_lagoon_desc` appears to be unused"
+        errorLine1="    &lt;string name=&quot;skilling_dungeon_abyssal_lagoon_desc&quot;>A still black lagoon with no visible bottom. The fish here glow faintly and dissolve within minutes of being caught.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="841"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.skilling_dungeon_crumbling_watchtower_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;skilling_dungeon_crumbling_watchtower_name&quot;>Crumbling Watchtower&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="842"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.skilling_dungeon_crumbling_watchtower_desc` appears to be unused"
+        errorLine1="    &lt;string name=&quot;skilling_dungeon_crumbling_watchtower_desc&quot;>A decrepit stone tower perched at the edge of the foothills. Something still guards what was once stored inside.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="843"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.skilling_dungeon_shattered_spire_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;skilling_dungeon_shattered_spire_name&quot;>Shattered Spire&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="844"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.skilling_dungeon_shattered_spire_desc` appears to be unused"
+        errorLine1="    &lt;string name=&quot;skilling_dungeon_shattered_spire_desc&quot;>The remains of a wizard\&apos;s tower reduced to a field of rubble. The air still crackles with residual magic.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="845"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.expeditions_title` appears to be unused"
+        errorLine1="    &lt;string name=&quot;expeditions_title&quot;>Expeditions&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="849"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.skill_slayer_desc` appears to be unused"
+        errorLine1="    &lt;string name=&quot;skill_slayer_desc&quot;>Receive tasks from the Slayer Master in Town.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="862"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.slayer_task_complete` appears to be unused"
+        errorLine1="    &lt;string name=&quot;slayer_task_complete&quot;>Task complete! Visit the Slayer Master for a new one.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="877"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.trade_route_local_market_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;trade_route_local_market_name&quot;>Local Market&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="941"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.trade_route_river_trading_post_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;trade_route_river_trading_post_name&quot;>River Trading Post&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="942"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.trade_route_eastern_caravan_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;trade_route_eastern_caravan_name&quot;>Eastern Caravan&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="943"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.trade_route_grand_exchange_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;trade_route_grand_exchange_name&quot;>Grand Exchange&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="944"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.trade_route_merchants_quarter_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;trade_route_merchants_quarter_name&quot;>Merchant\&apos;s Quarter&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="945"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.trade_route_northern_ports_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;trade_route_northern_ports_name&quot;>Northern Ports&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="946"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.trade_route_local_market_desc` appears to be unused"
+        errorLine1="    &lt;string name=&quot;trade_route_local_market_desc&quot;>Trade common goods at the local market. Returns are modest but variable.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="947"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.trade_route_river_trading_post_desc` appears to be unused"
+        errorLine1="    &lt;string name=&quot;trade_route_river_trading_post_desc&quot;>Move goods along the river trade route. Profits are unpredictable but often worthwhile.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="948"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.trade_route_eastern_caravan_desc` appears to be unused"
+        errorLine1="    &lt;string name=&quot;trade_route_eastern_caravan_desc&quot;>Join a merchant caravan heading east. The long journey pays well when the deal goes through.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="949"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.trade_route_grand_exchange_desc` appears to be unused"
+        errorLine1="    &lt;string name=&quot;trade_route_grand_exchange_desc&quot;>Trade at the legendary Grand Exchange where fortunes are made and lost.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="950"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.trade_route_merchants_quarter_desc` appears to be unused"
+        errorLine1="    &lt;string name=&quot;trade_route_merchants_quarter_desc&quot;>Trade rare commodities in the prestigious merchant district.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="951"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.trade_route_northern_ports_desc` appears to be unused"
+        errorLine1="    &lt;string name=&quot;trade_route_northern_ports_desc&quot;>Sail precious cargo to the northern port cities. High risk, high reward.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="952"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.crafting_cat_bar` appears to be unused"
+        errorLine1="    &lt;string name=&quot;crafting_cat_bar&quot;>Bar&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="953"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.crafting_cat_component` appears to be unused"
+        errorLine1="    &lt;string name=&quot;crafting_cat_component&quot;>Component&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="954"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.crafting_cat_tool` appears to be unused"
+        errorLine1="    &lt;string name=&quot;crafting_cat_tool&quot;>Tool&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="955"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.crafting_cat_weapon` appears to be unused"
+        errorLine1="    &lt;string name=&quot;crafting_cat_weapon&quot;>Weapon&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="956"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.crafting_cat_armour` appears to be unused"
+        errorLine1="    &lt;string name=&quot;crafting_cat_armour&quot;>Armour&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="957"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.crafting_cat_equipment` appears to be unused"
+        errorLine1="    &lt;string name=&quot;crafting_cat_equipment&quot;>Equipment&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="958"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.crafting_cat_food` appears to be unused"
+        errorLine1="    &lt;string name=&quot;crafting_cat_food&quot;>Food&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="959"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.crafting_cat_ammunition` appears to be unused"
+        errorLine1="    &lt;string name=&quot;crafting_cat_ammunition&quot;>Ammunition&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="960"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.crafting_cat_jewellery` appears to be unused"
+        errorLine1="    &lt;string name=&quot;crafting_cat_jewellery&quot;>Jewellery&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="961"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.crafting_cat_potion` appears to be unused"
+        errorLine1="    &lt;string name=&quot;crafting_cat_potion&quot;>Potion&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="962"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.crafting_tier_adamantite` appears to be unused"
+        errorLine1="    &lt;string name=&quot;crafting_tier_adamantite&quot;>Adamantite&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="965"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.crafting_tier_arrow` appears to be unused"
+        errorLine1="    &lt;string name=&quot;crafting_tier_arrow&quot;>Arrow&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="966"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.crafting_tier_bronze` appears to be unused"
+        errorLine1="    &lt;string name=&quot;crafting_tier_bronze&quot;>Bronze&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="967"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.crafting_tier_gold` appears to be unused"
+        errorLine1="    &lt;string name=&quot;crafting_tier_gold&quot;>Gold&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="968"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.crafting_tier_iron` appears to be unused"
+        errorLine1="    &lt;string name=&quot;crafting_tier_iron&quot;>Iron&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="969"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.crafting_tier_magic` appears to be unused"
+        errorLine1="    &lt;string name=&quot;crafting_tier_magic&quot;>Magic&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="970"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.crafting_tier_maple` appears to be unused"
+        errorLine1="    &lt;string name=&quot;crafting_tier_maple&quot;>Maple&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="971"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.crafting_tier_mithril` appears to be unused"
+        errorLine1="    &lt;string name=&quot;crafting_tier_mithril&quot;>Mithril&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="972"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.crafting_tier_oak` appears to be unused"
+        errorLine1="    &lt;string name=&quot;crafting_tier_oak&quot;>Oak&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="973"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.crafting_tier_platinum` appears to be unused"
+        errorLine1="    &lt;string name=&quot;crafting_tier_platinum&quot;>Platinum&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="974"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.crafting_tier_runite` appears to be unused"
+        errorLine1="    &lt;string name=&quot;crafting_tier_runite&quot;>Runite&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="975"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.crafting_tier_shortbow` appears to be unused"
+        errorLine1="    &lt;string name=&quot;crafting_tier_shortbow&quot;>Shortbow&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="976"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.crafting_tier_silver` appears to be unused"
+        errorLine1="    &lt;string name=&quot;crafting_tier_silver&quot;>Silver&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="977"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.crafting_tier_staff` appears to be unused"
+        errorLine1="    &lt;string name=&quot;crafting_tier_staff&quot;>Staff&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="978"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.crafting_tier_steel` appears to be unused"
+        errorLine1="    &lt;string name=&quot;crafting_tier_steel&quot;>Steel&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="979"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.crafting_tier_willow` appears to be unused"
+        errorLine1="    &lt;string name=&quot;crafting_tier_willow&quot;>Willow&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="980"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.crafting_tier_yew` appears to be unused"
+        errorLine1="    &lt;string name=&quot;crafting_tier_yew&quot;>Yew&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="981"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.farming_fertilizer` appears to be unused"
+        errorLine1="    &lt;string name=&quot;farming_fertilizer&quot;>Fertilizer&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="1000"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.farming_fertilized` appears to be unused"
+        errorLine1="    &lt;string name=&quot;farming_fertilized&quot;>Fertilized&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="1003"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.enemy_giant_rat_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;enemy_giant_rat_name&quot;>Giant Rat&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_enemies.xml"
+            line="4"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.enemy_goblin_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;enemy_goblin_name&quot;>Goblin&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_enemies.xml"
+            line="5"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.enemy_skeleton_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;enemy_skeleton_name&quot;>Skeleton&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_enemies.xml"
+            line="6"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.enemy_zombie_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;enemy_zombie_name&quot;>Zombie&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_enemies.xml"
+            line="7"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.enemy_bandit_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;enemy_bandit_name&quot;>Bandit&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_enemies.xml"
+            line="8"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.enemy_guard_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;enemy_guard_name&quot;>Guard&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_enemies.xml"
+            line="9"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.enemy_dark_wizard_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;enemy_dark_wizard_name&quot;>Dark Wizard&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_enemies.xml"
+            line="10"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.enemy_orc_warrior_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;enemy_orc_warrior_name&quot;>Orc Warrior&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_enemies.xml"
+            line="11"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.enemy_spider_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;enemy_spider_name&quot;>Giant Spider&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_enemies.xml"
+            line="12"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.enemy_wild_dog_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;enemy_wild_dog_name&quot;>Wild Dog&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_enemies.xml"
+            line="13"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.enemy_rogue_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;enemy_rogue_name&quot;>Rogue&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_enemies.xml"
+            line="14"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.enemy_knight_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;enemy_knight_name&quot;>Knight&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_enemies.xml"
+            line="15"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.enemy_hellhound_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;enemy_hellhound_name&quot;>Hellhound&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_enemies.xml"
+            line="16"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.enemy_troll_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;enemy_troll_name&quot;>Mountain Troll&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_enemies.xml"
+            line="17"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.enemy_demon_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;enemy_demon_name&quot;>Lesser Demon&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_enemies.xml"
+            line="18"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.enemy_dragon_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;enemy_dragon_name&quot;>Green Dragon&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_enemies.xml"
+            line="19"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.enemy_imp_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;enemy_imp_name&quot;>Imp&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_enemies.xml"
+            line="20"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.enemy_chicken_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;enemy_chicken_name&quot;>Chicken&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_enemies.xml"
+            line="21"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.enemy_sheep_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;enemy_sheep_name&quot;>Sheep&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_enemies.xml"
+            line="22"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.enemy_cow_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;enemy_cow_name&quot;>Cow&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_enemies.xml"
+            line="23"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.dungeon_imp_cavern_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;dungeon_imp_cavern_name&quot;>Imp Cavern&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_enemies.xml"
+            line="26"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.dungeon_imp_cavern_desc` appears to be unused"
+        errorLine1="    &lt;string name=&quot;dungeon_imp_cavern_desc&quot;>A shallow cave filled with mischievous imps. Perfect for absolute beginners!&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_enemies.xml"
+            line="27"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.dungeon_goblin_cave_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;dungeon_goblin_cave_name&quot;>Goblin Cave&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_enemies.xml"
+            line="28"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.dungeon_goblin_cave_desc` appears to be unused"
+        errorLine1="    &lt;string name=&quot;dungeon_goblin_cave_desc&quot;>A dark cave infested with goblins and giant rats. A good place for new adventurers to train.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_enemies.xml"
+            line="29"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.dungeon_spider_den_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;dungeon_spider_den_name&quot;>Spider Den&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_enemies.xml"
+            line="30"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.dungeon_spider_den_desc` appears to be unused"
+        errorLine1="    &lt;string name=&quot;dungeon_spider_den_desc&quot;>A web-filled cavern crawling with venomous spiders. Bring antivenom!&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_enemies.xml"
+            line="31"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.dungeon_bandit_camp_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;dungeon_bandit_camp_name&quot;>Bandit Camp&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_enemies.xml"
+            line="32"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.dungeon_bandit_camp_desc` appears to be unused"
+        errorLine1="    &lt;string name=&quot;dungeon_bandit_camp_desc&quot;>A hideout of thieves and rogues in the wilderness. Watch your coin purse!&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_enemies.xml"
+            line="33"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.dungeon_undead_crypt_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;dungeon_undead_crypt_name&quot;>Undead Crypt&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_enemies.xml"
+            line="34"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.dungeon_undead_crypt_desc` appears to be unused"
+        errorLine1="    &lt;string name=&quot;dungeon_undead_crypt_desc&quot;>An ancient burial ground where the dead refuse to rest. Beware the dark magic!&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_enemies.xml"
+            line="35"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.dungeon_fortress_ruins_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;dungeon_fortress_ruins_name&quot;>Fortress Ruins&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_enemies.xml"
+            line="36"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.dungeon_fortress_ruins_desc` appears to be unused"
+        errorLine1="    &lt;string name=&quot;dungeon_fortress_ruins_desc&quot;>The crumbling remains of an ancient castle, now guarded by knights and soldiers.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_enemies.xml"
+            line="37"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.dungeon_orc_stronghold_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;dungeon_orc_stronghold_name&quot;>Orc Stronghold&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_enemies.xml"
+            line="38"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.dungeon_orc_stronghold_desc` appears to be unused"
+        errorLine1="    &lt;string name=&quot;dungeon_orc_stronghold_desc&quot;>A fortified orc settlement deep in the mountains. Only the brave dare enter.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_enemies.xml"
+            line="39"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.dungeon_volcanic_depths_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;dungeon_volcanic_depths_name&quot;>Volcanic Depths&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_enemies.xml"
+            line="40"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.dungeon_volcanic_depths_desc` appears to be unused"
+        errorLine1="    &lt;string name=&quot;dungeon_volcanic_depths_desc&quot;>A scorching cavern inhabited by hellhounds and lesser demons. The heat is unbearable!&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_enemies.xml"
+            line="41"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.dungeon_dragon_lair_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;dungeon_dragon_lair_name&quot;>Dragon\&apos;s Lair&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_enemies.xml"
+            line="42"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.dungeon_dragon_lair_desc` appears to be unused"
+        errorLine1="    &lt;string name=&quot;dungeon_dragon_lair_desc&quot;>The legendary home of green dragons. Only master warriors survive this challenge.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_enemies.xml"
+            line="43"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.dungeon_farm_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;dungeon_farm_name&quot;>Farm&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_enemies.xml"
+            line="44"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.dungeon_farm_desc` appears to be unused"
+        errorLine1="    &lt;string name=&quot;dungeon_farm_desc&quot;>A peaceful farm with livestock. Great for beginners looking to gather food!&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_enemies.xml"
+            line="45"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.dungeon_infernal_stronghold_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;dungeon_infernal_stronghold_name&quot;>Infernal Stronghold&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_enemies.xml"
+            line="46"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.dungeon_infernal_stronghold_desc` appears to be unused"
+        errorLine1="    &lt;string name=&quot;dungeon_infernal_stronghold_desc&quot;>A fortress of fire and brimstone, ruled by demons and hellhounds. The heat alone can kill the unprepared.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_enemies.xml"
+            line="47"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.dungeon_ancient_temple_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;dungeon_ancient_temple_name&quot;>Ancient Temple&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_enemies.xml"
+            line="48"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.dungeon_ancient_temple_desc` appears to be unused"
+        errorLine1="    &lt;string name=&quot;dungeon_ancient_temple_desc&quot;>An ancient temple guarded by the most powerful creatures in the realm. Only the strongest warriors dare enter.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_enemies.xml"
+            line="49"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.boss_king_black_dragon_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;boss_king_black_dragon_name&quot;>King Black Dragon&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_enemies.xml"
+            line="52"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.boss_demon_lord_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;boss_demon_lord_name&quot;>Demon Lord&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_enemies.xml"
+            line="53"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.boss_kraken_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;boss_kraken_name&quot;>Kraken&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_enemies.xml"
+            line="54"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.boss_balrog_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;boss_balrog_name&quot;>Balrog&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_enemies.xml"
+            line="55"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.pet_dragon_whelp_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;pet_dragon_whelp_name&quot;>Dragon Whelp&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_enemies.xml"
+            line="58"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.pet_dragon_whelp_desc` appears to be unused"
+        errorLine1="    &lt;string name=&quot;pet_dragon_whelp_desc&quot;>A young dragon that boosts your combat XP.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_enemies.xml"
+            line="59"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.pet_imp_pet_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;pet_imp_pet_name&quot;>Imp Pet&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_enemies.xml"
+            line="60"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.pet_imp_pet_desc` appears to be unused"
+        errorLine1="    &lt;string name=&quot;pet_imp_pet_desc&quot;>A mischievous imp that enhances your Prayer training.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_enemies.xml"
+            line="61"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.pet_baby_kraken_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;pet_baby_kraken_name&quot;>Baby Kraken&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_enemies.xml"
+            line="62"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.pet_baby_kraken_desc` appears to be unused"
+        errorLine1="    &lt;string name=&quot;pet_baby_kraken_desc&quot;>A tiny kraken that improves your Cooking XP.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_enemies.xml"
+            line="63"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.pet_rock_golem_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;pet_rock_golem_name&quot;>Rock Golem&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_enemies.xml"
+            line="64"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.pet_rock_golem_desc` appears to be unused"
+        errorLine1="    &lt;string name=&quot;pet_rock_golem_desc&quot;>A living rock formation that enhances your Mining XP.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_enemies.xml"
+            line="65"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.pet_ent_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;pet_ent_name&quot;>Ent&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_enemies.xml"
+            line="66"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.pet_ent_desc` appears to be unused"
+        errorLine1="    &lt;string name=&quot;pet_ent_desc&quot;>An ancient tree spirit that boosts your Woodcutting XP.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_enemies.xml"
+            line="67"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.pet_tiny_templar_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;pet_tiny_templar_name&quot;>Tiny Templar&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_enemies.xml"
+            line="68"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.pet_tiny_templar_desc` appears to be unused"
+        errorLine1="    &lt;string name=&quot;pet_tiny_templar_desc&quot;>A small fish companion that boosts your Fishing XP.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_enemies.xml"
+            line="69"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.pet_tangleroot_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;pet_tangleroot_name&quot;>Tangleroot&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_enemies.xml"
+            line="70"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.pet_tangleroot_desc` appears to be unused"
+        errorLine1="    &lt;string name=&quot;pet_tangleroot_desc&quot;>A magical plant creature that enhances your Farming XP.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_enemies.xml"
+            line="71"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.dungeon_collapsed_mine_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;dungeon_collapsed_mine_name&quot;>Collapsed Mine&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_enemies.xml"
+            line="74"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.dungeon_collapsed_mine_desc` appears to be unused"
+        errorLine1="    &lt;string name=&quot;dungeon_collapsed_mine_desc&quot;>A vast cavern beneath the copper mines. Cave trolls and rock golems haunt the rubble, and giant spiders spin webs across the collapsed shafts.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_enemies.xml"
+            line="75"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.dungeon_shadow_den_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;dungeon_shadow_den_name&quot;>Shadow Den&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_enemies.xml"
+            line="76"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.dungeon_shadow_den_desc` appears to be unused"
+        errorLine1="    &lt;string name=&quot;dungeon_shadow_den_desc&quot;>A network of underground chambers used by the region\&apos;s thieves guild. Rogues, assassins, and shadow creatures lurk in every corner.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_enemies.xml"
+            line="77"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.dungeon_abyssal_ruins_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;dungeon_abyssal_ruins_name&quot;>Abyssal Ruins&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_enemies.xml"
+            line="78"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.dungeon_abyssal_ruins_desc` appears to be unused"
+        errorLine1="    &lt;string name=&quot;dungeon_abyssal_ruins_desc&quot;>Ancient ruins that exist simultaneously above and below the mortal plane. Strange abyssal creatures phase in and out of reality.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_enemies.xml"
+            line="79"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.dungeon_ancient_forest_ruins_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;dungeon_ancient_forest_ruins_name&quot;>Ancient Forest Ruins&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_enemies.xml"
+            line="80"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.dungeon_ancient_forest_ruins_desc` appears to be unused"
+        errorLine1="    &lt;string name=&quot;dungeon_ancient_forest_ruins_desc&quot;>Stone ruins swallowed by the primeval forest, now haunted by feral creatures and vengeful spirits of druids.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_enemies.xml"
+            line="81"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.dungeon_ancient_forge_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;dungeon_ancient_forge_name&quot;>Ancient Forge&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_enemies.xml"
+            line="82"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.dungeon_ancient_forge_desc` appears to be unused"
+        errorLine1="    &lt;string name=&quot;dungeon_ancient_forge_desc&quot;>A vast dwarven forge that has burned for centuries without stopping. Fire elementals and forge guardians protect its secrets.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_enemies.xml"
+            line="83"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.dungeon_arcane_ruins_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;dungeon_arcane_ruins_name&quot;>Arcane Ruins&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_enemies.xml"
+            line="84"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.dungeon_arcane_ruins_desc` appears to be unused"
+        errorLine1="    &lt;string name=&quot;dungeon_arcane_ruins_desc&quot;>The functional underground chambers of a destroyed wizard\&apos;s tower. Magical constructs and enchanted guardians still patrol its halls.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_enemies.xml"
+            line="85"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.dungeon_corrupted_sanctum_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;dungeon_corrupted_sanctum_name&quot;>Corrupted Sanctum&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_enemies.xml"
+            line="86"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.dungeon_corrupted_sanctum_desc` appears to be unused"
+        errorLine1="    &lt;string name=&quot;dungeon_corrupted_sanctum_desc&quot;>A shadow-drenched sanctum at the heart of the corrupted canopy. Dark priests and corrupted beasts guard an ancient evil.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_enemies.xml"
+            line="87"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.dungeon_drowned_temple_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;dungeon_drowned_temple_name&quot;>Drowned Temple&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_enemies.xml"
+            line="88"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.dungeon_drowned_temple_desc` appears to be unused"
+        errorLine1="    &lt;string name=&quot;dungeon_drowned_temple_desc&quot;>A sunken temple beneath the sea grotto, its halls filled with water and sea creatures that have made it their home.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_enemies.xml"
+            line="89"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.game_level_up` appears to be unused"
+        errorLine1="    &lt;string name=&quot;game_level_up&quot;>Level up! %1$s is now level %2$d!&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_game.xml"
+            line="5"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.game_level_up_short` appears to be unused"
+        errorLine1="    &lt;string name=&quot;game_level_up_short&quot;>%1$s → %2$d&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_game.xml"
+            line="7"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.game_max_level` appears to be unused"
+        errorLine1="    &lt;string name=&quot;game_max_level&quot;>Maximum level reached!&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_game.xml"
+            line="8"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.game_session_results_title` appears to be unused"
+        errorLine1="    &lt;string name=&quot;game_session_results_title&quot;>Session Results&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_game.xml"
+            line="11"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.game_session_summary_header` appears to be unused"
+        errorLine1="    &lt;string name=&quot;game_session_summary_header&quot;>%1$s session complete&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_game.xml"
+            line="13"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.game_session_xp_total` appears to be unused"
+        errorLine1="    &lt;string name=&quot;game_session_xp_total&quot;>+%1$s XP earned&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_game.xml"
+            line="15"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.game_session_no_items` appears to be unused"
+        errorLine1="    &lt;string name=&quot;game_session_no_items&quot;>No items collected&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_game.xml"
+            line="16"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.game_session_no_level_ups` appears to be unused"
+        errorLine1="    &lt;string name=&quot;game_session_no_level_ups&quot;>No level ups this session&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_game.xml"
+            line="17"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.game_session_level_up_count` appears to be unused"
+        errorLine1="    &lt;string name=&quot;game_session_level_up_count&quot;>%1$d level up!&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_game.xml"
+            line="19"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.game_combat_hit` appears to be unused"
+        errorLine1="    &lt;string name=&quot;game_combat_hit&quot;>%1$s hits for %2$d damage.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_game.xml"
+            line="23"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.game_combat_miss` appears to be unused"
+        errorLine1="    &lt;string name=&quot;game_combat_miss&quot;>%1$s misses!&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_game.xml"
+            line="24"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.game_combat_enemy_defeated` appears to be unused"
+        errorLine1="    &lt;string name=&quot;game_combat_enemy_defeated&quot;>%1$s defeated!&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_game.xml"
+            line="26"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.game_combat_food_eaten` appears to be unused"
+        errorLine1="    &lt;string name=&quot;game_combat_food_eaten&quot;>Ate food — restored %1$d HP.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_game.xml"
+            line="28"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.game_combat_player_died` appears to be unused"
+        errorLine1="    &lt;string name=&quot;game_combat_player_died&quot;>You were defeated.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_game.xml"
+            line="29"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.game_dungeon_cleared` appears to be unused"
+        errorLine1="    &lt;string name=&quot;game_dungeon_cleared&quot;>Dungeon cleared!&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_game.xml"
+            line="30"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.game_dungeon_summary` appears to be unused"
+        errorLine1="    &lt;string name=&quot;game_dungeon_summary&quot;>%1$s complete.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_game.xml"
+            line="32"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.game_farming_planted` appears to be unused"
+        errorLine1="    &lt;string name=&quot;game_farming_planted&quot;>%1$s planted.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_game.xml"
+            line="36"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.game_farming_harvested` appears to be unused"
+        errorLine1="    &lt;string name=&quot;game_farming_harvested&quot;>Harvested %2$d %1$s.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_game.xml"
+            line="38"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.game_farming_all_harvested` appears to be unused"
+        errorLine1="    &lt;string name=&quot;game_farming_all_harvested&quot;>All ready patches harvested.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_game.xml"
+            line="39"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.game_farming_patch_cleared` appears to be unused"
+        errorLine1="    &lt;string name=&quot;game_farming_patch_cleared&quot;>Patch cleared.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_game.xml"
+            line="40"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.game_farming_not_ready` appears to be unused"
+        errorLine1="    &lt;string name=&quot;game_farming_not_ready&quot;>This crop is not ready yet.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_game.xml"
+            line="41"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.game_farming_ready_in` appears to be unused"
+        errorLine1="    &lt;string name=&quot;game_farming_ready_in&quot;>%1$s ready in %2$s.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_game.xml"
+            line="43"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.game_crafted` appears to be unused"
+        errorLine1="    &lt;string name=&quot;game_crafted&quot;>Crafted %1$d %2$s.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_game.xml"
+            line="47"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.game_missing_ingredient` appears to be unused"
+        errorLine1="    &lt;string name=&quot;game_missing_ingredient&quot;>Missing ingredient: %1$s.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_game.xml"
+            line="49"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.game_shop_purchased` appears to be unused"
+        errorLine1="    &lt;string name=&quot;game_shop_purchased&quot;>Bought %1$d %2$s for %3$d coins.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_game.xml"
+            line="53"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.game_shop_sold` appears to be unused"
+        errorLine1="    &lt;string name=&quot;game_shop_sold&quot;>Sold %1$d %2$s for %3$d coins.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_game.xml"
+            line="55"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.game_bones_buried` appears to be unused"
+        errorLine1="    &lt;string name=&quot;game_bones_buried&quot;>Buried %1$s — +%2$s Prayer XP.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_game.xml"
+            line="59"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.game_quest_started` appears to be unused"
+        errorLine1="    &lt;string name=&quot;game_quest_started&quot;>Quest started: %1$s&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_game.xml"
+            line="63"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.game_quest_completed` appears to be unused"
+        errorLine1="    &lt;string name=&quot;game_quest_completed&quot;>Quest complete: %1$s&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_game.xml"
+            line="64"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.game_quest_abandoned` appears to be unused"
+        errorLine1="    &lt;string name=&quot;game_quest_abandoned&quot;>Quest abandoned.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_game.xml"
+            line="65"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.game_quest_progress` appears to be unused"
+        errorLine1="    &lt;string name=&quot;game_quest_progress&quot;>Progress: %1$d / %2$d&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_game.xml"
+            line="67"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.game_xp_gained` appears to be unused"
+        errorLine1="    &lt;string name=&quot;game_xp_gained&quot;>+%1$s XP&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_game.xml"
+            line="71"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.game_item_received` appears to be unused"
+        errorLine1="    &lt;string name=&quot;game_item_received&quot;>+%2$d %1$s&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_game.xml"
+            line="73"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.game_arena_challenged` appears to be unused"
+        errorLine1="    &lt;string name=&quot;game_arena_challenged&quot;>Challenged by %1$s!&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_game.xml"
+            line="77"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.game_arena_victory` appears to be unused"
+        errorLine1="    &lt;string name=&quot;game_arena_victory&quot;>Victory!&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_game.xml"
+            line="78"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.game_arena_defeat` appears to be unused"
+        errorLine1="    &lt;string name=&quot;game_arena_defeat&quot;>Defeated.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_game.xml"
+            line="79"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.game_arena_coins_won` appears to be unused"
+        errorLine1="    &lt;string name=&quot;game_arena_coins_won&quot;>Won %1$d coins.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_game.xml"
+            line="81"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.game_dig_you_dig` appears to be unused"
+        errorLine1="    &lt;string name=&quot;game_dig_you_dig&quot;>You dig into the earth…&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_game.xml"
+            line="84"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.game_dig_nothing` appears to be unused"
+        errorLine1="    &lt;string name=&quot;game_dig_nothing&quot;>You find nothing but dirt.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_game.xml"
+            line="85"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.game_dig_found` appears to be unused"
+        errorLine1="    &lt;string name=&quot;game_dig_found&quot;>You uncover a %1$s!&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_game.xml"
+            line="87"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.game_dig_depth` appears to be unused"
+        errorLine1="    &lt;string name=&quot;game_dig_depth&quot;>The hole is %1$d metres deep.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_game.xml"
+            line="89"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.game_dig_cooldown` appears to be unused"
+        errorLine1="    &lt;string name=&quot;game_dig_cooldown&quot;>You already dug today. Come back tomorrow.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_game.xml"
+            line="90"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_agility_guild_1_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_agility_guild_1_name&quot;>First Laps&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="4"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_agility_guild_10_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_agility_guild_10_name&quot;>Master of Movement&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="5"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_agility_guild_2_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_agility_guild_2_name&quot;>Dedicated Runner&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="6"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_agility_guild_3_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_agility_guild_3_name&quot;>Endurance Run&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="7"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_agility_guild_4_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_agility_guild_4_name&quot;>Obstacle Expert&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="8"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_agility_guild_5_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_agility_guild_5_name&quot;>Swift Feet&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="9"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_agility_guild_6_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_agility_guild_6_name&quot;>Course Master&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="10"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_agility_guild_7_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_agility_guild_7_name&quot;>Elite Runner&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="11"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_agility_guild_8_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_agility_guild_8_name&quot;>Relentless&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="12"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_agility_guild_9_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_agility_guild_9_name&quot;>Indomitable&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="13"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_archers_guild_1_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_archers_guild_1_name&quot;>First Arrow&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="14"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_archers_guild_10_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_archers_guild_10_name&quot;>Master Archer&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="15"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_archers_guild_2_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_archers_guild_2_name&quot;>Keen Eye&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="16"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_archers_guild_3_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_archers_guild_3_name&quot;>Marksman&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="17"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_archers_guild_4_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_archers_guild_4_name&quot;>Sharpshooter&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="18"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_archers_guild_5_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_archers_guild_5_name&quot;>Eagle Eye&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="19"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_archers_guild_6_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_archers_guild_6_name&quot;>Deadshot&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="20"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_archers_guild_7_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_archers_guild_7_name&quot;>Sniper&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="21"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_archers_guild_8_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_archers_guild_8_name&quot;>Hawkeye&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="22"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_archers_guild_9_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_archers_guild_9_name&quot;>Phantom&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="23"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_cooking_guild_1_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_cooking_guild_1_name&quot;>Chicken Run&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="24"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_cooking_guild_10_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_cooking_guild_10_name&quot;>Master Chef&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="25"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_cooking_guild_2_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_cooking_guild_2_name&quot;>Trout Feast&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="26"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_cooking_guild_3_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_cooking_guild_3_name&quot;>Beef Order&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="27"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_cooking_guild_4_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_cooking_guild_4_name&quot;>Lobster Spread&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="28"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_cooking_guild_5_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_cooking_guild_5_name&quot;>Swordfish Gala&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="29"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_cooking_guild_6_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_cooking_guild_6_name&quot;>Monkfish Mastery&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="30"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_cooking_guild_7_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_cooking_guild_7_name&quot;>Shark Special&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="31"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_cooking_guild_8_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_cooking_guild_8_name&quot;>Mutton Marathon&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="32"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_cooking_guild_9_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_cooking_guild_9_name&quot;>Sea Turtle Feast&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="33"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_crafting_guild_1_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_crafting_guild_1_name&quot;>Silver Jewels&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="34"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_crafting_guild_10_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_crafting_guild_10_name&quot;>Master Crafter&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="35"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_crafting_guild_2_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_crafting_guild_2_name&quot;>Gold Trinkets&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="36"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_crafting_guild_3_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_crafting_guild_3_name&quot;>Sapphire Set&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="37"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_crafting_guild_4_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_crafting_guild_4_name&quot;>Emerald Collection&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="38"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_crafting_guild_5_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_crafting_guild_5_name&quot;>Ruby Rings&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="39"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_crafting_guild_6_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_crafting_guild_6_name&quot;>Diamond Crafting&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="40"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_crafting_guild_7_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_crafting_guild_7_name&quot;>Platinum Jewels&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="41"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_crafting_guild_8_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_crafting_guild_8_name&quot;>Platinum Necklaces&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="42"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_crafting_guild_9_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_crafting_guild_9_name&quot;>Gem Hoard&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="43"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_farming_guild_1_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_farming_guild_1_name&quot;>Potato Harvest&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="44"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_farming_guild_10_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_farming_guild_10_name&quot;>Master Farmer&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="45"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_farming_guild_2_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_farming_guild_2_name&quot;>Carrot Delivery&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="46"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_farming_guild_3_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_farming_guild_3_name&quot;>Corn Stockpile&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="47"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_farming_guild_4_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_farming_guild_4_name&quot;>Pumpkin Patch&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="48"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_farming_guild_5_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_farming_guild_5_name&quot;>Strawberry Season&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="49"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_farming_guild_6_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_farming_guild_6_name&quot;>Magic Herbs&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="50"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_farming_guild_7_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_farming_guild_7_name&quot;>Dragon Fruit Yield&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="51"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_farming_guild_8_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_farming_guild_8_name&quot;>Golden Wheat&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="52"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_farming_guild_9_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_farming_guild_9_name&quot;>Spirit Herbs&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="53"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_firemaking_guild_1_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_firemaking_guild_1_name&quot;>First Flames&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="54"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_firemaking_guild_10_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_firemaking_guild_10_name&quot;>Master Firemaker&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="55"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_firemaking_guild_2_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_firemaking_guild_2_name&quot;>Oak Pyre&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="56"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_firemaking_guild_3_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_firemaking_guild_3_name&quot;>Willow Ember&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="57"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_firemaking_guild_4_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_firemaking_guild_4_name&quot;>Maple Blaze&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="58"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_firemaking_guild_5_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_firemaking_guild_5_name&quot;>Yew Inferno&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="59"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_firemaking_guild_6_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_firemaking_guild_6_name&quot;>Magic Pyre&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="60"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_firemaking_guild_7_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_firemaking_guild_7_name&quot;>Redwood Bonfire&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="61"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_firemaking_guild_8_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_firemaking_guild_8_name&quot;>Ancient Flame&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="62"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_firemaking_guild_9_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_firemaking_guild_9_name&quot;>Redwood Legacy&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="63"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_fishing_guild_1_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_fishing_guild_1_name&quot;>Shrimp Haul&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="64"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_fishing_guild_10_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_fishing_guild_10_name&quot;>Master Fisher&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="65"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_fishing_guild_2_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_fishing_guild_2_name&quot;>Trout Run&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="66"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_fishing_guild_3_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_fishing_guild_3_name&quot;>Salmon Haul&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="67"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_fishing_guild_4_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_fishing_guild_4_name&quot;>Tuna Delivery&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="68"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_fishing_guild_5_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_fishing_guild_5_name&quot;>Lobster Catch&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="69"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_fishing_guild_6_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_fishing_guild_6_name&quot;>Swordfish Quota&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="70"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_fishing_guild_7_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_fishing_guild_7_name&quot;>Monkfish Order&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="71"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_fishing_guild_8_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_fishing_guild_8_name&quot;>Shark Hunt&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="72"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_fishing_guild_9_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_fishing_guild_9_name&quot;>Manta Ray Reserve&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="73"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_fletching_guild_1_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_fletching_guild_1_name&quot;>Arrow Shafts&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="74"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_fletching_guild_10_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_fletching_guild_10_name&quot;>Master Fletcher&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="75"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_fletching_guild_2_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_fletching_guild_2_name&quot;>Bronze Arrows&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="76"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_fletching_guild_3_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_fletching_guild_3_name&quot;>Iron Flight&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="77"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_fletching_guild_4_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_fletching_guild_4_name&quot;>Steel Volley&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="78"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_fletching_guild_5_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_fletching_guild_5_name&quot;>Mithril Rain&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="79"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_fletching_guild_6_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_fletching_guild_6_name&quot;>Adamantite Arsenal&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="80"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_fletching_guild_7_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_fletching_guild_7_name&quot;>Runite Quiver&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="81"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_fletching_guild_8_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_fletching_guild_8_name&quot;>Yew Longbows&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="82"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_fletching_guild_9_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_fletching_guild_9_name&quot;>Magic Longbows&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="83"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_herblore_guild_1_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_herblore_guild_1_name&quot;>Attack Brews&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="84"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_herblore_guild_10_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_herblore_guild_10_name&quot;>Master Herbalist&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="85"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_herblore_guild_2_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_herblore_guild_2_name&quot;>Attack Potions&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="86"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_herblore_guild_3_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_herblore_guild_3_name&quot;>Strength Potions&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="87"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_herblore_guild_4_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_herblore_guild_4_name&quot;>Ranging Potions&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="88"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_herblore_guild_5_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_herblore_guild_5_name&quot;>Magic Potions&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="89"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_herblore_guild_6_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_herblore_guild_6_name&quot;>Super Brews&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="90"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_herblore_guild_7_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_herblore_guild_7_name&quot;>Super Ranging&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="91"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_herblore_guild_8_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_herblore_guild_8_name&quot;>Super Magic&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="92"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_herblore_guild_9_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_herblore_guild_9_name&quot;>Overload Stockpile&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="93"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_mages_guild_1_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_mages_guild_1_name&quot;>Apprentice Spellcaster&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="94"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_mages_guild_10_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_mages_guild_10_name&quot;>Grand Magus&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="95"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_mages_guild_2_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_mages_guild_2_name&quot;>Arcane Student&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="96"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_mages_guild_3_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_mages_guild_3_name&quot;>Journeyman Mage&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="97"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_mages_guild_4_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_mages_guild_4_name&quot;>Chaos Wielder&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="98"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_mages_guild_5_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_mages_guild_5_name&quot;>Sorcerer&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="99"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_mages_guild_6_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_mages_guild_6_name&quot;>Warlock&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="100"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_mages_guild_7_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_mages_guild_7_name&quot;>Archmage&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="101"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_mages_guild_8_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_mages_guild_8_name&quot;>Lich&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="102"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_mages_guild_9_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_mages_guild_9_name&quot;>Spellweaver&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="103"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_mercantile_guild_1_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_mercantile_guild_1_name&quot;>First Trade&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="104"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_mercantile_guild_10_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_mercantile_guild_10_name&quot;>Exchange Master&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="105"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_mercantile_guild_2_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_mercantile_guild_2_name&quot;>Budding Merchant&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="106"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_mercantile_guild_3_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_mercantile_guild_3_name&quot;>River Trader&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="107"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_mercantile_guild_4_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_mercantile_guild_4_name&quot;>Caravan Master&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="108"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_mercantile_guild_5_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_mercantile_guild_5_name&quot;>Port Authority&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="109"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_mercantile_guild_6_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_mercantile_guild_6_name&quot;>Merchant Prince&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="110"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_mercantile_guild_7_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_mercantile_guild_7_name&quot;>Trade Baron&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="111"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_mercantile_guild_8_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_mercantile_guild_8_name&quot;>Grand Merchant&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="112"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_mercantile_guild_9_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_mercantile_guild_9_name&quot;>Legendary Trader&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="113"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_mining_guild_1_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_mining_guild_1_name&quot;>Copper Run&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="114"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_mining_guild_10_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_mining_guild_10_name&quot;>Master Miner&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="115"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_mining_guild_2_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_mining_guild_2_name&quot;>Iron Quota&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="116"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_mining_guild_3_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_mining_guild_3_name&quot;>Coal Haul&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="117"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_mining_guild_4_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_mining_guild_4_name&quot;>Silver Delivery&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="118"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_mining_guild_5_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_mining_guild_5_name&quot;>Mithril Mandate&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="119"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_mining_guild_6_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_mining_guild_6_name&quot;>Gold Standard&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="120"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_mining_guild_7_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_mining_guild_7_name&quot;>Adamantite Order&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="121"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_mining_guild_8_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_mining_guild_8_name&quot;>Platinum Haul&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="122"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_mining_guild_9_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_mining_guild_9_name&quot;>Runite Reserve&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="123"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_prayer_guild_1_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_prayer_guild_1_name&quot;>First Offering&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="124"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_prayer_guild_10_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_prayer_guild_10_name&quot;>High Priest&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="125"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_prayer_guild_2_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_prayer_guild_2_name&quot;>Devoted&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="126"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_prayer_guild_3_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_prayer_guild_3_name&quot;>Pious&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="127"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_prayer_guild_4_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_prayer_guild_4_name&quot;>Righteous&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="128"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_prayer_guild_5_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_prayer_guild_5_name&quot;>Holy&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="129"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_prayer_guild_6_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_prayer_guild_6_name&quot;>Sacred&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="130"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_prayer_guild_7_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_prayer_guild_7_name&quot;>Blessed&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="131"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_prayer_guild_8_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_prayer_guild_8_name&quot;>Divine&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="132"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_prayer_guild_9_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_prayer_guild_9_name&quot;>Transcendent&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="133"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_runecrafting_guild_1_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_runecrafting_guild_1_name&quot;>Air Supply&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="134"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_runecrafting_guild_10_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_runecrafting_guild_10_name&quot;>Master Runecraftsman&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="135"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_runecrafting_guild_2_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_runecrafting_guild_2_name&quot;>Earth Batch&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="136"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_runecrafting_guild_3_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_runecrafting_guild_3_name&quot;>Fire Stockpile&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="137"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_runecrafting_guild_4_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_runecrafting_guild_4_name&quot;>Mind Craft&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="138"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_runecrafting_guild_5_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_runecrafting_guild_5_name&quot;>Chaos Order&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="139"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_runecrafting_guild_6_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_runecrafting_guild_6_name&quot;>Death Batch&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="140"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_runecrafting_guild_7_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_runecrafting_guild_7_name&quot;>Blood Reserve&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="141"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_runecrafting_guild_8_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_runecrafting_guild_8_name&quot;>Rune Vault&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="142"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_runecrafting_guild_9_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_runecrafting_guild_9_name&quot;>Arcane Stockpile&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="143"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_smithing_guild_1_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_smithing_guild_1_name&quot;>Bronze Basics&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="144"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_smithing_guild_10_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_smithing_guild_10_name&quot;>Master Smith&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="145"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_smithing_guild_2_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_smithing_guild_2_name&quot;>Iron Works&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="146"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_smithing_guild_3_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_smithing_guild_3_name&quot;>Steel Production&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="147"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_smithing_guild_4_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_smithing_guild_4_name&quot;>Mithril Foundry&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="148"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_smithing_guild_5_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_smithing_guild_5_name&quot;>Adamantite Forge&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="149"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_smithing_guild_6_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_smithing_guild_6_name&quot;>Platinum Smelter&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="150"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_smithing_guild_7_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_smithing_guild_7_name&quot;>Runite Smelter&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="151"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_smithing_guild_8_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_smithing_guild_8_name&quot;>Weapons Cache&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="152"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_smithing_guild_9_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_smithing_guild_9_name&quot;>Armour Vault&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="153"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_warriors_guild_1_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_warriors_guild_1_name&quot;>First Blood&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="154"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_warriors_guild_10_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_warriors_guild_10_name&quot;>Master Warrior&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="155"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_warriors_guild_2_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_warriors_guild_2_name&quot;>Skirmisher&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="156"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_warriors_guild_3_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_warriors_guild_3_name&quot;>Battle-Hardened&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="157"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_warriors_guild_4_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_warriors_guild_4_name&quot;>Veteran Soldier&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="158"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_warriors_guild_5_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_warriors_guild_5_name&quot;>Elite Warrior&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="159"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_warriors_guild_6_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_warriors_guild_6_name&quot;>Battlefield Legend&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="160"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_warriors_guild_7_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_warriors_guild_7_name&quot;>Champion&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="161"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_warriors_guild_8_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_warriors_guild_8_name&quot;>Warlord&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="162"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_warriors_guild_9_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_warriors_guild_9_name&quot;>Conqueror&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="163"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_woodcutting_guild_1_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_woodcutting_guild_1_name&quot;>Normal Logs&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="164"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_woodcutting_guild_10_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_woodcutting_guild_10_name&quot;>Master Woodcutter&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="165"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_woodcutting_guild_2_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_woodcutting_guild_2_name&quot;>Oak Delivery&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="166"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_woodcutting_guild_3_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_woodcutting_guild_3_name&quot;>Willow Run&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="167"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_woodcutting_guild_4_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_woodcutting_guild_4_name&quot;>Maple Order&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="168"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_woodcutting_guild_5_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_woodcutting_guild_5_name&quot;>Yew Haul&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="169"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_woodcutting_guild_6_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_woodcutting_guild_6_name&quot;>Magic Timber&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="170"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_woodcutting_guild_7_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_woodcutting_guild_7_name&quot;>Redwood Stockpile&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="171"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_woodcutting_guild_8_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_woodcutting_guild_8_name&quot;>Ancient Timber&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="172"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_woodcutting_guild_9_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_woodcutting_guild_9_name&quot;>Redwood Legacy&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="173"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_agility_daily_1a_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_agility_daily_1a_name&quot;>Morning Run&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="176"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_agility_daily_1b_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_agility_daily_1b_name&quot;>Sprint Training&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="177"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_agility_daily_1c_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_agility_daily_1c_name&quot;>Obstacle Circuit&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="178"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_agility_daily_4a_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_agility_daily_4a_name&quot;>Endurance Circuit&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="179"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_agility_daily_4b_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_agility_daily_4b_name&quot;>Elite Sprint&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="180"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_agility_daily_4c_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_agility_daily_4c_name&quot;>Advanced Run&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="181"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_agility_daily_7a_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_agility_daily_7a_name&quot;>Master Circuit&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="182"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_agility_daily_7b_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_agility_daily_7b_name&quot;>Champion Run&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="183"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_agility_daily_7c_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_agility_daily_7c_name&quot;>Legendary Sprint&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="184"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_archers_daily_1a_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_archers_daily_1a_name&quot;>Target Practice&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="185"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_archers_daily_1b_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_archers_daily_1b_name&quot;>Range Duty&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="186"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_archers_daily_1c_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_archers_daily_1c_name&quot;>Daily Hunt&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="187"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_archers_daily_1d_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_archers_daily_1d_name&quot;>Marksman\&apos;s Call&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="188"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_archers_daily_4a_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_archers_daily_4a_name&quot;>Sharpshooter Raid&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="189"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_archers_daily_4b_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_archers_daily_4b_name&quot;>Eagle Eye Duty&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="190"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_archers_daily_4c_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_archers_daily_4c_name&quot;>Phantom March&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="191"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_archers_daily_7a_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_archers_daily_7a_name&quot;>Sniper Raid&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="192"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_archers_daily_7b_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_archers_daily_7b_name&quot;>Hawkeye March&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="193"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_archers_daily_7c_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_archers_daily_7c_name&quot;>Grand Hunt&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="194"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_cooking_daily_1a_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_cooking_daily_1a_name&quot;>Shrimp Batch&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="195"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_cooking_daily_1b_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_cooking_daily_1b_name&quot;>Trout Feast&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="196"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_cooking_daily_1c_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_cooking_daily_1c_name&quot;>Salmon Dinner&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="197"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_cooking_daily_1d_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_cooking_daily_1d_name&quot;>Herring Haul&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="198"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_cooking_daily_1e_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_cooking_daily_1e_name&quot;>Tuna Batch&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="199"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_cooking_daily_4a_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_cooking_daily_4a_name&quot;>Lobster Feast&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="200"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_cooking_daily_4b_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_cooking_daily_4b_name&quot;>Swordfish Run&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="201"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_cooking_daily_4c_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_cooking_daily_4c_name&quot;>Monkfish Batch&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="202"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_cooking_daily_4d_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_cooking_daily_4d_name&quot;>Lobster Reserve&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="203"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_cooking_daily_4e_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_cooking_daily_4e_name&quot;>Swordfish Reserve&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="204"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_cooking_daily_7a_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_cooking_daily_7a_name&quot;>Shark Feast&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="205"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_cooking_daily_7b_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_cooking_daily_7b_name&quot;>Manta Banquet&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="206"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_cooking_daily_7c_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_cooking_daily_7c_name&quot;>Sea Turtle Feast&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="207"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_cooking_daily_7d_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_cooking_daily_7d_name&quot;>Shark Reserve&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="208"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_crafting_daily_1a_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_crafting_daily_1a_name&quot;>Silver Rings&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="209"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_crafting_daily_1b_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_crafting_daily_1b_name&quot;>Gold Rings&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="210"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_crafting_daily_1c_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_crafting_daily_1c_name&quot;>Sapphire Gems&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="211"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_crafting_daily_1d_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_crafting_daily_1d_name&quot;>Silver Necklaces&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="212"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_crafting_daily_1e_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_crafting_daily_1e_name&quot;>Gold Necklaces&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="213"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_crafting_daily_4a_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_crafting_daily_4a_name&quot;>Emerald Rings&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="214"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_crafting_daily_4b_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_crafting_daily_4b_name&quot;>Ruby Gems&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="215"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_crafting_daily_4c_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_crafting_daily_4c_name&quot;>Platinum Rings&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="216"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_crafting_daily_4d_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_crafting_daily_4d_name&quot;>Diamond Set&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="217"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_crafting_daily_4e_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_crafting_daily_4e_name&quot;>Platinum Necklaces&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="218"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_crafting_daily_7a_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_crafting_daily_7a_name&quot;>Platinum Diamonds&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="219"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_crafting_daily_7b_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_crafting_daily_7b_name&quot;>Diamond Necklaces&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="220"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_crafting_daily_7c_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_crafting_daily_7c_name&quot;>Gem Vault&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="221"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_farming_daily_1a_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_farming_daily_1a_name&quot;>Potato Run&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="222"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_farming_daily_1b_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_farming_daily_1b_name&quot;>Onion Delivery&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="223"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_farming_daily_1c_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_farming_daily_1c_name&quot;>Carrot Supply&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="224"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_farming_daily_1d_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_farming_daily_1d_name&quot;>Cabbage Haul&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="225"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_farming_daily_1e_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_farming_daily_1e_name&quot;>Corn Batch&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="226"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_farming_daily_4a_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_farming_daily_4a_name&quot;>Strawberry Harvest&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="227"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_farming_daily_4b_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_farming_daily_4b_name&quot;>Pumpkin Delivery&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="228"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_farming_daily_4c_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_farming_daily_4c_name&quot;>Watermelon Run&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="229"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_farming_daily_4d_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_farming_daily_4d_name&quot;>Magic Herb Batch&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="230"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_farming_daily_4e_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_farming_daily_4e_name&quot;>Dragon Fruit Run&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="231"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_farming_daily_7a_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_farming_daily_7a_name&quot;>Spirit Herbs&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="232"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_farming_daily_7b_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_farming_daily_7b_name&quot;>Celestial Bloom&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="233"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_farming_daily_7c_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_farming_daily_7c_name&quot;>Golden Wheat&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="234"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_farming_daily_7d_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_farming_daily_7d_name&quot;>Starfruit Delivery&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="235"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_farming_daily_7e_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_farming_daily_7e_name&quot;>Void Lotus&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="236"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_firemaking_daily_1a_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_firemaking_daily_1a_name&quot;>Log Burn&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="237"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_firemaking_daily_1b_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_firemaking_daily_1b_name&quot;>Oak Pyre&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="238"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_firemaking_daily_1c_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_firemaking_daily_1c_name&quot;>Willow Fire&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="239"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_firemaking_daily_1d_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_firemaking_daily_1d_name&quot;>Ember Stockpile&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="240"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_firemaking_daily_1e_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_firemaking_daily_1e_name&quot;>Maple Blaze&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="241"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_firemaking_daily_4a_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_firemaking_daily_4a_name&quot;>Yew Inferno&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="242"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_firemaking_daily_4b_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_firemaking_daily_4b_name&quot;>Magic Pyre&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="243"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_firemaking_daily_4c_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_firemaking_daily_4c_name&quot;>Maple Surplus&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="244"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_firemaking_daily_4d_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_firemaking_daily_4d_name&quot;>Yew Reserve&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="245"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_firemaking_daily_4e_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_firemaking_daily_4e_name&quot;>Magic Surge&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="246"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_firemaking_daily_7a_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_firemaking_daily_7a_name&quot;>Redwood Bonfire&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="247"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_firemaking_daily_7b_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_firemaking_daily_7b_name&quot;>Redwood Reserve&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="248"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_firemaking_daily_7c_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_firemaking_daily_7c_name&quot;>Ancient Flame&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="249"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_firemaking_daily_7d_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_firemaking_daily_7d_name&quot;>Eternal Blaze&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="250"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_firemaking_daily_7e_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_firemaking_daily_7e_name&quot;>Grand Pyre&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="251"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_fishing_daily_1a_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_fishing_daily_1a_name&quot;>Shrimp Haul&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="252"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_fishing_daily_1b_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_fishing_daily_1b_name&quot;>Trout Run&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="253"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_fishing_daily_1c_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_fishing_daily_1c_name&quot;>Salmon Batch&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="254"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_fishing_daily_1d_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_fishing_daily_1d_name&quot;>Sardine Catch&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="255"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_fishing_daily_1e_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_fishing_daily_1e_name&quot;>Tuna Delivery&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="256"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_fishing_daily_4a_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_fishing_daily_4a_name&quot;>Lobster Catch&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="257"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_fishing_daily_4b_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_fishing_daily_4b_name&quot;>Swordfish Run&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="258"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_fishing_daily_4c_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_fishing_daily_4c_name&quot;>Monkfish Haul&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="259"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_fishing_daily_4d_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_fishing_daily_4d_name&quot;>Tuna Surplus&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="260"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_fishing_daily_4e_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_fishing_daily_4e_name&quot;>Salmon Reserve&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="261"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_fishing_daily_7a_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_fishing_daily_7a_name&quot;>Shark Hunt&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="262"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_fishing_daily_7b_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_fishing_daily_7b_name&quot;>Manta Haul&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="263"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_fishing_daily_7c_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_fishing_daily_7c_name&quot;>Shark Surge&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="264"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_fishing_daily_7d_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_fishing_daily_7d_name&quot;>Sea Turtle Catch&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="265"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_fishing_daily_7e_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_fishing_daily_7e_name&quot;>Manta Stockpile&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="266"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_fletching_daily_1a_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_fletching_daily_1a_name&quot;>Arrow Shafts&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="267"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_fletching_daily_1b_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_fletching_daily_1b_name&quot;>Bronze Volley&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="268"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_fletching_daily_1c_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_fletching_daily_1c_name&quot;>Iron Arrows&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="269"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_fletching_daily_1d_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_fletching_daily_1d_name&quot;>Shortbow Run&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="270"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_fletching_daily_1e_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_fletching_daily_1e_name&quot;>Steel Flight&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="271"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_fletching_daily_4a_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_fletching_daily_4a_name&quot;>Mithril Volley&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="272"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_fletching_daily_4b_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_fletching_daily_4b_name&quot;>Adamantite Quiver&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="273"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_fletching_daily_4c_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_fletching_daily_4c_name&quot;>Runite Arrows&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="274"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_fletching_daily_4d_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_fletching_daily_4d_name&quot;>Yew Shortbow&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="275"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_fletching_daily_4e_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_fletching_daily_4e_name&quot;>Magic Shortbow&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="276"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_fletching_daily_7a_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_fletching_daily_7a_name&quot;>Yew Longbows&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="277"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_fletching_daily_7b_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_fletching_daily_7b_name&quot;>Magic Longbows&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="278"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_fletching_daily_7c_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_fletching_daily_7c_name&quot;>Runite Quiver&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="279"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_fletching_daily_7d_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_fletching_daily_7d_name&quot;>Grand Arsenal&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="280"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_herblore_daily_1a_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_herblore_daily_1a_name&quot;>Attack Brews&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="281"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_herblore_daily_1b_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_herblore_daily_1b_name&quot;>Defence Brews&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="282"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_herblore_daily_1c_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_herblore_daily_1c_name&quot;>Strength Brews&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="283"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_herblore_daily_1d_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_herblore_daily_1d_name&quot;>Attack Potions&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="284"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_herblore_daily_1e_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_herblore_daily_1e_name&quot;>Strength Potions&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="285"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_herblore_daily_4a_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_herblore_daily_4a_name&quot;>Ranging Potions&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="286"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_herblore_daily_4b_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_herblore_daily_4b_name&quot;>Magic Potions&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="287"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_herblore_daily_4c_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_herblore_daily_4c_name&quot;>Super Strength&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="288"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_herblore_daily_4d_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_herblore_daily_4d_name&quot;>Super Ranging&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="289"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_herblore_daily_4e_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_herblore_daily_4e_name&quot;>Super Magic&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="290"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_herblore_daily_7a_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_herblore_daily_7a_name&quot;>Overload Batch&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="291"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_herblore_daily_7b_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_herblore_daily_7b_name&quot;>Overload Reserve&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="292"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_herblore_daily_7c_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_herblore_daily_7c_name&quot;>Grand Stockpile&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="293"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_mages_daily_1a_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_mages_daily_1a_name&quot;>Spell Practice&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="294"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_mages_daily_1b_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_mages_daily_1b_name&quot;>Arcane Duty&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="295"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_mages_daily_1c_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_mages_daily_1c_name&quot;>Daily Spellwork&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="296"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_mages_daily_1d_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_mages_daily_1d_name&quot;>Sorcerer\&apos;s Call&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="297"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_mages_daily_4a_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_mages_daily_4a_name&quot;>Warlock Raid&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="298"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_mages_daily_4b_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_mages_daily_4b_name&quot;>Archmage Duty&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="299"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_mages_daily_4c_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_mages_daily_4c_name&quot;>Grand Spellwork&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="300"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_mages_daily_7a_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_mages_daily_7a_name&quot;>Lich Raid&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="301"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_mages_daily_7b_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_mages_daily_7b_name&quot;>Grand Magus Duty&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="302"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_mages_daily_7c_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_mages_daily_7c_name&quot;>Arcane Conquest&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="303"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_mercantile_daily_1a_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_mercantile_daily_1a_name&quot;>Quick Deal&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="304"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_mercantile_daily_1b_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_mercantile_daily_1b_name&quot;>Market Run&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="305"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_mercantile_daily_1c_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_mercantile_daily_1c_name&quot;>Busy Day&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="306"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_mercantile_daily_1d_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_mercantile_daily_1d_name&quot;>Coin Earner&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="307"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_mercantile_daily_1e_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_mercantile_daily_1e_name&quot;>Market Profits&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="308"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_mercantile_daily_4a_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_mercantile_daily_4a_name&quot;>Active Trader&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="309"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_mercantile_daily_4b_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_mercantile_daily_4b_name&quot;>High Volume&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="310"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_mercantile_daily_4c_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_mercantile_daily_4c_name&quot;>Port Connections&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="311"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_mercantile_daily_4d_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_mercantile_daily_4d_name&quot;>Coin Haul&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="312"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_mercantile_daily_4e_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_mercantile_daily_4e_name&quot;>Profit Drive&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="313"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_mercantile_daily_7a_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_mercantile_daily_7a_name&quot;>Grand Trade&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="314"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_mercantile_daily_7b_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_mercantile_daily_7b_name&quot;>Elite Routes&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="315"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_mercantile_daily_7c_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_mercantile_daily_7c_name&quot;>Exchange Master&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="316"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_mercantile_daily_7d_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_mercantile_daily_7d_name&quot;>Fortune Run&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="317"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_mercantile_daily_7e_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_mercantile_daily_7e_name&quot;>Grand Profit&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="318"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_mining_daily_1a_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_mining_daily_1a_name&quot;>Iron Delivery&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="319"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_mining_daily_1b_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_mining_daily_1b_name&quot;>Copper Quota&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="320"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_mining_daily_1c_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_mining_daily_1c_name&quot;>Coal Run&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="321"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_mining_daily_1d_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_mining_daily_1d_name&quot;>Tin Supply&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="322"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_mining_daily_1e_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_mining_daily_1e_name&quot;>Silver Find&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="323"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_mining_daily_4a_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_mining_daily_4a_name&quot;>Mithril Batch&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="324"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_mining_daily_4b_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_mining_daily_4b_name&quot;>Gold Haul&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="325"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_mining_daily_4c_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_mining_daily_4c_name&quot;>Adamantite Run&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="326"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_mining_daily_4d_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_mining_daily_4d_name&quot;>Coal Reserve&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="327"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_mining_daily_4e_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_mining_daily_4e_name&quot;>Iron Surplus&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="328"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_mining_daily_7a_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_mining_daily_7a_name&quot;>Platinum Run&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="329"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_mining_daily_7b_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_mining_daily_7b_name&quot;>Runite Quota&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="330"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_mining_daily_7c_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_mining_daily_7c_name&quot;>Adamantite Surge&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="331"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_mining_daily_7d_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_mining_daily_7d_name&quot;>Platinum Stockpile&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="332"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_mining_daily_7e_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_mining_daily_7e_name&quot;>Deep Haul&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="333"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_prayer_daily_1a_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_prayer_daily_1a_name&quot;>Morning Offering&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="334"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_prayer_daily_1b_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_prayer_daily_1b_name&quot;>Daily Rites&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="335"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_prayer_daily_1c_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_prayer_daily_1c_name&quot;>Sacred Offering&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="336"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_prayer_daily_1d_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_prayer_daily_1d_name&quot;>Pious Duty&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="337"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_prayer_daily_4a_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_prayer_daily_4a_name&quot;>Holy Rites&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="338"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_prayer_daily_4b_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_prayer_daily_4b_name&quot;>Sacred Rites&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="339"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_prayer_daily_4c_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_prayer_daily_4c_name&quot;>Grand Offering&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="340"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_prayer_daily_7a_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_prayer_daily_7a_name&quot;>Divine Offering&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="341"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_prayer_daily_7b_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_prayer_daily_7b_name&quot;>Transcendent Rites&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="342"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_prayer_daily_7c_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_prayer_daily_7c_name&quot;>Grand Piety&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="343"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_runecrafting_daily_1a_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_runecrafting_daily_1a_name&quot;>Air Runes&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="344"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_runecrafting_daily_1b_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_runecrafting_daily_1b_name&quot;>Water Runes&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="345"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_runecrafting_daily_1c_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_runecrafting_daily_1c_name&quot;>Earth Runes&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="346"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_runecrafting_daily_1d_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_runecrafting_daily_1d_name&quot;>Fire Runes&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="347"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_runecrafting_daily_1e_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_runecrafting_daily_1e_name&quot;>Mind Runes&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="348"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_runecrafting_daily_4a_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_runecrafting_daily_4a_name&quot;>Chaos Batch&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="349"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_runecrafting_daily_4b_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_runecrafting_daily_4b_name&quot;>Death Batch&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="350"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_runecrafting_daily_4c_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_runecrafting_daily_4c_name&quot;>Blood Reserve&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="351"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_runecrafting_daily_4d_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_runecrafting_daily_4d_name&quot;>Death Reserve&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="352"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_runecrafting_daily_4e_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_runecrafting_daily_4e_name&quot;>Blood Batch&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="353"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_runecrafting_daily_7a_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_runecrafting_daily_7a_name&quot;>Blood Vault&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="354"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_runecrafting_daily_7b_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_runecrafting_daily_7b_name&quot;>Arcane Reserve&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="355"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_runecrafting_daily_7c_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_runecrafting_daily_7c_name&quot;>Grand Stockpile&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="356"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_smithing_daily_1a_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_smithing_daily_1a_name&quot;>Bronze Batch&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="357"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_smithing_daily_1b_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_smithing_daily_1b_name&quot;>Iron Run&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="358"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_smithing_daily_1c_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_smithing_daily_1c_name&quot;>Steel Delivery&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="359"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_smithing_daily_1d_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_smithing_daily_1d_name&quot;>Iron Surplus&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="360"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_smithing_daily_1e_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_smithing_daily_1e_name&quot;>Steel Reserve&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="361"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_smithing_daily_4a_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_smithing_daily_4a_name&quot;>Mithril Batch&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="362"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_smithing_daily_4b_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_smithing_daily_4b_name&quot;>Adamantite Run&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="363"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_smithing_daily_4c_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_smithing_daily_4c_name&quot;>Platinum Batch&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="364"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_smithing_daily_4d_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_smithing_daily_4d_name&quot;>Mithril Reserve&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="365"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_smithing_daily_4e_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_smithing_daily_4e_name&quot;>Adamantite Reserve&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="366"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_smithing_daily_7a_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_smithing_daily_7a_name&quot;>Runite Batch&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="367"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_smithing_daily_7b_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_smithing_daily_7b_name&quot;>Runite Reserve&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="368"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_smithing_daily_7c_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_smithing_daily_7c_name&quot;>Platinum Vault&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="369"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_smithing_daily_7d_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_smithing_daily_7d_name&quot;>Grand Forge&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="370"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_warriors_daily_1a_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_warriors_daily_1a_name&quot;>First Skirmish&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="371"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_warriors_daily_1b_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_warriors_daily_1b_name&quot;>Daily Raid&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="372"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_warriors_daily_1c_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_warriors_daily_1c_name&quot;>Warrior\&apos;s Duty&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="373"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_warriors_daily_1d_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_warriors_daily_1d_name&quot;>Combat Practice&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="374"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_warriors_daily_4a_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_warriors_daily_4a_name&quot;>Elite Raid&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="375"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_warriors_daily_4b_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_warriors_daily_4b_name&quot;>Veteran\&apos;s Duty&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="376"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_warriors_daily_4c_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_warriors_daily_4c_name&quot;>Champion\&apos;s March&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="377"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_warriors_daily_7a_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_warriors_daily_7a_name&quot;>Warlord\&apos;s Raid&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="378"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_warriors_daily_7b_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_warriors_daily_7b_name&quot;>Conqueror\&apos;s March&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="379"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_warriors_daily_7c_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_warriors_daily_7c_name&quot;>Grand Battle&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="380"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_woodcutting_daily_1a_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_woodcutting_daily_1a_name&quot;>Log Supply&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="381"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_woodcutting_daily_1b_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_woodcutting_daily_1b_name&quot;>Oak Run&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="382"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_woodcutting_daily_1c_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_woodcutting_daily_1c_name&quot;>Willow Batch&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="383"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_woodcutting_daily_1d_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_woodcutting_daily_1d_name&quot;>Oak Surplus&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="384"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_woodcutting_daily_1e_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_woodcutting_daily_1e_name&quot;>Willow Reserve&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="385"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_woodcutting_daily_4a_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_woodcutting_daily_4a_name&quot;>Maple Batch&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="386"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_woodcutting_daily_4b_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_woodcutting_daily_4b_name&quot;>Yew Run&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="387"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_woodcutting_daily_4c_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_woodcutting_daily_4c_name&quot;>Magic Timber&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="388"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_woodcutting_daily_4d_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_woodcutting_daily_4d_name&quot;>Maple Surplus&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="389"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_woodcutting_daily_4e_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_woodcutting_daily_4e_name&quot;>Yew Reserve&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="390"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_woodcutting_daily_7a_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_woodcutting_daily_7a_name&quot;>Magic Haul&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="391"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_woodcutting_daily_7b_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_woodcutting_daily_7b_name&quot;>Redwood Run&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="392"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_woodcutting_daily_7c_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_woodcutting_daily_7c_name&quot;>Ancient Timber&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="393"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_woodcutting_daily_7d_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_woodcutting_daily_7d_name&quot;>Redwood Stockpile&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="394"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_woodcutting_daily_7e_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_woodcutting_daily_7e_name&quot;>Master Timber&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_guild_quests.xml"
+            line="395"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_copper_ore_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_copper_ore_name&quot;>Copper Ore&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="4"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_copper_ore_desc` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_copper_ore_desc&quot;>Common ore. Combine with tin ore to smelt bronze bars.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="5"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_tin_ore_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_tin_ore_name&quot;>Tin Ore&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="6"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_tin_ore_desc` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_tin_ore_desc&quot;>Common ore. Combine with copper ore to smelt bronze bars.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="7"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_iron_ore_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_iron_ore_name&quot;>Iron Ore&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="8"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_iron_ore_desc` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_iron_ore_desc&quot;>Versatile ore used to smelt iron and steel bars.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="9"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_coal_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_coal_name&quot;>Coal&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="10"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_coal_desc` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_coal_desc&quot;>Used as a fuel component when smelting steel and higher-tier bars.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="11"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_silver_ore_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_silver_ore_name&quot;>Silver Ore&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="12"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_silver_ore_desc` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_silver_ore_desc&quot;>Precious ore used to craft silver bars and jewellery.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="13"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_gold_ore_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_gold_ore_name&quot;>Gold Ore&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="14"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_gold_ore_desc` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_gold_ore_desc&quot;>Precious ore used to craft gold bars and jewellery.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="15"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_mithril_ore_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_mithril_ore_name&quot;>Mithril Ore&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="16"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_mithril_ore_desc` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_mithril_ore_desc&quot;>A rare ore with magical properties.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="17"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_adamantite_ore_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_adamantite_ore_name&quot;>Adamantite Ore&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="18"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_adamantite_ore_desc` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_adamantite_ore_desc&quot;>Extremely hard and very rare ore.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="19"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_runite_ore_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_runite_ore_name&quot;>Runite Ore&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="20"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_runite_ore_desc` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_runite_ore_desc&quot;>The rarest mineable ore, used for the strongest equipment.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="21"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_rune_essence_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_rune_essence_name&quot;>Rune Essence&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="22"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_rune_essence_desc` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_rune_essence_desc&quot;>Raw magical stone used to craft all types of runes.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="23"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_bronze_bar_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_bronze_bar_name&quot;>Bronze Bar&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="26"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_bronze_bar_desc` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_bronze_bar_desc&quot;>Smelted from copper ore and tin ore. The most basic metal bar.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="27"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_iron_bar_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_iron_bar_name&quot;>Iron Bar&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="28"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_iron_bar_desc` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_iron_bar_desc&quot;>A sturdy iron bar used for crafting iron equipment.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="29"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_silver_bar_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_silver_bar_name&quot;>Silver Bar&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="30"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_silver_bar_desc` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_silver_bar_desc&quot;>Refined silver bar used for crafting jewellery.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="31"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_steel_bar_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_steel_bar_name&quot;>Steel Bar&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="32"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_steel_bar_desc` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_steel_bar_desc&quot;>Stronger than iron. Used for crafting steel equipment.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="33"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_gold_bar_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_gold_bar_name&quot;>Gold Bar&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="34"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_gold_bar_desc` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_gold_bar_desc&quot;>Refined gold bar used for crafting jewellery and gold equipment.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="35"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_mithril_bar_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_mithril_bar_name&quot;>Mithril Bar&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="36"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_mithril_bar_desc` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_mithril_bar_desc&quot;>A lightweight magical metal bar.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="37"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_adamantite_bar_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_adamantite_bar_name&quot;>Adamantite Bar&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="38"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_adamantite_bar_desc` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_adamantite_bar_desc&quot;>An extraordinarily hard metal bar.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="39"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_platinum_bar_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_platinum_bar_name&quot;>Platinum Bar&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="40"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_platinum_bar_desc` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_platinum_bar_desc&quot;>A rare and lustrous platinum bar for high-tier jewellery.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="41"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_runite_bar_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_runite_bar_name&quot;>Runite Bar&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="42"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_runite_bar_desc` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_runite_bar_desc&quot;>The strongest smeltable metal bar.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="43"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_sapphire_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_sapphire_name&quot;>Sapphire&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="46"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_sapphire_desc` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_sapphire_desc&quot;>A blue gemstone used in jewellery crafting.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="47"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_emerald_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_emerald_name&quot;>Emerald&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="48"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_emerald_desc` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_emerald_desc&quot;>A green gemstone of moderate rarity.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="49"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_ruby_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_ruby_name&quot;>Ruby&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="50"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_ruby_desc` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_ruby_desc&quot;>A red gemstone. Rare and valuable.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="51"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_diamond_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_diamond_name&quot;>Diamond&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="52"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_diamond_desc` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_diamond_desc&quot;>The rarest and most valuable gemstone.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="53"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_log_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_log_name&quot;>Logs&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="56"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_log_desc` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_log_desc&quot;>Basic logs from normal trees. Used in Firemaking and Fletching.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="57"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_oak_log_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_oak_log_name&quot;>Oak Logs&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="58"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_oak_log_desc` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_oak_log_desc&quot;>Logs from oak trees.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="59"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_willow_log_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_willow_log_name&quot;>Willow Logs&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="60"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_willow_log_desc` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_willow_log_desc&quot;>Lightweight logs from willow trees.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="61"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_maple_log_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_maple_log_name&quot;>Maple Logs&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="62"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_maple_log_desc` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_maple_log_desc&quot;>Dense logs from maple trees.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="63"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_yew_log_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_yew_log_name&quot;>Yew Logs&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="64"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_yew_log_desc` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_yew_log_desc&quot;>Logs from ancient yew trees.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="65"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_magic_log_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_magic_log_name&quot;>Magic Logs&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="66"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_magic_log_desc` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_magic_log_desc&quot;>Imbued logs from rare magic trees.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="67"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_redwood_log_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_redwood_log_name&quot;>Redwood Logs&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="68"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_redwood_log_desc` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_redwood_log_desc&quot;>Massive logs from the tallest redwood trees.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="69"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_raw_shrimp_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_raw_shrimp_name&quot;>Raw Shrimp&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="72"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_raw_shrimp_desc` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_raw_shrimp_desc&quot;>Raw shrimp. Cook before eating.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="73"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_raw_sardine_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_raw_sardine_name&quot;>Raw Sardine&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="74"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_raw_sardine_desc` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_raw_sardine_desc&quot;>Raw sardine. Cook before eating.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="75"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_raw_herring_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_raw_herring_name&quot;>Raw Herring&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="76"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_raw_herring_desc` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_raw_herring_desc&quot;>Raw herring. Cook before eating.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="77"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_raw_mackerel_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_raw_mackerel_name&quot;>Raw Mackerel&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="78"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_raw_mackerel_desc` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_raw_mackerel_desc&quot;>Raw mackerel. Cook before eating.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="79"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_raw_trout_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_raw_trout_name&quot;>Raw Trout&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="80"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_raw_trout_desc` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_raw_trout_desc&quot;>Raw trout. Cook before eating.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="81"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_raw_salmon_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_raw_salmon_name&quot;>Raw Salmon&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="82"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_raw_salmon_desc` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_raw_salmon_desc&quot;>Raw salmon. Cook before eating.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="83"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_raw_tuna_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_raw_tuna_name&quot;>Raw Tuna&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="84"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_raw_tuna_desc` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_raw_tuna_desc&quot;>Raw tuna. Cook before eating.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="85"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_raw_lobster_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_raw_lobster_name&quot;>Raw Lobster&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="86"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_raw_lobster_desc` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_raw_lobster_desc&quot;>Raw lobster. Cook before eating.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="87"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_raw_swordfish_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_raw_swordfish_name&quot;>Raw Swordfish&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="88"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_raw_swordfish_desc` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_raw_swordfish_desc&quot;>Raw swordfish. Cook before eating.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="89"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_raw_monkfish_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_raw_monkfish_name&quot;>Raw Monkfish&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="90"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_raw_monkfish_desc` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_raw_monkfish_desc&quot;>Raw monkfish. Cook before eating.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="91"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_raw_shark_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_raw_shark_name&quot;>Raw Shark&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="92"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_raw_shark_desc` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_raw_shark_desc&quot;>Raw shark. Cook before eating.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="93"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_raw_sea_turtle_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_raw_sea_turtle_name&quot;>Raw Sea Turtle&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="94"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_raw_sea_turtle_desc` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_raw_sea_turtle_desc&quot;>Raw sea turtle. Cook before eating.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="95"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_raw_manta_ray_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_raw_manta_ray_name&quot;>Raw Manta Ray&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="96"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_raw_manta_ray_desc` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_raw_manta_ray_desc&quot;>Raw manta ray. Cook before eating.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="97"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_shrimp_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_shrimp_name&quot;>Shrimp&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="100"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_shrimp_desc` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_shrimp_desc&quot;>Cooked shrimp. Restores a small amount of HP.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="101"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_sardine_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_sardine_name&quot;>Sardine&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="102"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_sardine_desc` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_sardine_desc&quot;>Cooked sardine. Restores HP when eaten.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="103"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_herring_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_herring_name&quot;>Herring&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="104"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_herring_desc` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_herring_desc&quot;>Cooked herring. Restores HP when eaten.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="105"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_mackerel_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_mackerel_name&quot;>Mackerel&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="106"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_mackerel_desc` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_mackerel_desc&quot;>Cooked mackerel. Restores HP when eaten.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="107"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_trout_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_trout_name&quot;>Trout&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="108"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_trout_desc` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_trout_desc&quot;>Cooked trout. Restores HP when eaten.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="109"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_salmon_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_salmon_name&quot;>Salmon&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="110"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_salmon_desc` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_salmon_desc&quot;>Cooked salmon. Restores HP when eaten.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="111"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_tuna_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_tuna_name&quot;>Tuna&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="112"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_tuna_desc` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_tuna_desc&quot;>Cooked tuna. Restores HP when eaten.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="113"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_lobster_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_lobster_name&quot;>Lobster&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="114"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_lobster_desc` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_lobster_desc&quot;>Cooked lobster. Restores a good amount of HP.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="115"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_swordfish_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_swordfish_name&quot;>Swordfish&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="116"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_swordfish_desc` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_swordfish_desc&quot;>Cooked swordfish. Restores a significant amount of HP.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="117"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_monkfish_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_monkfish_name&quot;>Monkfish&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="118"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_monkfish_desc` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_monkfish_desc&quot;>Cooked monkfish. Restores a solid amount of HP.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="119"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_shark_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_shark_name&quot;>Shark&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="120"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_shark_desc` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_shark_desc&quot;>Cooked shark. Restores a large amount of HP.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="121"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_sea_turtle_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_sea_turtle_name&quot;>Sea Turtle&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="122"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_sea_turtle_desc` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_sea_turtle_desc&quot;>Cooked sea turtle. Restores a very large amount of HP.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="123"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_manta_ray_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_manta_ray_name&quot;>Manta Ray&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="124"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_manta_ray_desc` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_manta_ray_desc&quot;>Cooked manta ray. One of the best food items available.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="125"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_raw_rat_meat_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_raw_rat_meat_name&quot;>Raw Rat Meat&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="128"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_raw_rat_meat_desc` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_raw_rat_meat_desc&quot;>Raw rat meat. Cook before eating.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="129"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_raw_chicken_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_raw_chicken_name&quot;>Raw Chicken&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="130"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_raw_chicken_desc` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_raw_chicken_desc&quot;>Raw chicken. Cook before eating.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="131"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_raw_mutton_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_raw_mutton_name&quot;>Raw Mutton&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="132"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_raw_mutton_desc` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_raw_mutton_desc&quot;>Raw mutton. Cook before eating.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="133"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_raw_beef_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_raw_beef_name&quot;>Raw Beef&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="134"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_raw_beef_desc` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_raw_beef_desc&quot;>Raw beef. Cook before eating.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="135"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_raw_meat_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_raw_meat_name&quot;>Raw Meat&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="136"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_raw_meat_desc` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_raw_meat_desc&quot;>Unidentified raw meat. Cook before eating.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="137"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_cooked_rat_meat_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_cooked_rat_meat_name&quot;>Rat Meat&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="140"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_cooked_rat_meat_desc` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_cooked_rat_meat_desc&quot;>Cooked rat meat. Barely edible, but restores a tiny amount of HP.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="141"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_cooked_chicken_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_cooked_chicken_name&quot;>Cooked Chicken&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="142"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_cooked_chicken_desc` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_cooked_chicken_desc&quot;>Cooked chicken. Restores HP when eaten.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="143"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_cooked_mutton_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_cooked_mutton_name&quot;>Cooked Mutton&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="144"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_cooked_mutton_desc` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_cooked_mutton_desc&quot;>Cooked mutton. Restores HP when eaten.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="145"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_cooked_beef_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_cooked_beef_name&quot;>Cooked Beef&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="146"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_cooked_beef_desc` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_cooked_beef_desc&quot;>Cooked beef. Restores HP when eaten.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="147"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_bronze_sword_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_bronze_sword_name&quot;>Bronze Sword&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="150"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_bronze_sword_desc` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_bronze_sword_desc&quot;>A basic one-handed bronze blade.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="151"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_bronze_scimitar_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_bronze_scimitar_name&quot;>Bronze Scimitar&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="152"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_bronze_scimitar_desc` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_bronze_scimitar_desc&quot;>A curved one-handed bronze blade with good strength bonus.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="153"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_bronze_2h_sword_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_bronze_2h_sword_name&quot;>Bronze 2H Sword&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="154"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_bronze_2h_sword_desc` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_bronze_2h_sword_desc&quot;>A two-handed bronze sword. High damage, slow speed.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="155"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_bronze_warhammer_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_bronze_warhammer_name&quot;>Bronze Warhammer&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="156"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_bronze_warhammer_desc` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_bronze_warhammer_desc&quot;>A heavy one-handed bronze hammer.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="157"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_bronze_battleaxe_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_bronze_battleaxe_name&quot;>Bronze Battleaxe&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="158"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_bronze_battleaxe_desc` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_bronze_battleaxe_desc&quot;>A fearsome one-handed bronze axe.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="159"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_bronze_dagger_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_bronze_dagger_name&quot;>Bronze Dagger&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="160"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_bronze_dagger_desc` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_bronze_dagger_desc&quot;>A quick and lightweight bronze dagger.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="161"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_iron_sword_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_iron_sword_name&quot;>Iron Sword&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="164"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_iron_sword_desc` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_iron_sword_desc&quot;>A one-handed iron blade.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="165"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_iron_scimitar_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_iron_scimitar_name&quot;>Iron Scimitar&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="166"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_iron_scimitar_desc` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_iron_scimitar_desc&quot;>A curved one-handed iron blade with good strength bonus.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="167"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_iron_2h_sword_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_iron_2h_sword_name&quot;>Iron 2H Sword&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="168"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_iron_2h_sword_desc` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_iron_2h_sword_desc&quot;>A two-handed iron sword.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="169"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_iron_warhammer_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_iron_warhammer_name&quot;>Iron Warhammer&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="170"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_iron_warhammer_desc` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_iron_warhammer_desc&quot;>A heavy one-handed iron hammer.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="171"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_iron_battleaxe_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_iron_battleaxe_name&quot;>Iron Battleaxe&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="172"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_iron_battleaxe_desc` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_iron_battleaxe_desc&quot;>A fearsome one-handed iron axe.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="173"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_iron_dagger_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_iron_dagger_name&quot;>Iron Dagger&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="174"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_iron_dagger_desc` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_iron_dagger_desc&quot;>A quick and lightweight iron dagger.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="175"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_steel_sword_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_steel_sword_name&quot;>Steel Sword&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="178"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_steel_sword_desc` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_steel_sword_desc&quot;>A one-handed steel blade.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="179"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_steel_scimitar_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_steel_scimitar_name&quot;>Steel Scimitar&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="180"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_steel_scimitar_desc` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_steel_scimitar_desc&quot;>A curved one-handed steel blade with good strength bonus.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="181"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_steel_2h_sword_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_steel_2h_sword_name&quot;>Steel 2H Sword&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="182"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_steel_2h_sword_desc` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_steel_2h_sword_desc&quot;>A two-handed steel sword.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="183"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_steel_warhammer_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_steel_warhammer_name&quot;>Steel Warhammer&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="184"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_steel_warhammer_desc` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_steel_warhammer_desc&quot;>A heavy one-handed steel hammer.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="185"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_steel_battleaxe_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_steel_battleaxe_name&quot;>Steel Battleaxe&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="186"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_steel_battleaxe_desc` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_steel_battleaxe_desc&quot;>A fearsome one-handed steel axe.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="187"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_mithril_sword_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_mithril_sword_name&quot;>Mithril Sword&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="190"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_mithril_sword_desc` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_mithril_sword_desc&quot;>A lightweight magical one-handed sword.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="191"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_mithril_scimitar_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_mithril_scimitar_name&quot;>Mithril Scimitar&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="192"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_mithril_scimitar_desc` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_mithril_scimitar_desc&quot;>A curved mithril blade, supernaturally sharp.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="193"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_mithril_2h_sword_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_mithril_2h_sword_name&quot;>Mithril 2H Sword&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="194"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_mithril_2h_sword_desc` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_mithril_2h_sword_desc&quot;>A two-handed mithril sword.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="195"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_mithril_warhammer_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_mithril_warhammer_name&quot;>Mithril Warhammer&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="196"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_mithril_warhammer_desc` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_mithril_warhammer_desc&quot;>A lightweight magical warhammer.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="197"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_mithril_battleaxe_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_mithril_battleaxe_name&quot;>Mithril Battleaxe&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="198"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_mithril_battleaxe_desc` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_mithril_battleaxe_desc&quot;>A mithril battleaxe of exceptional quality.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="199"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_adamantite_sword_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_adamantite_sword_name&quot;>Adamantite Sword&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="202"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_adamantite_sword_desc` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_adamantite_sword_desc&quot;>An extraordinarily hard one-handed sword.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="203"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_adamantite_scimitar_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_adamantite_scimitar_name&quot;>Adamantite Scimitar&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="204"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_adamantite_scimitar_desc` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_adamantite_scimitar_desc&quot;>An incredibly hard curved blade with excellent strength bonus.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="205"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_adamantite_2h_sword_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_adamantite_2h_sword_name&quot;>Adamantite 2H Sword&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="206"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_adamantite_2h_sword_desc` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_adamantite_2h_sword_desc&quot;>A two-handed sword forged from adamantite.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="207"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_adamantite_warhammer_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_adamantite_warhammer_name&quot;>Adamantite Warhammer&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="208"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_adamantite_warhammer_desc` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_adamantite_warhammer_desc&quot;>An extraordinarily heavy and hard warhammer.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="209"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_adamantite_battleaxe_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_adamantite_battleaxe_name&quot;>Adamantite Battleaxe&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="210"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_adamantite_battleaxe_desc` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_adamantite_battleaxe_desc&quot;>A devastating adamantite battleaxe.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="211"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_runite_sword_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_runite_sword_name&quot;>Runite Sword&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="214"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_runite_sword_desc` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_runite_sword_desc&quot;>The finest one-handed sword available.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="215"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_runite_scimitar_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_runite_scimitar_name&quot;>Runite Scimitar&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="216"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_runite_scimitar_desc` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_runite_scimitar_desc&quot;>The finest scimitar available, with exceptional strength bonus.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="217"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_runite_2h_sword_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_runite_2h_sword_name&quot;>Runite 2H Sword&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="218"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_runite_2h_sword_desc` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_runite_2h_sword_desc&quot;>The finest two-handed sword available.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="219"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_runite_warhammer_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_runite_warhammer_name&quot;>Runite Warhammer&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="220"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_runite_warhammer_desc` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_runite_warhammer_desc&quot;>The finest warhammer available.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="221"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_runite_battleaxe_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_runite_battleaxe_name&quot;>Runite Battleaxe&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="222"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_runite_battleaxe_desc` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_runite_battleaxe_desc&quot;>The finest battleaxe available.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="223"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_wooden_bow_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_wooden_bow_name&quot;>Wooden Bow&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="226"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_wooden_bow_desc` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_wooden_bow_desc&quot;>A simple wooden bow. Good for training Ranged.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="227"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_oak_bow_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_oak_bow_name&quot;>Oak Bow&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="228"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_oak_bow_desc` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_oak_bow_desc&quot;>A reliable bow crafted from oak wood.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="229"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_basic_staff_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_basic_staff_name&quot;>Basic Staff&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="232"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_basic_staff_desc` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_basic_staff_desc&quot;>A simple magical staff for apprentice mages.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="233"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_apprentice_staff_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_apprentice_staff_name&quot;>Apprentice Staff&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="234"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_apprentice_staff_desc` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_apprentice_staff_desc&quot;>An improved staff for developing mages.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="235"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_staff_of_air_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_staff_of_air_name&quot;>Staff of Air&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="236"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_staff_of_air_desc` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_staff_of_air_desc&quot;>An elemental staff imbued with the power of air.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="237"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_staff_of_water_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_staff_of_water_name&quot;>Staff of Water&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="238"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_staff_of_water_desc` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_staff_of_water_desc&quot;>An elemental staff imbued with the power of water.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="239"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_staff_of_earth_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_staff_of_earth_name&quot;>Staff of Earth&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="240"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_staff_of_earth_desc` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_staff_of_earth_desc&quot;>An elemental staff imbued with the power of earth.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="241"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_staff_of_fire_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_staff_of_fire_name&quot;>Staff of Fire&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="242"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_staff_of_fire_desc` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_staff_of_fire_desc&quot;>An elemental staff imbued with the power of fire.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="243"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_staff_of_mind_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_staff_of_mind_name&quot;>Staff of Mind&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="244"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_staff_of_mind_desc` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_staff_of_mind_desc&quot;>A staff imbued with psychic energy.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="245"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_staff_of_chaos_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_staff_of_chaos_name&quot;>Staff of Chaos&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="246"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_staff_of_chaos_desc` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_staff_of_chaos_desc&quot;>A chaotic staff pulsing with wild magical energy.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="247"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_staff_of_death_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_staff_of_death_name&quot;>Staff of Death&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="248"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_staff_of_death_desc` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_staff_of_death_desc&quot;>A dark staff wreathed in the power of death.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="249"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_staff_of_blood_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_staff_of_blood_name&quot;>Staff of Blood&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="250"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_staff_of_blood_desc` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_staff_of_blood_desc&quot;>A powerful staff fuelled by blood magic.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="251"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_bronze_helmet_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_bronze_helmet_name&quot;>Bronze Helmet&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="254"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_bronze_helmet_desc` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_bronze_helmet_desc&quot;>Basic bronze head protection.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="255"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_bronze_platebody_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_bronze_platebody_name&quot;>Bronze Platebody&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="256"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_bronze_platebody_desc` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_bronze_platebody_desc&quot;>Basic bronze body armour.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="257"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_bronze_platelegs_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_bronze_platelegs_name&quot;>Bronze Platelegs&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="258"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_bronze_platelegs_desc` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_bronze_platelegs_desc&quot;>Basic bronze leg protection.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="259"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_bronze_shield_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_bronze_shield_name&quot;>Bronze Shield&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="260"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_bronze_shield_desc` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_bronze_shield_desc&quot;>A basic bronze shield.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="261"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_iron_helmet_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_iron_helmet_name&quot;>Iron Helmet&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="264"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_iron_helmet_desc` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_iron_helmet_desc&quot;>Iron head protection.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="265"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_iron_platebody_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_iron_platebody_name&quot;>Iron Platebody&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="266"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_iron_platebody_desc` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_iron_platebody_desc&quot;>Iron body armour.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="267"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_iron_platelegs_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_iron_platelegs_name&quot;>Iron Platelegs&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="268"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_iron_platelegs_desc` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_iron_platelegs_desc&quot;>Iron leg protection.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="269"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_iron_shield_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_iron_shield_name&quot;>Iron Shield&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="270"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_iron_shield_desc` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_iron_shield_desc&quot;>An iron shield.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="271"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_steel_helmet_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_steel_helmet_name&quot;>Steel Helmet&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="274"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_steel_helmet_desc` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_steel_helmet_desc&quot;>Sturdy steel head protection.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="275"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_steel_platebody_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_steel_platebody_name&quot;>Steel Platebody&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="276"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_steel_platebody_desc` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_steel_platebody_desc&quot;>Sturdy steel body armour.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="277"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_steel_platelegs_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_steel_platelegs_name&quot;>Steel Platelegs&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="278"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_steel_platelegs_desc` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_steel_platelegs_desc&quot;>Sturdy steel leg protection.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="279"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_steel_shield_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_steel_shield_name&quot;>Steel Shield&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="280"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_steel_shield_desc` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_steel_shield_desc&quot;>A sturdy steel shield.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="281"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_mithril_helmet_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_mithril_helmet_name&quot;>Mithril Helmet&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="284"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_mithril_helmet_desc` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_mithril_helmet_desc&quot;>Lightweight magical head protection.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="285"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_mithril_platebody_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_mithril_platebody_name&quot;>Mithril Platebody&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="286"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_mithril_platebody_desc` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_mithril_platebody_desc&quot;>Lightweight magical body armour.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="287"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_mithril_platelegs_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_mithril_platelegs_name&quot;>Mithril Platelegs&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="288"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_mithril_platelegs_desc` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_mithril_platelegs_desc&quot;>Lightweight magical leg protection.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="289"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_mithril_shield_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_mithril_shield_name&quot;>Mithril Shield&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="290"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_mithril_shield_desc` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_mithril_shield_desc&quot;>A lightweight magical shield.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="291"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_adamantite_helmet_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_adamantite_helmet_name&quot;>Adamantite Helmet&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="294"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_adamantite_helmet_desc` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_adamantite_helmet_desc&quot;>Extremely hard head protection.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="295"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_adamantite_platebody_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_adamantite_platebody_name&quot;>Adamantite Platebody&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="296"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_adamantite_platebody_desc` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_adamantite_platebody_desc&quot;>Extremely hard body armour.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="297"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_adamantite_platelegs_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_adamantite_platelegs_name&quot;>Adamantite Platelegs&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="298"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_adamantite_platelegs_desc` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_adamantite_platelegs_desc&quot;>Extremely hard leg protection.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="299"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_adamantite_shield_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_adamantite_shield_name&quot;>Adamantite Shield&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="300"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_adamantite_shield_desc` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_adamantite_shield_desc&quot;>An extremely hard shield.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="301"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_runite_helmet_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_runite_helmet_name&quot;>Runite Helmet&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="304"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_runite_helmet_desc` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_runite_helmet_desc&quot;>The finest head protection available.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="305"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_runite_platebody_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_runite_platebody_name&quot;>Runite Platebody&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="306"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_runite_platebody_desc` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_runite_platebody_desc&quot;>The finest body armour available.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="307"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_runite_platelegs_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_runite_platelegs_name&quot;>Runite Platelegs&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="308"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_runite_platelegs_desc` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_runite_platelegs_desc&quot;>The finest leg protection available.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="309"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_runite_shield_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_runite_shield_name&quot;>Runite Shield&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="310"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_runite_shield_desc` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_runite_shield_desc&quot;>The finest shield available.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="311"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_bronze_pickaxe_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_bronze_pickaxe_name&quot;>Bronze Pickaxe&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="314"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_bronze_pickaxe_desc` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_bronze_pickaxe_desc&quot;>A basic pickaxe for Mining.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="315"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_iron_pickaxe_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_iron_pickaxe_name&quot;>Iron Pickaxe&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="316"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_iron_pickaxe_desc` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_iron_pickaxe_desc&quot;>A reliable pickaxe for Mining.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="317"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_steel_pickaxe_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_steel_pickaxe_name&quot;>Steel Pickaxe&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="318"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_steel_pickaxe_desc` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_steel_pickaxe_desc&quot;>A sturdy pickaxe for Mining.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="319"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_mithril_pickaxe_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_mithril_pickaxe_name&quot;>Mithril Pickaxe&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="320"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_mithril_pickaxe_desc` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_mithril_pickaxe_desc&quot;>A lightweight magical pickaxe for Mining.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="321"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_adamantite_pickaxe_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_adamantite_pickaxe_name&quot;>Adamantite Pickaxe&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="322"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_adamantite_pickaxe_desc` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_adamantite_pickaxe_desc&quot;>An extremely hard pickaxe for Mining.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="323"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_runite_pickaxe_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_runite_pickaxe_name&quot;>Runite Pickaxe&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="324"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_runite_pickaxe_desc` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_runite_pickaxe_desc&quot;>The finest pickaxe available for Mining.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="325"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_bronze_axe_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_bronze_axe_name&quot;>Bronze Axe&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="328"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_bronze_axe_desc` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_bronze_axe_desc&quot;>A basic axe for Woodcutting.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="329"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_iron_axe_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_iron_axe_name&quot;>Iron Axe&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="330"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_iron_axe_desc` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_iron_axe_desc&quot;>A reliable axe for Woodcutting.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="331"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_steel_axe_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_steel_axe_name&quot;>Steel Axe&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="332"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_steel_axe_desc` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_steel_axe_desc&quot;>A sturdy axe for Woodcutting.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="333"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_mithril_axe_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_mithril_axe_name&quot;>Mithril Axe&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="334"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_mithril_axe_desc` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_mithril_axe_desc&quot;>A lightweight magical axe for Woodcutting.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="335"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_adamantite_axe_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_adamantite_axe_name&quot;>Adamantite Axe&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="336"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_adamantite_axe_desc` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_adamantite_axe_desc&quot;>An extremely hard axe for Woodcutting.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="337"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_runite_axe_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_runite_axe_name&quot;>Runite Axe&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="338"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_runite_axe_desc` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_runite_axe_desc&quot;>The finest axe available for Woodcutting.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="339"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_bronze_fishing_rod_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_bronze_fishing_rod_name&quot;>Bronze Fishing Rod&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="342"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_bronze_fishing_rod_desc` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_bronze_fishing_rod_desc&quot;>A basic fishing rod.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="343"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_iron_fishing_rod_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_iron_fishing_rod_name&quot;>Iron Fishing Rod&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="344"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_iron_fishing_rod_desc` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_iron_fishing_rod_desc&quot;>A reliable fishing rod.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="345"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_steel_fishing_rod_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_steel_fishing_rod_name&quot;>Steel Fishing Rod&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="346"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_steel_fishing_rod_desc` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_steel_fishing_rod_desc&quot;>A sturdy fishing rod.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="347"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_mithril_fishing_rod_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_mithril_fishing_rod_name&quot;>Mithril Fishing Rod&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="348"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_mithril_fishing_rod_desc` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_mithril_fishing_rod_desc&quot;>A lightweight magical fishing rod.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="349"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_adamantite_fishing_rod_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_adamantite_fishing_rod_name&quot;>Adamantite Fishing Rod&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="350"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_adamantite_fishing_rod_desc` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_adamantite_fishing_rod_desc&quot;>An extremely durable fishing rod.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="351"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_runite_fishing_rod_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_runite_fishing_rod_name&quot;>Runite Fishing Rod&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="352"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_runite_fishing_rod_desc` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_runite_fishing_rod_desc&quot;>The finest fishing rod available.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="353"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_bronze_arrow_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_bronze_arrow_name&quot;>Bronze Arrows&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="356"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_bronze_arrow_desc` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_bronze_arrow_desc&quot;>Basic arrows for ranged combat.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="357"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_iron_arrow_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_iron_arrow_name&quot;>Iron Arrows&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="358"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_iron_arrow_desc` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_iron_arrow_desc&quot;>Iron arrows for ranged combat.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="359"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_steel_arrow_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_steel_arrow_name&quot;>Steel Arrows&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="360"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_steel_arrow_desc` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_steel_arrow_desc&quot;>Steel arrows for ranged combat.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="361"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_mithril_arrow_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_mithril_arrow_name&quot;>Mithril Arrows&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="362"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_mithril_arrow_desc` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_mithril_arrow_desc&quot;>Mithril arrows for ranged combat.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="363"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_adamantite_arrow_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_adamantite_arrow_name&quot;>Adamantite Arrows&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="364"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_adamantite_arrow_desc` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_adamantite_arrow_desc&quot;>Adamantite arrows for ranged combat.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="365"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_runite_arrow_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_runite_arrow_name&quot;>Runite Arrows&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="366"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_runite_arrow_desc` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_runite_arrow_desc&quot;>The finest arrows available.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="367"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_arrow_shaft_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_arrow_shaft_name&quot;>Arrow Shafts&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="370"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_arrow_shaft_desc` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_arrow_shaft_desc&quot;>Wooden shafts used to fletch arrows.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="371"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_bronze_arrow_tips_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_bronze_arrow_tips_name&quot;>Bronze Arrow Tips&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="372"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_bronze_arrow_tips_desc` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_bronze_arrow_tips_desc&quot;>Bronze tips for fletching bronze arrows.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="373"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_iron_arrow_tips_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_iron_arrow_tips_name&quot;>Iron Arrow Tips&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="374"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_iron_arrow_tips_desc` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_iron_arrow_tips_desc&quot;>Iron tips for fletching iron arrows.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="375"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_steel_arrow_tips_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_steel_arrow_tips_name&quot;>Steel Arrow Tips&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="376"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_steel_arrow_tips_desc` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_steel_arrow_tips_desc&quot;>Steel tips for fletching steel arrows.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="377"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_mithril_arrow_tips_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_mithril_arrow_tips_name&quot;>Mithril Arrow Tips&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="378"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_mithril_arrow_tips_desc` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_mithril_arrow_tips_desc&quot;>Mithril tips for fletching mithril arrows.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="379"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_adamantite_arrow_tips_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_adamantite_arrow_tips_name&quot;>Adamantite Arrow Tips&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="380"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_adamantite_arrow_tips_desc` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_adamantite_arrow_tips_desc&quot;>Adamantite tips for fletching adamantite arrows.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="381"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_runite_arrow_tips_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_runite_arrow_tips_name&quot;>Runite Arrow Tips&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="382"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_runite_arrow_tips_desc` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_runite_arrow_tips_desc&quot;>Runite tips for fletching runite arrows.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="383"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_silver_ring_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_silver_ring_name&quot;>Silver Ring&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="386"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_silver_ring_desc` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_silver_ring_desc&quot;>A plain silver ring.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="387"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_silver_necklace_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_silver_necklace_name&quot;>Silver Necklace&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="388"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_silver_necklace_desc` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_silver_necklace_desc&quot;>A plain silver necklace.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="389"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_gold_ring_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_gold_ring_name&quot;>Gold Ring&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="390"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_gold_ring_desc` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_gold_ring_desc&quot;>A plain gold ring.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="391"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_gold_necklace_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_gold_necklace_name&quot;>Gold Necklace&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="392"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_gold_necklace_desc` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_gold_necklace_desc&quot;>A plain gold necklace.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="393"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_platinum_ring_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_platinum_ring_name&quot;>Platinum Ring&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="394"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_platinum_ring_desc` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_platinum_ring_desc&quot;>A plain platinum ring.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="395"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_platinum_necklace_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_platinum_necklace_name&quot;>Platinum Necklace&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="396"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_platinum_necklace_desc` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_platinum_necklace_desc&quot;>A plain platinum necklace.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="397"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_silver_sapphire_ring_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_silver_sapphire_ring_name&quot;>Silver Sapphire Ring&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="400"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_silver_sapphire_ring_desc` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_silver_sapphire_ring_desc&quot;>A silver ring set with a sapphire.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="401"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_silver_sapphire_necklace_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_silver_sapphire_necklace_name&quot;>Silver Sapphire Necklace&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="402"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_silver_sapphire_necklace_desc` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_silver_sapphire_necklace_desc&quot;>A silver necklace set with a sapphire.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="403"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_gold_sapphire_ring_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_gold_sapphire_ring_name&quot;>Gold Sapphire Ring&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="404"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_gold_sapphire_ring_desc` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_gold_sapphire_ring_desc&quot;>A gold ring set with a sapphire.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="405"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_gold_sapphire_necklace_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_gold_sapphire_necklace_name&quot;>Gold Sapphire Necklace&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="406"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_gold_sapphire_necklace_desc` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_gold_sapphire_necklace_desc&quot;>A gold necklace set with a sapphire.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="407"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_platinum_sapphire_ring_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_platinum_sapphire_ring_name&quot;>Platinum Sapphire Ring&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="408"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_platinum_sapphire_ring_desc` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_platinum_sapphire_ring_desc&quot;>A platinum ring set with a sapphire.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="409"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_platinum_sapphire_necklace_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_platinum_sapphire_necklace_name&quot;>Platinum Sapphire Necklace&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="410"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_platinum_sapphire_necklace_desc` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_platinum_sapphire_necklace_desc&quot;>A platinum necklace set with a sapphire.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="411"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_gold_emerald_ring_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_gold_emerald_ring_name&quot;>Gold Emerald Ring&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="414"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_gold_emerald_ring_desc` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_gold_emerald_ring_desc&quot;>A gold ring set with an emerald.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="415"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_gold_emerald_necklace_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_gold_emerald_necklace_name&quot;>Gold Emerald Necklace&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="416"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_gold_emerald_necklace_desc` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_gold_emerald_necklace_desc&quot;>A gold necklace set with an emerald.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="417"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_platinum_emerald_ring_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_platinum_emerald_ring_name&quot;>Platinum Emerald Ring&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="418"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_platinum_emerald_ring_desc` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_platinum_emerald_ring_desc&quot;>A platinum ring set with an emerald.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="419"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_platinum_emerald_necklace_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_platinum_emerald_necklace_name&quot;>Platinum Emerald Necklace&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="420"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_platinum_emerald_necklace_desc` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_platinum_emerald_necklace_desc&quot;>A platinum necklace set with an emerald.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="421"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_gold_ruby_ring_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_gold_ruby_ring_name&quot;>Gold Ruby Ring&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="424"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_gold_ruby_ring_desc` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_gold_ruby_ring_desc&quot;>A gold ring set with a ruby.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="425"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_gold_ruby_necklace_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_gold_ruby_necklace_name&quot;>Gold Ruby Necklace&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="426"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_gold_ruby_necklace_desc` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_gold_ruby_necklace_desc&quot;>A gold necklace set with a ruby.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="427"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_platinum_ruby_ring_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_platinum_ruby_ring_name&quot;>Platinum Ruby Ring&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="428"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_platinum_ruby_ring_desc` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_platinum_ruby_ring_desc&quot;>A platinum ring set with a ruby.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="429"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_platinum_ruby_necklace_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_platinum_ruby_necklace_name&quot;>Platinum Ruby Necklace&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="430"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_platinum_ruby_necklace_desc` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_platinum_ruby_necklace_desc&quot;>A platinum necklace set with a ruby.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="431"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_gold_diamond_ring_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_gold_diamond_ring_name&quot;>Gold Diamond Ring&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="434"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_gold_diamond_ring_desc` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_gold_diamond_ring_desc&quot;>A gold ring set with a diamond.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="435"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_gold_diamond_necklace_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_gold_diamond_necklace_name&quot;>Gold Diamond Necklace&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="436"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_gold_diamond_necklace_desc` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_gold_diamond_necklace_desc&quot;>A gold necklace set with a diamond.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="437"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_platinum_diamond_ring_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_platinum_diamond_ring_name&quot;>Platinum Diamond Ring&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="438"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_platinum_diamond_ring_desc` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_platinum_diamond_ring_desc&quot;>A platinum ring set with a diamond.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="439"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_platinum_diamond_necklace_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_platinum_diamond_necklace_name&quot;>Platinum Diamond Necklace&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="440"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_platinum_diamond_necklace_desc` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_platinum_diamond_necklace_desc&quot;>A platinum necklace set with a diamond.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="441"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_ashes_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_ashes_name&quot;>Ashes&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="444"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_ashes_desc` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_ashes_desc&quot;>Burnt remnants of regular logs. Scatter in the Prayer skill for bonus Prayer XP.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="445"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_oak_ashes_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_oak_ashes_name&quot;>Oak Ashes&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="446"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_oak_ashes_desc` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_oak_ashes_desc&quot;>Burnt remnants of oak logs. Scatter for more Prayer XP than regular ashes.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="447"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_willow_ashes_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_willow_ashes_name&quot;>Willow Ashes&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="448"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_willow_ashes_desc` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_willow_ashes_desc&quot;>Burnt remnants of willow logs. Scatter for Prayer XP.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="449"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_maple_ashes_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_maple_ashes_name&quot;>Maple Ashes&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="450"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_maple_ashes_desc` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_maple_ashes_desc&quot;>Burnt remnants of maple logs. Scatter for Prayer XP.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="451"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_yew_ashes_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_yew_ashes_name&quot;>Yew Ashes&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="452"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_yew_ashes_desc` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_yew_ashes_desc&quot;>Burnt remnants of yew logs. Scatter for significant Prayer XP.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="453"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_magic_ashes_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_magic_ashes_name&quot;>Magic Ashes&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="454"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_magic_ashes_desc` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_magic_ashes_desc&quot;>Burnt remnants of magic logs. Scatter for substantial Prayer XP.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="455"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_redwood_ashes_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_redwood_ashes_name&quot;>Redwood Ashes&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="456"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_redwood_ashes_desc` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_redwood_ashes_desc&quot;>Burnt remnants of redwood logs. Scatter for the most Prayer XP of any ash.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="457"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_bones_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_bones_name&quot;>Bones&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="458"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_bones_desc` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_bones_desc&quot;>Bones from a small creature. Bury for Prayer XP.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="459"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_big_bones_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_big_bones_name&quot;>Big Bones&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="460"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_big_bones_desc` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_big_bones_desc&quot;>Larger bones. Grant more Prayer XP when buried.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="461"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_giant_bones_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_giant_bones_name&quot;>Giant Bones&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="462"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_giant_bones_desc` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_giant_bones_desc&quot;>Massive bones from powerful foes. Grant significant Prayer XP.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="463"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_dragon_bone_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_dragon_bone_name&quot;>Dragon Bone&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="464"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_dragon_bone_desc` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_dragon_bone_desc&quot;>Ancient dragon bones. Grant the most Prayer XP when buried.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="465"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_dragon_scale_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_dragon_scale_name&quot;>Dragon Scale&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="466"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_dragon_scale_desc` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_dragon_scale_desc&quot;>A tough scale from a green dragon. Rare and valuable.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="467"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_coins_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_coins_name&quot;>Coins&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="468"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_coins_desc` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_coins_desc&quot;>The currency of the realm. Spend at the shop.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="469"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_goblin_mail_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_goblin_mail_name&quot;>Goblin Mail&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="470"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_goblin_mail_desc` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_goblin_mail_desc&quot;>Battered armour dropped by goblins. Sells well.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="471"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_imp_hide_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_imp_hide_name&quot;>Imp Hide&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="472"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_imp_hide_desc` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_imp_hide_desc&quot;>Leathery skin from an imp.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="473"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_spider_silk_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_spider_silk_name&quot;>Spider Silk&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="474"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_spider_silk_desc` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_spider_silk_desc&quot;>Fine silk spun by giant spiders. Valuable to crafters.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="475"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_spider_fang_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_spider_fang_name&quot;>Spider Fang&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="476"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_spider_fang_desc` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_spider_fang_desc&quot;>A venomous fang from a giant spider.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="477"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_cowhide_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_cowhide_name&quot;>Cowhide&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="478"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_cowhide_desc` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_cowhide_desc&quot;>Rough hide from a cow. Used in leather crafting.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="479"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_wool_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_wool_name&quot;>Wool&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="480"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_wool_desc` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_wool_desc&quot;>Soft wool from a sheep.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="481"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_feather_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_feather_name&quot;>Feather&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="482"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_feather_desc` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_feather_desc&quot;>A feather used in fletching arrows.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="483"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_rotten_flesh_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_rotten_flesh_name&quot;>Rotten Flesh&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="484"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_rotten_flesh_desc` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_rotten_flesh_desc&quot;>Decaying flesh from an undead creature. Smells terrible.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="485"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_lockpick_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_lockpick_name&quot;>Lockpick&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="486"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_lockpick_desc` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_lockpick_desc&quot;>A lockpick dropped by rogues.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="487"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_magic_bean_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_magic_bean_name&quot;>Magic Bean&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="488"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_magic_bean_desc` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_magic_bean_desc&quot;>A magical bean with mysterious properties.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="489"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_hellhound_fang_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_hellhound_fang_name&quot;>Hellhound Fang&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="490"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_hellhound_fang_desc` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_hellhound_fang_desc&quot;>A scorched fang from a hellhound.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="491"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_demon_horn_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_demon_horn_name&quot;>Demon Horn&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="492"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_demon_horn_desc` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_demon_horn_desc&quot;>A jagged horn torn from a lesser demon.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="493"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_troll_bone_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_troll_bone_name&quot;>Troll Bone&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="494"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_troll_bone_desc` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_troll_bone_desc&quot;>A huge, gnarled bone from a mountain troll.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="495"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_air_rune_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_air_rune_name&quot;>Air Rune&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="498"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_air_rune_desc` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_air_rune_desc&quot;>A rune imbued with the power of air. Used in air spells.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="499"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_water_rune_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_water_rune_name&quot;>Water Rune&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="500"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_water_rune_desc` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_water_rune_desc&quot;>A rune imbued with the power of water.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="501"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_earth_rune_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_earth_rune_name&quot;>Earth Rune&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="502"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_earth_rune_desc` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_earth_rune_desc&quot;>A rune imbued with the power of earth.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="503"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_fire_rune_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_fire_rune_name&quot;>Fire Rune&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="504"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_fire_rune_desc` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_fire_rune_desc&quot;>A rune imbued with the power of fire.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="505"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_mind_rune_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_mind_rune_name&quot;>Mind Rune&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="506"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_mind_rune_desc` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_mind_rune_desc&quot;>A rune channelling psychic energy.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="507"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_chaos_rune_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_chaos_rune_name&quot;>Chaos Rune&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="508"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_chaos_rune_desc` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_chaos_rune_desc&quot;>A rune of wild, chaotic magic.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="509"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_death_rune_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_death_rune_name&quot;>Death Rune&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="510"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_death_rune_desc` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_death_rune_desc&quot;>A rune infused with the power of death.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="511"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_blood_rune_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_blood_rune_name&quot;>Blood Rune&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="512"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_blood_rune_desc` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_blood_rune_desc&quot;>A rare rune fuelled by blood magic.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="513"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.crop_potato_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;crop_potato_name&quot;>Potato&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="516"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.crop_onion_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;crop_onion_name&quot;>Onion&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="517"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.crop_cabbage_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;crop_cabbage_name&quot;>Cabbage&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="518"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.crop_carrot_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;crop_carrot_name&quot;>Carrot&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="519"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.crop_tomato_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;crop_tomato_name&quot;>Tomato&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="520"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.crop_corn_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;crop_corn_name&quot;>Corn&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="521"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.crop_pumpkin_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;crop_pumpkin_name&quot;>Pumpkin&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="522"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.crop_watermelon_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;crop_watermelon_name&quot;>Watermelon&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="523"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.crop_strawberry_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;crop_strawberry_name&quot;>Strawberry&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="524"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.crop_magic_herb_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;crop_magic_herb_name&quot;>Magic Herb&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="525"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.crop_dragon_fruit_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;crop_dragon_fruit_name&quot;>Dragon Fruit&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="526"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.crop_golden_wheat_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;crop_golden_wheat_name&quot;>Golden Wheat&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="527"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.crop_spirit_herb_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;crop_spirit_herb_name&quot;>Spirit Herb&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="528"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.crop_celestial_bloom_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;crop_celestial_bloom_name&quot;>Celestial Bloom&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="529"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.crop_starfruit_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;crop_starfruit_name&quot;>Starfruit&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="530"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.crop_void_lotus_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;crop_void_lotus_name&quot;>Void Lotus&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="531"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.spell_wind_strike_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;spell_wind_strike_name&quot;>Wind Strike&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="534"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.spell_wind_bolt_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;spell_wind_bolt_name&quot;>Wind Bolt&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="535"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.spell_wind_blast_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;spell_wind_blast_name&quot;>Wind Blast&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="536"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.spell_wind_wave_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;spell_wind_wave_name&quot;>Wind Wave&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="537"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.spell_water_strike_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;spell_water_strike_name&quot;>Water Strike&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="538"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.spell_water_bolt_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;spell_water_bolt_name&quot;>Water Bolt&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="539"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.spell_water_blast_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;spell_water_blast_name&quot;>Water Blast&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="540"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.spell_water_wave_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;spell_water_wave_name&quot;>Water Wave&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="541"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.spell_earth_strike_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;spell_earth_strike_name&quot;>Earth Strike&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="542"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.spell_earth_bolt_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;spell_earth_bolt_name&quot;>Earth Bolt&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="543"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.spell_earth_blast_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;spell_earth_blast_name&quot;>Earth Blast&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="544"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.spell_earth_wave_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;spell_earth_wave_name&quot;>Earth Wave&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="545"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.spell_fire_strike_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;spell_fire_strike_name&quot;>Fire Strike&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="546"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.spell_fire_bolt_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;spell_fire_bolt_name&quot;>Fire Bolt&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="547"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.spell_fire_blast_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;spell_fire_blast_name&quot;>Fire Blast&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="548"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.spell_fire_wave_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;spell_fire_wave_name&quot;>Fire Wave&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="549"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.spell_mind_strike_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;spell_mind_strike_name&quot;>Mind Strike&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="550"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.spell_mind_bolt_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;spell_mind_bolt_name&quot;>Mind Bolt&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="551"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.spell_mind_blast_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;spell_mind_blast_name&quot;>Mind Blast&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="552"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.spell_mind_wave_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;spell_mind_wave_name&quot;>Mind Wave&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="553"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.spell_chaos_strike_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;spell_chaos_strike_name&quot;>Chaos Strike&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="554"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.spell_chaos_bolt_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;spell_chaos_bolt_name&quot;>Chaos Bolt&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="555"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.spell_chaos_blast_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;spell_chaos_blast_name&quot;>Chaos Blast&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="556"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.spell_chaos_wave_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;spell_chaos_wave_name&quot;>Chaos Wave&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="557"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.spell_death_strike_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;spell_death_strike_name&quot;>Death Strike&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="558"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.spell_death_bolt_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;spell_death_bolt_name&quot;>Death Bolt&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="559"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.spell_death_blast_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;spell_death_blast_name&quot;>Death Blast&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="560"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.spell_death_wave_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;spell_death_wave_name&quot;>Death Wave&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="561"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.spell_blood_strike_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;spell_blood_strike_name&quot;>Blood Strike&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="562"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.spell_blood_bolt_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;spell_blood_bolt_name&quot;>Blood Bolt&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="563"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.spell_blood_blast_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;spell_blood_blast_name&quot;>Blood Blast&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="564"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.spell_blood_wave_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;spell_blood_wave_name&quot;>Blood Wave&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="565"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_bronze_hoe_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_bronze_hoe_name&quot;>Bronze Hoe&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="568"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_iron_hoe_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_iron_hoe_name&quot;>Iron Hoe&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="569"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_steel_hoe_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_steel_hoe_name&quot;>Steel Hoe&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="570"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_mithril_hoe_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_mithril_hoe_name&quot;>Mithril Hoe&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="571"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_adamantite_hoe_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_adamantite_hoe_name&quot;>Adamantite Hoe&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="572"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_runite_hoe_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_runite_hoe_name&quot;>Runite Hoe&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="573"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_attack_brew_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_attack_brew_name&quot;>Attack Brew&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="576"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_defense_brew_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_defense_brew_name&quot;>Defense Brew&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="577"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_attack_potion_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_attack_potion_name&quot;>Attack Potion&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="578"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_defense_potion_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_defense_potion_name&quot;>Defense Potion&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="579"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_onion_brew_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_onion_brew_name&quot;>Onion Brew&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="580"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_carrot_brew_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_carrot_brew_name&quot;>Carrot Brew&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="581"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_strength_brew_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_strength_brew_name&quot;>Strength Brew&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="582"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_strength_potion_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_strength_potion_name&quot;>Strength Potion&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="583"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_ranging_potion_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_ranging_potion_name&quot;>Ranging Potion&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="584"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_magic_potion_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_magic_potion_name&quot;>Magic Potion&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="585"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_super_strength_potion_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_super_strength_potion_name&quot;>Super Strength Potion&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="586"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_super_attack_potion_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_super_attack_potion_name&quot;>Super Attack Potion&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="587"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_super_defense_potion_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_super_defense_potion_name&quot;>Super Defense Potion&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="588"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_super_ranging_potion_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_super_ranging_potion_name&quot;>Super Ranging Potion&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="589"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_super_magic_potion_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_super_magic_potion_name&quot;>Super Magic Potion&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="590"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_overload_potion_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_overload_potion_name&quot;>Overload Potion&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="591"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_enhanced_attack_brew_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_enhanced_attack_brew_name&quot;>Attack Brew&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="594"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_enhanced_defense_brew_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_enhanced_defense_brew_name&quot;>Defense Brew&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="595"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_enhanced_attack_potion_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_enhanced_attack_potion_name&quot;>Attack Potion&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="596"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_enhanced_defense_potion_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_enhanced_defense_potion_name&quot;>Defense Potion&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="597"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_enhanced_onion_brew_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_enhanced_onion_brew_name&quot;>Onion Brew&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="598"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_enhanced_carrot_brew_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_enhanced_carrot_brew_name&quot;>Carrot Brew&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="599"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_enhanced_strength_brew_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_enhanced_strength_brew_name&quot;>Strength Brew&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="600"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_enhanced_strength_potion_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_enhanced_strength_potion_name&quot;>Strength Potion&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="601"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_enhanced_ranging_potion_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_enhanced_ranging_potion_name&quot;>Ranging Potion&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="602"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_enhanced_magic_potion_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_enhanced_magic_potion_name&quot;>Magic Potion&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="603"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_enhanced_super_strength_potion_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_enhanced_super_strength_potion_name&quot;>Super Strength Potion&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="604"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_enhanced_super_attack_potion_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_enhanced_super_attack_potion_name&quot;>Super Attack Potion&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="605"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_enhanced_super_defense_potion_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_enhanced_super_defense_potion_name&quot;>Super Defense Potion&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="606"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_enhanced_super_ranging_potion_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_enhanced_super_ranging_potion_name&quot;>Super Ranging Potion&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="607"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_enhanced_super_magic_potion_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_enhanced_super_magic_potion_name&quot;>Super Magic Potion&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="608"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_enhanced_overload_potion_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_enhanced_overload_potion_name&quot;>Overload Potion&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="609"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.item_any_fish_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;item_any_fish_name&quot;>fish (any type)&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_items.xml"
+            line="611"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.notif_farming_ready_body_multi` appears to be unused"
+        errorLine1="    &lt;string name=&quot;notif_farming_ready_body_multi&quot;>%1$d patches are ready to harvest.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_notifications.xml"
+            line="20"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_mining_1_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_mining_1_name&quot;>Mining I&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="7"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_mining_1_objective` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_mining_1_objective&quot;>Mine 500 Copper Ore&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="8"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_mining_2_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_mining_2_name&quot;>Mining II&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="9"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_mining_2_objective` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_mining_2_objective&quot;>Mine 750 Iron Ore&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="10"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_mining_3_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_mining_3_name&quot;>Mining III&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="11"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_mining_3_objective` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_mining_3_objective&quot;>Mine 1100 Coal&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="12"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_mining_4_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_mining_4_name&quot;>Mining IV&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="13"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_mining_4_objective` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_mining_4_objective&quot;>Mine 1650 Mithril Ore&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="14"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_mining_5_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_mining_5_name&quot;>Mining V&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="15"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_mining_5_objective` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_mining_5_objective&quot;>Mine 2450 Adamantite Ore&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="16"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_mining_6_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_mining_6_name&quot;>Mining VI&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="17"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_mining_6_objective` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_mining_6_objective&quot;>Mine 3650 Runite Ore&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="18"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_woodcutting_1_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_woodcutting_1_name&quot;>Woodcutting I&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="21"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_woodcutting_1_objective` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_woodcutting_1_objective&quot;>Cut 500 Logs&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="22"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_woodcutting_2_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_woodcutting_2_name&quot;>Woodcutting II&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="23"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_woodcutting_2_objective` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_woodcutting_2_objective&quot;>Cut 750 Oak Logs&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="24"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_woodcutting_3_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_woodcutting_3_name&quot;>Woodcutting III&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="25"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_woodcutting_3_objective` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_woodcutting_3_objective&quot;>Cut 1100 Willow Logs&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="26"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_woodcutting_4_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_woodcutting_4_name&quot;>Woodcutting IV&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="27"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_woodcutting_4_objective` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_woodcutting_4_objective&quot;>Cut 1650 Maple Logs&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="28"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_woodcutting_5_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_woodcutting_5_name&quot;>Woodcutting V&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="29"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_woodcutting_5_objective` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_woodcutting_5_objective&quot;>Cut 2450 Yew Logs&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="30"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_woodcutting_6_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_woodcutting_6_name&quot;>Woodcutting VI&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="31"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_woodcutting_6_objective` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_woodcutting_6_objective&quot;>Cut 3650 Magic Logs&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="32"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_fishing_1_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_fishing_1_name&quot;>Fishing I&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="35"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_fishing_1_objective` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_fishing_1_objective&quot;>Catch 500 fish&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="36"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_fishing_2_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_fishing_2_name&quot;>Fishing II&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="37"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_fishing_2_objective` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_fishing_2_objective&quot;>Catch 750 fish&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="38"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_fishing_3_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_fishing_3_name&quot;>Fishing III&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="39"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_fishing_3_objective` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_fishing_3_objective&quot;>Catch 1100 fish&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="40"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_fishing_4_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_fishing_4_name&quot;>Fishing IV&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="41"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_fishing_4_objective` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_fishing_4_objective&quot;>Catch 1650 fish&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="42"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_fishing_5_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_fishing_5_name&quot;>Fishing V&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="43"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_fishing_5_objective` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_fishing_5_objective&quot;>Catch 2450 fish&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="44"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_fishing_6_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_fishing_6_name&quot;>Fishing VI&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="45"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_fishing_6_objective` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_fishing_6_objective&quot;>Catch 3650 fish&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="46"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_smithing_1_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_smithing_1_name&quot;>Smithing I&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="49"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_smithing_1_objective` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_smithing_1_objective&quot;>Smelt 500 Bronze Bars&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="50"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_smithing_2_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_smithing_2_name&quot;>Smithing II&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="51"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_smithing_2_objective` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_smithing_2_objective&quot;>Smelt 750 Iron Bars&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="52"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_smithing_3_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_smithing_3_name&quot;>Smithing III&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="53"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_smithing_3_objective` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_smithing_3_objective&quot;>Smelt 1100 Steel Bars&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="54"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_smithing_4_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_smithing_4_name&quot;>Smithing IV&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="55"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_smithing_4_objective` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_smithing_4_objective&quot;>Smelt 1650 Mithril Bars&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="56"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_smithing_5_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_smithing_5_name&quot;>Smithing V&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="57"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_smithing_5_objective` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_smithing_5_objective&quot;>Smelt 2450 Adamantite Bars&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="58"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_smithing_6_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_smithing_6_name&quot;>Smithing VI&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="59"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_smithing_6_objective` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_smithing_6_objective&quot;>Smelt 3650 Runite Bars&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="60"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_cooking_fish_1_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_cooking_fish_1_name&quot;>Cooking — Fish I&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="63"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_cooking_fish_1_objective` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_cooking_fish_1_objective&quot;>Cook 500 fish&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="64"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_cooking_fish_2_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_cooking_fish_2_name&quot;>Cooking — Fish II&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="65"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_cooking_fish_2_objective` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_cooking_fish_2_objective&quot;>Cook 750 fish&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="66"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_cooking_fish_3_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_cooking_fish_3_name&quot;>Cooking — Fish III&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="67"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_cooking_fish_3_objective` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_cooking_fish_3_objective&quot;>Cook 1100 fish&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="68"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_cooking_fish_4_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_cooking_fish_4_name&quot;>Cooking — Fish IV&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="69"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_cooking_fish_4_objective` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_cooking_fish_4_objective&quot;>Cook 1650 fish&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="70"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_cooking_fish_5_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_cooking_fish_5_name&quot;>Cooking — Fish V&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="71"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_cooking_fish_5_objective` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_cooking_fish_5_objective&quot;>Cook 2450 fish&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="72"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_cooking_fish_6_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_cooking_fish_6_name&quot;>Cooking — Fish VI&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="73"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_cooking_fish_6_objective` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_cooking_fish_6_objective&quot;>Cook 3650 fish&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="74"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_cooking_beef_1_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_cooking_beef_1_name&quot;>Cooking — Beef I&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="77"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_cooking_beef_1_objective` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_cooking_beef_1_objective&quot;>Cook 100 Beef&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="78"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_cooking_beef_2_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_cooking_beef_2_name&quot;>Cooking — Beef II&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="79"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_cooking_beef_2_objective` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_cooking_beef_2_objective&quot;>Cook 250 Beef&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="80"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_cooking_beef_3_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_cooking_beef_3_name&quot;>Cooking — Beef III&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="81"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_cooking_beef_3_objective` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_cooking_beef_3_objective&quot;>Cook 500 Beef&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="82"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_cooking_chicken_1_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_cooking_chicken_1_name&quot;>Cooking — Chicken I&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="85"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_cooking_chicken_1_objective` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_cooking_chicken_1_objective&quot;>Cook 100 Chicken&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="86"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_cooking_chicken_2_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_cooking_chicken_2_name&quot;>Cooking — Chicken II&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="87"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_cooking_chicken_2_objective` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_cooking_chicken_2_objective&quot;>Cook 250 Chicken&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="88"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_cooking_chicken_3_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_cooking_chicken_3_name&quot;>Cooking — Chicken III&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="89"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_cooking_chicken_3_objective` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_cooking_chicken_3_objective&quot;>Cook 500 Chicken&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="90"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_cooking_mutton_1_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_cooking_mutton_1_name&quot;>Cooking — Mutton I&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="93"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_cooking_mutton_1_objective` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_cooking_mutton_1_objective&quot;>Cook 100 Mutton&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="94"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_cooking_mutton_2_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_cooking_mutton_2_name&quot;>Cooking — Mutton II&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="95"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_cooking_mutton_2_objective` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_cooking_mutton_2_objective&quot;>Cook 250 Mutton&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="96"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_cooking_mutton_3_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_cooking_mutton_3_name&quot;>Cooking — Mutton III&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="97"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_cooking_mutton_3_objective` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_cooking_mutton_3_objective&quot;>Cook 500 Mutton&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="98"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_fletching_1_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_fletching_1_name&quot;>Fletching I&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="101"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_fletching_1_objective` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_fletching_1_objective&quot;>Fletch 500 Bronze Arrows&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="102"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_fletching_2_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_fletching_2_name&quot;>Fletching II&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="103"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_fletching_2_objective` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_fletching_2_objective&quot;>Fletch 750 Iron Arrows&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="104"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_fletching_3_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_fletching_3_name&quot;>Fletching III&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="105"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_fletching_3_objective` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_fletching_3_objective&quot;>Fletch 1100 Steel Arrows&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="106"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_fletching_4_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_fletching_4_name&quot;>Fletching IV&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="107"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_fletching_4_objective` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_fletching_4_objective&quot;>Fletch 1650 Mithril Arrows&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="108"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_fletching_5_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_fletching_5_name&quot;>Fletching V&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="109"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_fletching_5_objective` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_fletching_5_objective&quot;>Fletch 2450 Adamantite Arrows&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="110"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_fletching_6_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_fletching_6_name&quot;>Fletching VI&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="111"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_fletching_6_objective` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_fletching_6_objective&quot;>Fletch 3650 Runite Arrows&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="112"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_prayer_1_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_prayer_1_name&quot;>Prayer I&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="115"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_prayer_1_objective` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_prayer_1_objective&quot;>Bury 500 bones&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="116"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_prayer_2_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_prayer_2_name&quot;>Prayer II&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="117"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_prayer_2_objective` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_prayer_2_objective&quot;>Bury 750 bones&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="118"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_prayer_3_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_prayer_3_name&quot;>Prayer III&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="119"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_prayer_3_objective` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_prayer_3_objective&quot;>Bury 1100 bones&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="120"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_prayer_4_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_prayer_4_name&quot;>Prayer IV&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="121"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_prayer_4_objective` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_prayer_4_objective&quot;>Bury 1650 bones&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="122"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_prayer_5_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_prayer_5_name&quot;>Prayer V&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="123"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_prayer_5_objective` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_prayer_5_objective&quot;>Bury 2450 bones&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="124"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_prayer_6_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_prayer_6_name&quot;>Prayer VI&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="125"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_prayer_6_objective` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_prayer_6_objective&quot;>Bury 3650 bones&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="126"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_combat_kills_1_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_combat_kills_1_name&quot;>Monster Hunter I&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="129"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_combat_kills_1_objective` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_combat_kills_1_objective&quot;>Defeat 100 enemies&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="130"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_combat_kills_2_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_combat_kills_2_name&quot;>Monster Hunter II&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="131"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_combat_kills_2_objective` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_combat_kills_2_objective&quot;>Defeat 150 enemies&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="132"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_combat_kills_3_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_combat_kills_3_name&quot;>Monster Hunter III&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="133"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_combat_kills_3_objective` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_combat_kills_3_objective&quot;>Defeat 200 enemies&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="134"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_combat_kills_4_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_combat_kills_4_name&quot;>Monster Hunter IV&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="135"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_combat_kills_4_objective` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_combat_kills_4_objective&quot;>Defeat 300 enemies&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="136"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_combat_kills_5_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_combat_kills_5_name&quot;>Monster Hunter V&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="137"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_combat_kills_5_objective` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_combat_kills_5_objective&quot;>Defeat 450 enemies&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="138"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_combat_kills_6_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_combat_kills_6_name&quot;>Monster Hunter VI&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="139"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_combat_kills_6_objective` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_combat_kills_6_objective&quot;>Defeat 650 enemies&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="140"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_dungeon_farm_1_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_dungeon_farm_1_name&quot;>Dungeon Explorer I&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="143"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_dungeon_farm_1_objective` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_dungeon_farm_1_objective&quot;>Complete the Farm dungeon 5 times&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="144"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_dungeon_goblin_1_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_dungeon_goblin_1_name&quot;>Dungeon Explorer II&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="145"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_dungeon_goblin_1_objective` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_dungeon_goblin_1_objective&quot;>Complete the Goblin Cave 5 times&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="146"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_dungeon_spider_1_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_dungeon_spider_1_name&quot;>Dungeon Explorer III&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="147"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_dungeon_spider_1_objective` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_dungeon_spider_1_objective&quot;>Complete the Spider Den 5 times&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="148"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_dungeon_bandit_1_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_dungeon_bandit_1_name&quot;>Dungeon Explorer IV&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="149"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_dungeon_bandit_1_objective` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_dungeon_bandit_1_objective&quot;>Complete the Bandit Camp 5 times&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="150"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_dungeon_undead_1_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_dungeon_undead_1_name&quot;>Dungeon Explorer V&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="151"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_dungeon_undead_1_objective` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_dungeon_undead_1_objective&quot;>Complete the Undead Crypt 5 times&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="152"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_dungeon_fortress_1_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_dungeon_fortress_1_name&quot;>Dungeon Explorer VI&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="153"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_dungeon_fortress_1_objective` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_dungeon_fortress_1_objective&quot;>Complete the Fortress Ruins 5 times&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="154"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_dungeon_orc_1_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_dungeon_orc_1_name&quot;>Dungeon Master I&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="155"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_dungeon_orc_1_objective` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_dungeon_orc_1_objective&quot;>Complete the Orc Stronghold 5 times&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="156"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_dungeon_volcanic_1_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_dungeon_volcanic_1_name&quot;>Dungeon Master II&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="157"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_dungeon_volcanic_1_objective` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_dungeon_volcanic_1_objective&quot;>Complete the Volcanic Depths 5 times&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="158"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_dungeon_dragon_1_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_dungeon_dragon_1_name&quot;>Dungeon Master III&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="159"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_dungeon_dragon_1_objective` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_dungeon_dragon_1_objective&quot;>Complete the Dragon\&apos;s Lair 5 times&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="160"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_crafting_1_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_crafting_1_name&quot;>Crafting I&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="163"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_crafting_1_objective` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_crafting_1_objective&quot;>Craft 100 Silver Rings&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="164"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_crafting_2_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_crafting_2_name&quot;>Crafting II&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="165"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_crafting_2_objective` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_crafting_2_objective&quot;>Craft 250 Gold Rings&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="166"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_crafting_3_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_crafting_3_name&quot;>Crafting III&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="167"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_crafting_3_objective` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_crafting_3_objective&quot;>Craft 500 Platinum Rings&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="168"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_crafting_4_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_crafting_4_name&quot;>Crafting IV&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="169"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_crafting_4_objective` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_crafting_4_objective&quot;>Craft 750 Silver Sapphire Rings&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="170"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_crafting_5_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_crafting_5_name&quot;>Crafting V&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="171"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_crafting_5_objective` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_crafting_5_objective&quot;>Craft 1000 Gold Sapphire Rings&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="172"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_crafting_6_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_crafting_6_name&quot;>Crafting VI&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="173"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_crafting_6_objective` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_crafting_6_objective&quot;>Craft 1500 Platinum Diamond Rings&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="174"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_goblin_slayer_1_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_goblin_slayer_1_name&quot;>Goblin Slayer I&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="177"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_goblin_slayer_1_objective` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_goblin_slayer_1_objective&quot;>Defeat 50 Goblins&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="178"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_goblin_slayer_2_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_goblin_slayer_2_name&quot;>Goblin Slayer II&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="179"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_goblin_slayer_2_objective` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_goblin_slayer_2_objective&quot;>Defeat 100 Goblins&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="180"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_spider_slayer_1_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_spider_slayer_1_name&quot;>Spider Slayer I&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="181"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_spider_slayer_1_objective` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_spider_slayer_1_objective&quot;>Defeat 40 Giant Spiders&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="182"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_spider_slayer_2_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_spider_slayer_2_name&quot;>Spider Slayer II&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="183"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_spider_slayer_2_objective` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_spider_slayer_2_objective&quot;>Defeat 80 Giant Spiders&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="184"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_skeleton_slayer_1_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_skeleton_slayer_1_name&quot;>Skeleton Slayer I&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="185"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_skeleton_slayer_1_objective` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_skeleton_slayer_1_objective&quot;>Defeat 35 Skeletons&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="186"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_skeleton_slayer_2_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_skeleton_slayer_2_name&quot;>Skeleton Slayer II&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="187"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_skeleton_slayer_2_objective` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_skeleton_slayer_2_objective&quot;>Defeat 70 Skeletons&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="188"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_bandit_hunter_1_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_bandit_hunter_1_name&quot;>Bandit Hunter I&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="189"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_bandit_hunter_1_objective` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_bandit_hunter_1_objective&quot;>Defeat 30 Bandits&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="190"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_bandit_hunter_2_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_bandit_hunter_2_name&quot;>Bandit Hunter II&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="191"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_bandit_hunter_2_objective` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_bandit_hunter_2_objective&quot;>Defeat 60 Bandits&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="192"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_orc_slayer_1_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_orc_slayer_1_name&quot;>Orc Slayer I&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="193"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_orc_slayer_1_objective` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_orc_slayer_1_objective&quot;>Defeat 25 Orc Warriors&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="194"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_orc_slayer_2_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_orc_slayer_2_name&quot;>Orc Slayer II&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="195"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_orc_slayer_2_objective` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_orc_slayer_2_objective&quot;>Defeat 50 Orc Warriors&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="196"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_demon_slayer_1_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_demon_slayer_1_name&quot;>Demon Slayer I&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="197"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_demon_slayer_1_objective` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_demon_slayer_1_objective&quot;>Defeat the Demon Lord&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="198"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_demon_slayer_2_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_demon_slayer_2_name&quot;>Demon Slayer II&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="199"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_demon_slayer_2_objective` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_demon_slayer_2_objective&quot;>Defeat the Demon Lord 5 times&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="200"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_demon_slayer_3_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_demon_slayer_3_name&quot;>Demon Slayer III&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="201"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_demon_slayer_3_objective` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_demon_slayer_3_objective&quot;>Defeat the Demon Lord 25 times&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="202"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_dragon_slayer_1_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_dragon_slayer_1_name&quot;>Dragon Slayer I&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="203"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_dragon_slayer_1_objective` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_dragon_slayer_1_objective&quot;>Defeat 10 Green Dragons&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="204"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_dragon_slayer_2_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_dragon_slayer_2_name&quot;>Dragon Slayer II&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="205"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_dragon_slayer_2_objective` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_dragon_slayer_2_objective&quot;>Defeat 25 Green Dragons&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="206"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_melee_warrior_1_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_melee_warrior_1_name&quot;>Melee Warrior I&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="209"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_melee_warrior_1_objective` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_melee_warrior_1_objective&quot;>Complete the Goblin Cave using only melee&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="210"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_melee_warrior_2_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_melee_warrior_2_name&quot;>Melee Warrior II&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="211"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_melee_warrior_2_objective` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_melee_warrior_2_objective&quot;>Complete the Bandit Camp using only melee&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="212"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_melee_warrior_3_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_melee_warrior_3_name&quot;>Melee Warrior III&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="213"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_melee_warrior_3_objective` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_melee_warrior_3_objective&quot;>Complete the Fortress Ruins using only melee&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="214"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_ranger_elite_1_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_ranger_elite_1_name&quot;>Ranger Elite I&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="215"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_ranger_elite_1_objective` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_ranger_elite_1_objective&quot;>Complete the Goblin Cave using only ranged&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="216"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_ranger_elite_2_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_ranger_elite_2_name&quot;>Ranger Elite II&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="217"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_ranger_elite_2_objective` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_ranger_elite_2_objective&quot;>Complete the Bandit Camp using only ranged&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="218"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_ranger_elite_3_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_ranger_elite_3_name&quot;>Ranger Elite III&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="219"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_ranger_elite_3_objective` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_ranger_elite_3_objective&quot;>Complete the Fortress Ruins using only ranged&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="220"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_mage_master_1_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_mage_master_1_name&quot;>Mage Master I&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="221"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_mage_master_1_objective` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_mage_master_1_objective&quot;>Complete the Goblin Cave using only magic&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="222"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_mage_master_2_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_mage_master_2_name&quot;>Mage Master II&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="223"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_mage_master_2_objective` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_mage_master_2_objective&quot;>Complete the Bandit Camp using only magic&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="224"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_mage_master_3_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_mage_master_3_name&quot;>Mage Master III&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="225"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_mage_master_3_objective` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_mage_master_3_objective&quot;>Complete the Fortress Ruins using only magic&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="226"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_iron_stomach_1_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_iron_stomach_1_name&quot;>Iron Stomach I&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="229"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_iron_stomach_1_objective` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_iron_stomach_1_objective&quot;>Complete the Spider Den without using food&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="230"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_iron_stomach_2_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_iron_stomach_2_name&quot;>Iron Stomach II&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="231"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_iron_stomach_2_objective` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_iron_stomach_2_objective&quot;>Complete the Undead Crypt without using food&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="232"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_iron_stomach_3_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_iron_stomach_3_name&quot;>Iron Stomach III&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="233"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_iron_stomach_3_objective` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_iron_stomach_3_objective&quot;>Complete the Orc Stronghold without using food&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="234"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_iron_stomach_4_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_iron_stomach_4_name&quot;>Iron Stomach IV&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="235"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_iron_stomach_4_objective` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_iron_stomach_4_objective&quot;>Complete the Dragon\&apos;s Lair without using food&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="236"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_treasure_hunter_1_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_treasure_hunter_1_name&quot;>Treasure Hunter I&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="239"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_treasure_hunter_1_objective` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_treasure_hunter_1_objective&quot;>Collect 20 Spider Silk from combat&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="240"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_treasure_hunter_2_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_treasure_hunter_2_name&quot;>Treasure Hunter II&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="241"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_treasure_hunter_2_objective` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_treasure_hunter_2_objective&quot;>Collect 10 Goblin Mail from combat&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="242"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_treasure_hunter_3_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_treasure_hunter_3_name&quot;>Treasure Hunter III&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="243"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_treasure_hunter_3_objective` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_treasure_hunter_3_objective&quot;>Collect 5 Demon Horns from combat&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="244"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_treasure_hunter_4_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_treasure_hunter_4_name&quot;>Treasure Hunter IV&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="245"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_treasure_hunter_4_objective` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_treasure_hunter_4_objective&quot;>Collect 3 Dragon Scales from combat&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="246"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_firemaking_1_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_firemaking_1_name&quot;>Firemaking I&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="249"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_firemaking_1_objective` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_firemaking_1_objective&quot;>Burn 500 Logs&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="250"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_firemaking_2_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_firemaking_2_name&quot;>Firemaking II&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="251"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_firemaking_2_objective` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_firemaking_2_objective&quot;>Burn 750 Oak Logs&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="252"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_firemaking_3_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_firemaking_3_name&quot;>Firemaking III&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="253"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_firemaking_3_objective` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_firemaking_3_objective&quot;>Burn 1100 Willow Logs&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="254"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_firemaking_4_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_firemaking_4_name&quot;>Firemaking IV&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="255"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_firemaking_4_objective` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_firemaking_4_objective&quot;>Burn 1650 Maple Logs&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="256"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_firemaking_5_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_firemaking_5_name&quot;>Firemaking V&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="257"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_firemaking_5_objective` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_firemaking_5_objective&quot;>Burn 2450 Yew Logs&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="258"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_firemaking_6_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_firemaking_6_name&quot;>Firemaking VI&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="259"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_firemaking_6_objective` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_firemaking_6_objective&quot;>Burn 3650 Magic Logs&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="260"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_runecrafting_1_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_runecrafting_1_name&quot;>Runecrafting I&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="263"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_runecrafting_1_objective` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_runecrafting_1_objective&quot;>Craft 500 Air Runes&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="264"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_runecrafting_2_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_runecrafting_2_name&quot;>Runecrafting II&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="265"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_runecrafting_2_objective` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_runecrafting_2_objective&quot;>Craft 750 Water Runes&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="266"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_runecrafting_3_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_runecrafting_3_name&quot;>Runecrafting III&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="267"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_runecrafting_3_objective` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_runecrafting_3_objective&quot;>Craft 1100 Earth Runes&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="268"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_runecrafting_4_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_runecrafting_4_name&quot;>Runecrafting IV&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="269"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_runecrafting_4_objective` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_runecrafting_4_objective&quot;>Craft 1650 Fire Runes&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="270"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_runecrafting_5_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_runecrafting_5_name&quot;>Runecrafting V&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="271"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_runecrafting_5_objective` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_runecrafting_5_objective&quot;>Craft 2450 Mind Runes&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="272"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_runecrafting_6_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_runecrafting_6_name&quot;>Runecrafting VI&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="273"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_runecrafting_6_objective` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_runecrafting_6_objective&quot;>Craft 3650 Chaos Runes&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="274"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_herblore_1_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_herblore_1_name&quot;>Herblore I&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="277"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_herblore_1_objective` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_herblore_1_objective&quot;>Brew 100 Attack Brews&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="278"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_herblore_2_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_herblore_2_name&quot;>Herblore II&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="279"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_herblore_2_objective` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_herblore_2_objective&quot;>Mix 250 Defense Potions&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="280"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_herblore_3_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_herblore_3_name&quot;>Herblore III&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="281"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_herblore_3_objective` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_herblore_3_objective&quot;>Mix 500 Strength Potions&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="282"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_herblore_4_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_herblore_4_name&quot;>Herblore IV&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="283"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_herblore_4_objective` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_herblore_4_objective&quot;>Mix 750 Ranging Potions&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="284"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_herblore_5_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_herblore_5_name&quot;>Herblore V&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="285"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_herblore_5_objective` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_herblore_5_objective&quot;>Mix 1000 Magic Potions&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="286"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_herblore_6_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_herblore_6_name&quot;>Herblore VI&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="287"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_herblore_6_objective` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_herblore_6_objective&quot;>Mix 1500 Super Strength Potions&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="288"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_combat_kills_7_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_combat_kills_7_name&quot;>Monster Hunter VII&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="291"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_combat_kills_7_objective` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_combat_kills_7_objective&quot;>Defeat 1000 enemies&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="292"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_combat_kills_8_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_combat_kills_8_name&quot;>Monster Hunter VIII&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="293"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_combat_kills_8_objective` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_combat_kills_8_objective&quot;>Defeat 1500 enemies&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="294"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_combat_kills_9_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_combat_kills_9_name&quot;>Monster Hunter IX&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="295"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_combat_kills_9_objective` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_combat_kills_9_objective&quot;>Defeat 2250 enemies&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="296"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_combat_kills_10_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_combat_kills_10_name&quot;>Monster Hunter X&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="297"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_combat_kills_10_objective` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_combat_kills_10_objective&quot;>Defeat 3400 enemies&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="298"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_combat_kills_11_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_combat_kills_11_name&quot;>Monster Hunter XI&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="299"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_combat_kills_11_objective` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_combat_kills_11_objective&quot;>Defeat 5100 enemies&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="300"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_combat_kills_12_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_combat_kills_12_name&quot;>Monster Hunter XII&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="301"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_combat_kills_12_objective` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_combat_kills_12_objective&quot;>Defeat 7650 enemies&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="302"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_zombie_slayer_1_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_zombie_slayer_1_name&quot;>Zombie Slayer I&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="305"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_zombie_slayer_1_objective` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_zombie_slayer_1_objective&quot;>Defeat 35 Zombies&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="306"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_zombie_slayer_2_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_zombie_slayer_2_name&quot;>Zombie Slayer II&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="307"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_zombie_slayer_2_objective` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_zombie_slayer_2_objective&quot;>Defeat 70 Zombies&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="308"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_hellhound_slayer_1_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_hellhound_slayer_1_name&quot;>Hellhound Slayer I&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="309"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_hellhound_slayer_1_objective` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_hellhound_slayer_1_objective&quot;>Defeat 25 Hellhounds&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="310"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_hellhound_slayer_2_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_hellhound_slayer_2_name&quot;>Hellhound Slayer II&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="311"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_hellhound_slayer_2_objective` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_hellhound_slayer_2_objective&quot;>Defeat 50 Hellhounds&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="312"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_troll_slayer_1_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_troll_slayer_1_name&quot;>Troll Slayer I&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="313"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_troll_slayer_1_objective` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_troll_slayer_1_objective&quot;>Defeat 20 Mountain Trolls&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="314"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_troll_slayer_2_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_troll_slayer_2_name&quot;>Troll Slayer II&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="315"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_troll_slayer_2_objective` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_troll_slayer_2_objective&quot;>Defeat 40 Mountain Trolls&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="316"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_fire_giant_slayer_1_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_fire_giant_slayer_1_name&quot;>Fire Giant Slayer I&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="317"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_fire_giant_slayer_1_objective` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_fire_giant_slayer_1_objective&quot;>Defeat 15 Fire Giants&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="318"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_fire_giant_slayer_2_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_fire_giant_slayer_2_name&quot;>Fire Giant Slayer II&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="319"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_fire_giant_slayer_2_objective` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_fire_giant_slayer_2_objective&quot;>Defeat 30 Fire Giants&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="320"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_ancient_guardian_slayer_1_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_ancient_guardian_slayer_1_name&quot;>Ancient Guardian Slayer I&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="321"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_ancient_guardian_slayer_1_objective` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_ancient_guardian_slayer_1_objective&quot;>Defeat 10 Ancient Guardians&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="322"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_ancient_guardian_slayer_2_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_ancient_guardian_slayer_2_name&quot;>Ancient Guardian Slayer II&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="323"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_ancient_guardian_slayer_2_objective` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_ancient_guardian_slayer_2_objective&quot;>Defeat 20 Ancient Guardians&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="324"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_lich_slayer_1_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_lich_slayer_1_name&quot;>Lich Slayer I&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="325"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_lich_slayer_1_objective` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_lich_slayer_1_objective&quot;>Defeat 10 Liches&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="326"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_lich_slayer_2_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_lich_slayer_2_name&quot;>Lich Slayer II&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="327"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_lich_slayer_2_objective` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_lich_slayer_2_objective&quot;>Defeat 20 Liches&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="328"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_dungeon_imp_1_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_dungeon_imp_1_name&quot;>Dungeon Explorer VII&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="331"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_dungeon_imp_1_objective` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_dungeon_imp_1_objective&quot;>Complete the Imp Cavern 5 times&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="332"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_dungeon_infernal_1_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_dungeon_infernal_1_name&quot;>Dungeon Master IV&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="333"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_dungeon_infernal_1_objective` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_dungeon_infernal_1_objective&quot;>Complete the Infernal Stronghold 5 times&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="334"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_dungeon_ancient_1_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_dungeon_ancient_1_name&quot;>Dungeon Master V&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="335"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_dungeon_ancient_1_objective` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_dungeon_ancient_1_objective&quot;>Complete the Ancient Temple 5 times&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="336"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_kbd_slayer_1_objective` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_kbd_slayer_1_objective&quot;>Defeat the King Black Dragon&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="339"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_kbd_slayer_2_objective` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_kbd_slayer_2_objective&quot;>Defeat the King Black Dragon 5 times&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="340"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_kbd_slayer_3_objective` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_kbd_slayer_3_objective&quot;>Defeat the King Black Dragon 25 times&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="341"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_kbd_slayer_4_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_kbd_slayer_4_name&quot;>King Black Dragon Slayer IV&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="342"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_kbd_slayer_4_objective` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_kbd_slayer_4_objective&quot;>Defeat the King Black Dragon 50 times&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="343"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_demon_slayer_4_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_demon_slayer_4_name&quot;>Demon Slayer IV&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="344"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_demon_slayer_4_objective` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_demon_slayer_4_objective&quot;>Defeat the Demon Lord 50 times&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="345"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_kraken_killer_1_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_kraken_killer_1_name&quot;>Kraken Killer I&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="346"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_kraken_killer_1_objective` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_kraken_killer_1_objective&quot;>Defeat the Kraken&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="347"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_kraken_killer_2_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_kraken_killer_2_name&quot;>Kraken Killer II&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="348"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_kraken_killer_2_objective` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_kraken_killer_2_objective&quot;>Defeat the Kraken 5 times&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="349"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_kraken_killer_3_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_kraken_killer_3_name&quot;>Kraken Killer III&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="350"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_kraken_killer_3_objective` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_kraken_killer_3_objective&quot;>Defeat the Kraken 25 times&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="351"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_kraken_killer_4_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_kraken_killer_4_name&quot;>Kraken Killer IV&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="352"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_kraken_killer_4_objective` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_kraken_killer_4_objective&quot;>Defeat the Kraken 50 times&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="353"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_balrog_bane_1_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_balrog_bane_1_name&quot;>Balrog Bane I&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="354"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_balrog_bane_1_objective` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_balrog_bane_1_objective&quot;>Defeat the Balrog&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="355"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_balrog_bane_2_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_balrog_bane_2_name&quot;>Balrog Bane II&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="356"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_balrog_bane_2_objective` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_balrog_bane_2_objective&quot;>Defeat the Balrog 5 times&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="357"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_balrog_bane_3_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_balrog_bane_3_name&quot;>Balrog Bane III&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="358"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_balrog_bane_3_objective` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_balrog_bane_3_objective&quot;>Defeat the Balrog 25 times&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="359"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_balrog_bane_4_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_balrog_bane_4_name&quot;>Balrog Bane IV&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="360"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_balrog_bane_4_objective` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_balrog_bane_4_objective&quot;>Defeat the Balrog 50 times&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="361"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_melee_warrior_4_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_melee_warrior_4_name&quot;>Melee Warrior IV&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="364"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_melee_warrior_4_objective` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_melee_warrior_4_objective&quot;>Complete the Orc Stronghold using only melee&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="365"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_melee_warrior_5_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_melee_warrior_5_name&quot;>Melee Warrior V&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="366"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_melee_warrior_5_objective` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_melee_warrior_5_objective&quot;>Complete the Dragon\&apos;s Lair using only melee&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="367"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_ranger_elite_4_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_ranger_elite_4_name&quot;>Ranger Elite IV&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="368"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_ranger_elite_4_objective` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_ranger_elite_4_objective&quot;>Complete the Orc Stronghold using only ranged&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="369"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_ranger_elite_5_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_ranger_elite_5_name&quot;>Ranger Elite V&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="370"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_ranger_elite_5_objective` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_ranger_elite_5_objective&quot;>Complete the Dragon\&apos;s Lair using only ranged&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="371"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_mage_master_4_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_mage_master_4_name&quot;>Mage Master IV&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="372"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_mage_master_4_objective` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_mage_master_4_objective&quot;>Complete the Orc Stronghold using only magic&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="373"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_mage_master_5_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_mage_master_5_name&quot;>Mage Master V&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="374"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_mage_master_5_objective` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_mage_master_5_objective&quot;>Complete the Dragon\&apos;s Lair using only magic&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="375"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_iron_stomach_5_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_iron_stomach_5_name&quot;>Iron Stomach V&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="378"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_iron_stomach_5_objective` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_iron_stomach_5_objective&quot;>Complete the Infernal Stronghold without using food&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="379"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_iron_stomach_6_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_iron_stomach_6_name&quot;>Iron Stomach VI&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="380"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_iron_stomach_6_objective` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_iron_stomach_6_objective&quot;>Complete the Ancient Temple without using food&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="381"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_treasure_hunter_5_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_treasure_hunter_5_name&quot;>Treasure Hunter V&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="384"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_treasure_hunter_5_objective` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_treasure_hunter_5_objective&quot;>Collect 10 Hellhound Fangs from combat&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="385"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_treasure_hunter_6_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_treasure_hunter_6_name&quot;>Treasure Hunter VI&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="386"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_treasure_hunter_6_objective` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_treasure_hunter_6_objective&quot;>Collect 15 Troll Bones from combat&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="387"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_daily_mine_iron_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_daily_mine_iron_name&quot;>Iron Miner&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="398"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_daily_mine_coal_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_daily_mine_coal_name&quot;>Coal Hauler&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="399"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_daily_mine_mithril_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_daily_mine_mithril_name&quot;>Mithril Prospector&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="400"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_daily_mine_runite_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_daily_mine_runite_name&quot;>Runite Rush&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="401"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_daily_fish_salmon_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_daily_fish_salmon_name&quot;>Salmon Run&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="402"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_daily_fish_lobster_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_daily_fish_lobster_name&quot;>Lobster Haul&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="403"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_daily_fish_swordfish_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_daily_fish_swordfish_name&quot;>Swordfish Hunter&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="404"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_daily_fish_shark_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_daily_fish_shark_name&quot;>Shark Wrangler&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="405"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_daily_wc_oak_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_daily_wc_oak_name&quot;>Oak Chopper&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="406"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_daily_wc_willow_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_daily_wc_willow_name&quot;>Willow Worker&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="407"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_daily_wc_yew_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_daily_wc_yew_name&quot;>Yew Logger&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="408"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_daily_wc_magic_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_daily_wc_magic_name&quot;>Magic Lumberjack&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="409"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_daily_smith_iron_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_daily_smith_iron_name&quot;>Iron Smith&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="410"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_daily_smith_mithril_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_daily_smith_mithril_name&quot;>Mithril Forger&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="411"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_daily_smith_adamantite_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_daily_smith_adamantite_name&quot;>Adamantite Artisan&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="412"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_daily_smith_runite_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_daily_smith_runite_name&quot;>Runite Smelter&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="413"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_daily_cook_trout_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_daily_cook_trout_name&quot;>Trout Chef&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="414"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_daily_cook_salmon_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_daily_cook_salmon_name&quot;>Salmon Griller&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="415"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_daily_cook_lobster_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_daily_cook_lobster_name&quot;>Lobster Cook&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="416"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_daily_cook_swordfish_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_daily_cook_swordfish_name&quot;>Swordfish Cook&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="417"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_daily_kill_goblin_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_daily_kill_goblin_name&quot;>Goblin Slayer&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="418"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_daily_kill_bandit_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_daily_kill_bandit_name&quot;>Bandit Buster&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="419"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_daily_kill_demon_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_daily_kill_demon_name&quot;>Demon Hunter&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="420"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.quest_daily_kill_dragon_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;quest_daily_kill_dragon_name&quot;>Dragon Slayer&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="421"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.daily_verb_crafting` appears to be unused"
+        errorLine1="    &lt;string name=&quot;daily_verb_crafting&quot;>Craft&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="424"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.daily_verb_firemaking` appears to be unused"
+        errorLine1="    &lt;string name=&quot;daily_verb_firemaking&quot;>Burn&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="425"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.daily_verb_fletching` appears to be unused"
+        errorLine1="    &lt;string name=&quot;daily_verb_fletching&quot;>Fletch&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="426"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.daily_verb_herblore` appears to be unused"
+        errorLine1="    &lt;string name=&quot;daily_verb_herblore&quot;>Brew&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="427"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.daily_verb_runecrafting` appears to be unused"
+        errorLine1="    &lt;string name=&quot;daily_verb_runecrafting&quot;>Craft&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="428"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.daily_verb_prayer` appears to be unused"
+        errorLine1="    &lt;string name=&quot;daily_verb_prayer&quot;>Bury&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_quests.xml"
+            line="429"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.skill_mining_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;skill_mining_name&quot;>Mining&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_skills.xml"
+            line="6"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.skill_fishing_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;skill_fishing_name&quot;>Fishing&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_skills.xml"
+            line="8"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.skill_woodcutting_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;skill_woodcutting_name&quot;>Woodcutting&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_skills.xml"
+            line="10"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.skill_farming_desc` appears to be unused"
+        errorLine1="    &lt;string name=&quot;skill_farming_desc&quot;>Plant and harvest crops from your farming patches.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_skills.xml"
+            line="13"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.skill_agility_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;skill_agility_name&quot;>Agility&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_skills.xml"
+            line="16"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.skill_smithing_desc` appears to be unused"
+        errorLine1="    &lt;string name=&quot;skill_smithing_desc&quot;>Smelt ores into bars and forge powerful metal equipment.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_skills.xml"
+            line="21"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.skill_cooking_desc` appears to be unused"
+        errorLine1="    &lt;string name=&quot;skill_cooking_desc&quot;>Cook raw ingredients into food that restores HP in combat.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_skills.xml"
+            line="23"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.skill_fletching_desc` appears to be unused"
+        errorLine1="    &lt;string name=&quot;skill_fletching_desc&quot;>Craft bows and arrows from logs and metal components.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_skills.xml"
+            line="25"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.skill_crafting_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;skill_crafting_name&quot;>Crafting&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_skills.xml"
+            line="26"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.skill_crafting_desc` appears to be unused"
+        errorLine1="    &lt;string name=&quot;skill_crafting_desc&quot;>Create jewellery and other crafted items from precious materials.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_skills.xml"
+            line="27"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.skill_herblore_desc` appears to be unused"
+        errorLine1="    &lt;string name=&quot;skill_herblore_desc&quot;>Brew potions from farming herbs and dungeon reagents to boost your combat stats.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_skills.xml"
+            line="31"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.skill_attack_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;skill_attack_name&quot;>Attack&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_skills.xml"
+            line="34"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.skill_attack_desc` appears to be unused"
+        errorLine1="    &lt;string name=&quot;skill_attack_desc&quot;>Improves your melee accuracy, increasing your chance to hit.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_skills.xml"
+            line="35"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.skill_strength_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;skill_strength_name&quot;>Strength&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_skills.xml"
+            line="36"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.skill_strength_desc` appears to be unused"
+        errorLine1="    &lt;string name=&quot;skill_strength_desc&quot;>Increases your maximum melee damage per hit.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_skills.xml"
+            line="37"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.skill_defense_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;skill_defense_name&quot;>Defense&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_skills.xml"
+            line="38"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.skill_defense_desc` appears to be unused"
+        errorLine1="    &lt;string name=&quot;skill_defense_desc&quot;>Reduces the damage you take from enemy attacks.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_skills.xml"
+            line="39"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.skill_ranged_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;skill_ranged_name&quot;>Ranged&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_skills.xml"
+            line="40"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.skill_ranged_desc` appears to be unused"
+        errorLine1="    &lt;string name=&quot;skill_ranged_desc&quot;>Attack enemies from a safe distance using a bow and arrows.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_skills.xml"
+            line="41"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.skill_magic_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;skill_magic_name&quot;>Magic&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_skills.xml"
+            line="42"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.skill_magic_desc` appears to be unused"
+        errorLine1="    &lt;string name=&quot;skill_magic_desc&quot;>Cast powerful spells using runes. Higher levels unlock stronger spells.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_skills.xml"
+            line="43"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.skill_hitpoints_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;skill_hitpoints_name&quot;>Hitpoints&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_skills.xml"
+            line="44"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.skill_hitpoints_desc` appears to be unused"
+        errorLine1="    &lt;string name=&quot;skill_hitpoints_desc&quot;>Your total health. Higher levels let you survive longer in combat.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_skills.xml"
+            line="45"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.skill_prayer_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;skill_prayer_name&quot;>Prayer&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_skills.xml"
+            line="46"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.agility_beginner_course_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;agility_beginner_course_name&quot;>Beginner Course&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_skills.xml"
+            line="59"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.agility_beginner_course_desc` appears to be unused"
+        errorLine1="    &lt;string name=&quot;agility_beginner_course_desc&quot;>A simple obstacle course for those just starting their agility training.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_skills.xml"
+            line="60"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.agility_novice_course_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;agility_novice_course_name&quot;>Novice Course&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_skills.xml"
+            line="61"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.agility_novice_course_desc` appears to be unused"
+        errorLine1="    &lt;string name=&quot;agility_novice_course_desc&quot;>A slightly more challenging course with basic obstacles.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_skills.xml"
+            line="62"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.agility_apprentice_course_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;agility_apprentice_course_name&quot;>Apprentice Course&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_skills.xml"
+            line="63"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.agility_apprentice_course_desc` appears to be unused"
+        errorLine1="    &lt;string name=&quot;agility_apprentice_course_desc&quot;>An intermediate course requiring some skill to navigate.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_skills.xml"
+            line="64"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.agility_intermediate_course_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;agility_intermediate_course_name&quot;>Intermediate Course&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_skills.xml"
+            line="65"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.agility_intermediate_course_desc` appears to be unused"
+        errorLine1="    &lt;string name=&quot;agility_intermediate_course_desc&quot;>A moderately difficult course with tricky obstacles.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_skills.xml"
+            line="66"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.agility_advanced_course_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;agility_advanced_course_name&quot;>Advanced Course&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_skills.xml"
+            line="67"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.agility_advanced_course_desc` appears to be unused"
+        errorLine1="    &lt;string name=&quot;agility_advanced_course_desc&quot;>A challenging course that tests your agility prowess.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_skills.xml"
+            line="68"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.agility_expert_course_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;agility_expert_course_name&quot;>Expert Course&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_skills.xml"
+            line="69"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.agility_expert_course_desc` appears to be unused"
+        errorLine1="    &lt;string name=&quot;agility_expert_course_desc&quot;>An expert-level course with dangerous obstacles.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_skills.xml"
+            line="70"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.agility_elite_course_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;agility_elite_course_name&quot;>Elite Course&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_skills.xml"
+            line="71"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.agility_elite_course_desc` appears to be unused"
+        errorLine1="    &lt;string name=&quot;agility_elite_course_desc&quot;>Only the most agile can master this elite course.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_skills.xml"
+            line="72"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.agility_master_course_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;agility_master_course_name&quot;>Master Course&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_skills.xml"
+            line="73"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.agility_master_course_desc` appears to be unused"
+        errorLine1="    &lt;string name=&quot;agility_master_course_desc&quot;>A master-tier course with extreme obstacles.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_skills.xml"
+            line="74"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.agility_veteran_course_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;agility_veteran_course_name&quot;>Veteran Course&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_skills.xml"
+            line="75"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.agility_veteran_course_desc` appears to be unused"
+        errorLine1="    &lt;string name=&quot;agility_veteran_course_desc&quot;>A veteran\&apos;s training ground with punishing challenges.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_skills.xml"
+            line="76"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.agility_champion_course_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;agility_champion_course_name&quot;>Champion Course&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_skills.xml"
+            line="77"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.agility_champion_course_desc` appears to be unused"
+        errorLine1="    &lt;string name=&quot;agility_champion_course_desc&quot;>A champion-level course that pushes you to your limits.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_skills.xml"
+            line="78"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.agility_heroic_course_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;agility_heroic_course_name&quot;>Heroic Course&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_skills.xml"
+            line="79"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.agility_heroic_course_desc` appears to be unused"
+        errorLine1="    &lt;string name=&quot;agility_heroic_course_desc&quot;>A heroic course where only the best dare to tread.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_skills.xml"
+            line="80"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.agility_legendary_course_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;agility_legendary_course_name&quot;>Legendary Course&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_skills.xml"
+            line="81"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.agility_legendary_course_desc` appears to be unused"
+        errorLine1="    &lt;string name=&quot;agility_legendary_course_desc&quot;>A legendary course spoken of in whispers among the agile elite.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_skills.xml"
+            line="82"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.agility_mythic_course_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;agility_mythic_course_name&quot;>Mythic Course&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_skills.xml"
+            line="83"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.agility_mythic_course_desc` appears to be unused"
+        errorLine1="    &lt;string name=&quot;agility_mythic_course_desc&quot;>A mythical course that defies the laws of physics.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_skills.xml"
+            line="84"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.agility_divine_course_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;agility_divine_course_name&quot;>Divine Course&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_skills.xml"
+            line="85"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.agility_divine_course_desc` appears to be unused"
+        errorLine1="    &lt;string name=&quot;agility_divine_course_desc&quot;>A divine course blessed by the gods of agility.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_skills.xml"
+            line="86"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.agility_transcendent_course_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;agility_transcendent_course_name&quot;>Transcendent Course&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_skills.xml"
+            line="87"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.agility_transcendent_course_desc` appears to be unused"
+        errorLine1="    &lt;string name=&quot;agility_transcendent_course_desc&quot;>The ultimate test of agility, transcending mortal limits.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings_skills.xml"
+            line="88"
+            column="13"/>
+    </issue>
+
+</issues>

--- a/app/src/main/kotlin/com/fantasyidler/simulator/MercantileSimulator.kt
+++ b/app/src/main/kotlin/com/fantasyidler/simulator/MercantileSimulator.kt
@@ -17,6 +17,7 @@ object MercantileSimulator {
         route: TradeRouteData,
         startXp: Long,
         agilityLevel: Int = 1,
+        random: Random = Random.Default,
     ): Result {
         var currentXp = startXp
         val frames = mutableListOf<SessionFrame>()
@@ -27,11 +28,11 @@ object MercantileSimulator {
         for (minute in 1..60) {
             val xpBefore   = currentXp
             val levelBefore = XpTable.levelForXp(currentXp)
-            val xpGain     = Random.nextInt(xpRange.min, xpRange.max + 1)
+            val xpGain     = random.nextInt(xpRange.min, xpRange.max + 1)
             currentXp += xpGain
             val levelAfter = XpTable.levelForXp(currentXp)
 
-            val coinReturn = Random.nextInt(coinRange.min, coinRange.max + 1)
+            val coinReturn = random.nextInt(coinRange.min, coinRange.max + 1)
 
             frames += SessionFrame(
                 minute      = minute,

--- a/app/src/main/kotlin/com/fantasyidler/simulator/SkillSimulator.kt
+++ b/app/src/main/kotlin/com/fantasyidler/simulator/SkillSimulator.kt
@@ -54,6 +54,7 @@ object SkillSimulator {
         toolEfficiency: Float = 1.0f,
         petDropKey: String? = null,
         petDropChance: Double = 0.0,
+        random: Random = Random.Default,
     ): Result {
         var currentXp = startXp
         val frames = mutableListOf<SessionFrame>()
@@ -75,12 +76,12 @@ object SkillSimulator {
             // Bonus gem rolls — one independent roll per ore mined per gem type
             for (i in 0 until oreQty) {
                 for ((gemKey, gemData) in gems) {
-                    if (Random.nextDouble() < gemData.dropRate) {
+                    if (random.nextDouble() < gemData.dropRate) {
                         items[gemKey] = (items[gemKey] ?: 0) + 1
                     }
                 }
             }
-            if (petDropKey != null && petDropChance > 0.0 && Random.nextDouble() < petDropChance) {
+            if (petDropKey != null && petDropChance > 0.0 && random.nextDouble() < petDropChance) {
                 items[petDropKey] = 1
             }
 
@@ -118,6 +119,7 @@ object SkillSimulator {
         toolEfficiency: Float = 1.0f,
         petDropKey: String? = null,
         petDropChance: Double = 0.0,
+        random: Random = Random.Default,
     ): Result {
         var currentXp = startXp
         val frames = mutableListOf<SessionFrame>()
@@ -134,7 +136,7 @@ object SkillSimulator {
 
             val logQty = max(1, toolEfficiency.roundToInt())
             val items = mutableMapOf(treeData.logName to logQty)
-            if (petDropKey != null && petDropChance > 0.0 && Random.nextDouble() < petDropChance) {
+            if (petDropKey != null && petDropChance > 0.0 && random.nextDouble() < petDropChance) {
                 items[petDropKey] = 1
             }
 
@@ -169,6 +171,7 @@ object SkillSimulator {
         petDropKey: String? = null,
         petDropChance: Double = 0.0,
         fishingSkillData: GatheringSkillData? = null,
+        random: Random = Random.Default,
     ): Result {
         var currentXp = startXp
         val frames = mutableListOf<SessionFrame>()
@@ -185,10 +188,10 @@ object SkillSimulator {
 
             val fishQty = max(1, rodEfficiency.roundToInt())
             val items = mutableMapOf<String, Int>()
-            if (fishingSkillData != null && Random.nextDouble() > 0.8) {
+            if (fishingSkillData != null && random.nextDouble() > 0.8) {
                 val dropTable = getTierData(fishingSkillData.dropTables, levelBefore)
                 for (entry in dropTable) {
-                    if (Random.nextDouble() < entry.chance) {
+                    if (random.nextDouble() < entry.chance) {
                         items[entry.item] = (items[entry.item] ?: 0) + 1
                     }
                 }
@@ -196,7 +199,7 @@ object SkillSimulator {
             } else {
                 items[fishKey] = fishQty
             }
-            if (petDropKey != null && petDropChance > 0.0 && Random.nextDouble() < petDropChance) {
+            if (petDropKey != null && petDropChance > 0.0 && random.nextDouble() < petDropChance) {
                 items[petDropKey] = 1
             }
 
@@ -235,6 +238,7 @@ object SkillSimulator {
         petDropKey: String? = null,
         petDropChance: Double = 0.0,
         forcedDropPerFrame: String? = null,
+        random: Random = Random.Default,
     ): Result {
         var currentXp = startXp
         val frames = mutableListOf<SessionFrame>()
@@ -244,7 +248,7 @@ object SkillSimulator {
             val levelBefore = XpTable.levelForXp(currentXp)
 
             val xpRange = getTierData(skillData.xpRanges, levelBefore)
-            val baseXp = (Random.nextInt(xpRange.min, xpRange.max + 1) * toolEfficiency).toInt()
+            val baseXp = (random.nextInt(xpRange.min, xpRange.max + 1) * toolEfficiency).toInt()
             val xpGain = applyPetBoost(baseXp, petBoostPct)
 
             currentXp += xpGain
@@ -255,14 +259,14 @@ object SkillSimulator {
                             else getTierData(skillData.dropTables, levelBefore)
             val items = mutableMapOf<String, Int>()
             for (entry in dropTable) {
-                if (Random.nextDouble() < entry.chance) {
+                if (random.nextDouble() < entry.chance) {
                     items[entry.item] = (items[entry.item] ?: 0) + 1
                 }
             }
             if (forcedDropPerFrame != null) {
                 items[forcedDropPerFrame] = (items[forcedDropPerFrame] ?: 0) + 1
             }
-            if (petDropKey != null && petDropChance > 0.0 && Random.nextDouble() < petDropChance) {
+            if (petDropKey != null && petDropChance > 0.0 && random.nextDouble() < petDropChance) {
                 items[petDropKey] = 1
             }
 
@@ -301,6 +305,7 @@ object SkillSimulator {
         startXp: Long,
         agilityLevel: Int = 1,
         petBoostPct: Int = 0,
+        random: Random = Random.Default,
     ): Result {
         var currentXp = startXp
         val frames = mutableListOf<SessionFrame>()
@@ -312,7 +317,7 @@ object SkillSimulator {
             val xpBefore    = currentXp
             val levelBefore = XpTable.levelForXp(currentXp)
 
-            val successfulLaps = (0 until LAPS_PER_MINUTE).count { Random.nextDouble() < successRate }
+            val successfulLaps = (0 until LAPS_PER_MINUTE).count { random.nextDouble() < successRate }
             val baseXp = successfulLaps * courseData.xpPerSuccess
             val xpGain = applyPetBoost(baseXp, petBoostPct)
 

--- a/app/src/main/kotlin/com/fantasyidler/simulator/SkillingDungeonSimulator.kt
+++ b/app/src/main/kotlin/com/fantasyidler/simulator/SkillingDungeonSimulator.kt
@@ -23,6 +23,7 @@ object SkillingDungeonSimulator {
         agilityLevel: Int = 1,
         toolEfficiency: Float = 1.0f,
         petBoostPct: Int = 0,
+        random: Random = Random.Default,
     ): SkillSimulator.Result {
         var currentXp = startXp
         val frames = mutableListOf<SessionFrame>()
@@ -33,7 +34,7 @@ object SkillingDungeonSimulator {
             val levelBefore = XpTable.levelForXp(currentXp)
 
             val xpRange = getTierData(dungeon.xpRanges, levelBefore)
-            val baseXp = (Random.nextInt(xpRange.min, xpRange.max + 1) * toolEfficiency).toInt()
+            val baseXp = (random.nextInt(xpRange.min, xpRange.max + 1) * toolEfficiency).toInt()
             val xpGain = if (petBoostPct > 0) (baseXp * (1.0 + petBoostPct / 100.0)).toInt() else baseXp
 
             currentXp += xpGain
@@ -43,12 +44,12 @@ object SkillingDungeonSimulator {
                             else getTierData(dungeon.dropTables, levelBefore)
             val items = mutableMapOf<String, Int>()
             for (entry in dropTable) {
-                if (Random.nextDouble() < entry.chance) {
+                if (random.nextDouble() < entry.chance) {
                     items[entry.item] = (items[entry.item] ?: 0) + 1
                 }
             }
 
-            if (Random.nextDouble() < dungeon.noteChancePerFrame) {
+            if (random.nextDouble() < dungeon.noteChancePerFrame) {
                 items[noteKey] = (items[noteKey] ?: 0) + 1
             }
 

--- a/app/src/test/kotlin/com/fantasyidler/simulator/MercantileSimulatorTest.kt
+++ b/app/src/test/kotlin/com/fantasyidler/simulator/MercantileSimulatorTest.kt
@@ -1,0 +1,38 @@
+package com.fantasyidler.simulator
+
+import com.fantasyidler.data.json.CoinRange
+import com.fantasyidler.data.json.TradeRouteData
+import com.fantasyidler.data.json.XpRange
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import kotlin.random.Random
+
+/** Outcome tests for [MercantileSimulator] using the injected `random` seam. */
+class MercantileSimulatorTest {
+
+    private fun route(xp: XpRange, coins: CoinRange) = TradeRouteData(
+        id = "silk", displayName = "Silk Road", description = "", levelRequired = 1, coinCost = 0,
+        xpRanges = mapOf("1" to xp),
+        coinRanges = mapOf("1" to coins),
+    )
+
+    @Test
+    fun `fixed XP and coin ranges yield exact totals over 60 frames`() {
+        val r = MercantileSimulator.simulate(route(XpRange(4, 4), CoinRange(20, 20)), startXp = 0, random = Random(11))
+        assertEquals(60, r.frames.size)
+        assertTrue(r.frames.all { it.xpGain == 4 })
+        assertEquals(240L, r.frames.sumOf { it.xpGain.toLong() })
+        assertTrue(r.frames.all { (it.items["_coins"] ?: 0) == 20 })
+    }
+
+    @Test
+    fun `wide ranges stay within bounds and seeded runs reproduce`() {
+        val cfg = route(XpRange(2, 9), CoinRange(5, 50))
+        val a = MercantileSimulator.simulate(cfg, startXp = 0, random = Random(123))
+        val b = MercantileSimulator.simulate(cfg, startXp = 0, random = Random(123))
+        assertEquals(a.frames, b.frames)
+        assertTrue(a.frames.all { it.xpGain in 2..9 })
+        assertTrue(a.frames.all { (it.items["_coins"] ?: 0) in 5..50 })
+    }
+}

--- a/app/src/test/kotlin/com/fantasyidler/simulator/SkillSimulatorRngTest.kt
+++ b/app/src/test/kotlin/com/fantasyidler/simulator/SkillSimulatorRngTest.kt
@@ -1,0 +1,110 @@
+package com.fantasyidler.simulator
+
+import com.fantasyidler.data.json.AgilityCourseData
+import com.fantasyidler.data.json.FishData
+import com.fantasyidler.data.json.GatheringSkillData
+import com.fantasyidler.data.json.GemData
+import com.fantasyidler.data.json.OreData
+import com.fantasyidler.data.json.SkillDropEntry
+import com.fantasyidler.data.json.TreeData
+import com.fantasyidler.data.json.XpRange
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import kotlin.random.Random
+
+/**
+ * Outcome tests for the RNG-driven [SkillSimulator] functions, made deterministic
+ * via the injected `random` seam.
+ *
+ * Strategy: where a value has no randomness (fixed per-action XP) or the
+ * randomness is pinned to a certain outcome (drop chance 0.0/1.0, single-value
+ * XP range), assert exact values; for genuinely stochastic parts assert
+ * reproducibility under a fixed seed plus range invariants.
+ */
+class SkillSimulatorRngTest {
+
+    private fun ore(xp: Int) = OreData(displayName = "Iron", levelRequired = 1, xpPerOre = xp, timePerOre = 1)
+    private fun tree(xp: Int) = TreeData(
+        displayName = "Oak", logName = "oak_log", logDisplayName = "Oak log",
+        levelRequired = 1, xpPerLog = xp, timePerLog = 1,
+    )
+    private fun fish(xp: Int) = FishData(displayName = "Trout", levelRequired = 1, xpPerCatch = xp, timePerCatch = 1)
+    private fun gatheringSkill(range: XpRange, drops: List<SkillDropEntry> = emptyList()) =
+        GatheringSkillData(
+            name = "mining", displayName = "Mining", description = "",
+            xpRanges = mapOf("1" to range),
+            dropTables = if (drops.isEmpty()) emptyMap() else mapOf("1" to drops),
+        )
+
+    @Test
+    fun `mining grants fixed XP per frame and is reproducible under a seed`() {
+        val a = SkillSimulator.simulateMining("iron_ore", ore(10), emptyMap(), startXp = 0, random = Random(42))
+        val b = SkillSimulator.simulateMining("iron_ore", ore(10), emptyMap(), startXp = 0, random = Random(42))
+
+        assertEquals(60, a.frames.size)
+        assertEquals(a.frames, b.frames)                       // same seed -> identical run
+        assertTrue(a.frames.all { it.xpGain == 10 })           // no RNG in mining XP
+        assertEquals(600L, a.frames.sumOf { it.xpGain.toLong() })
+        assertTrue(a.frames.all { (it.items["iron_ore"] ?: 0) == 1 })
+    }
+
+    @Test
+    fun `gem drop chance of 1 always drops and 0 never drops regardless of seed`() {
+        val always = GemData("Diamond", "", dropRate = 1.0, rarity = "rare")
+        val never = GemData("Diamond", "", dropRate = 0.0, rarity = "rare")
+
+        val withGem = SkillSimulator.simulateMining(
+            "iron_ore", ore(10), mapOf("diamond" to always), startXp = 0, random = Random(7),
+        )
+        val withoutGem = SkillSimulator.simulateMining(
+            "iron_ore", ore(10), mapOf("diamond" to never), startXp = 0, random = Random(7),
+        )
+
+        assertTrue(withGem.frames.all { (it.items["diamond"] ?: 0) == 1 })
+        assertTrue(withoutGem.frames.none { it.items.containsKey("diamond") })
+    }
+
+    @Test
+    fun `woodcutting and fishing produce their item every frame with fixed XP`() {
+        val wc = SkillSimulator.simulateWoodcutting(tree(8), startXp = 0, random = Random(1))
+        assertTrue(wc.frames.all { it.xpGain == 8 && (it.items["oak_log"] ?: 0) == 1 })
+
+        // With no fishingSkillData, fishing has no RNG in its item output.
+        val f = SkillSimulator.simulateFishing("trout", fish(12), startXp = 0, random = Random(1))
+        assertTrue(f.frames.all { it.xpGain == 12 && (it.items["trout"] ?: 0) == 1 })
+        assertEquals(720L, f.frames.sumOf { it.xpGain.toLong() })
+    }
+
+    @Test
+    fun `gathering XP is exact for a single-value range and bounded for a wide range`() {
+        // min == max -> XP is deterministic regardless of seed.
+        val fixed = SkillSimulator.simulateGathering(gatheringSkill(XpRange(5, 5)), startXp = 0, random = Random(99))
+        assertTrue(fixed.frames.all { it.xpGain == 5 })
+        assertEquals(300L, fixed.frames.sumOf { it.xpGain.toLong() })
+
+        // Wide range -> every roll must stay within [min, max].
+        val wide = SkillSimulator.simulateGathering(gatheringSkill(XpRange(3, 7)), startXp = 0, random = Random(99))
+        assertTrue(wide.frames.all { it.xpGain in 3..7 })
+    }
+
+    @Test
+    fun `gathering drop chance of 1 always drops and seeded runs reproduce`() {
+        val drops = listOf(SkillDropEntry(item = "nugget", chance = 1.0))
+        val a = SkillSimulator.simulateGathering(gatheringSkill(XpRange(5, 5), drops), startXp = 0, random = Random(3))
+        val b = SkillSimulator.simulateGathering(gatheringSkill(XpRange(5, 5), drops), startXp = 0, random = Random(3))
+        assertEquals(a.frames, b.frames)
+        assertTrue(a.frames.all { (it.items["nugget"] ?: 0) == 1 })
+    }
+
+    @Test
+    fun `agility XP is always a bounded multiple of xp-per-success and reproducible`() {
+        val course = AgilityCourseData(name = "gnome", displayName = "Gnome", levelRequired = 1, xpPerSuccess = 9)
+        val a = SkillSimulator.simulateAgility(course, startXp = 0, agilityLevel = 50, random = Random(5))
+        val b = SkillSimulator.simulateAgility(course, startXp = 0, agilityLevel = 50, random = Random(5))
+
+        assertEquals(a.frames, b.frames)
+        // At most LAPS_PER_MINUTE (2) successful laps per frame, each worth 9 XP.
+        assertTrue(a.frames.all { it.xpGain % 9 == 0 && it.xpGain in 0..18 })
+    }
+}

--- a/app/src/test/kotlin/com/fantasyidler/simulator/SkillingDungeonSimulatorTest.kt
+++ b/app/src/test/kotlin/com/fantasyidler/simulator/SkillingDungeonSimulatorTest.kt
@@ -1,0 +1,58 @@
+package com.fantasyidler.simulator
+
+import com.fantasyidler.data.json.SkillDropEntry
+import com.fantasyidler.data.json.SkillingDungeonData
+import com.fantasyidler.data.json.XpRange
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import kotlin.random.Random
+
+/** Outcome tests for [SkillingDungeonSimulator] using the injected `random` seam. */
+class SkillingDungeonSimulatorTest {
+
+    private fun dungeon(
+        xp: XpRange,
+        drops: List<SkillDropEntry> = emptyList(),
+        noteChance: Double = 0.0,
+    ) = SkillingDungeonData(
+        name = "caves", displayName = "Crystal Caves", description = "", skill = "mining", levelRequired = 1,
+        xpRanges = mapOf("1" to xp),
+        dropTables = if (drops.isEmpty()) emptyMap() else mapOf("1" to drops),
+        noteChancePerFrame = noteChance,
+        noteTexts = listOf("a", "b", "c", "d", "e"),
+        unlockDungeon = "deeper_caves",
+        unlockMessage = "Unlocked!",
+    )
+
+    @Test
+    fun `fixed XP range gives exact totals over 60 frames`() {
+        val r = SkillingDungeonSimulator.simulate("caves", dungeon(XpRange(6, 6)), startXp = 0, random = Random(8))
+        assertEquals(60, r.frames.size)
+        assertTrue(r.frames.all { it.xpGain == 6 })
+        assertEquals(360L, r.frames.sumOf { it.xpGain.toLong() })
+    }
+
+    @Test
+    fun `note chance of 1 drops a note every frame and 0 drops none`() {
+        val always = SkillingDungeonSimulator.simulate(
+            "caves", dungeon(XpRange(6, 6), noteChance = 1.0), startXp = 0, random = Random(8),
+        )
+        assertTrue(always.frames.all { (it.items["note_caves"] ?: 0) == 1 })
+
+        val never = SkillingDungeonSimulator.simulate(
+            "caves", dungeon(XpRange(6, 6), noteChance = 0.0), startXp = 0, random = Random(8),
+        )
+        assertTrue(never.frames.none { it.items.containsKey("note_caves") })
+    }
+
+    @Test
+    fun `guaranteed drop appears every frame and seeded runs reproduce`() {
+        val cfg = dungeon(XpRange(4, 10), drops = listOf(SkillDropEntry(item = "shard", chance = 1.0)))
+        val a = SkillingDungeonSimulator.simulate("caves", cfg, startXp = 0, random = Random(55))
+        val b = SkillingDungeonSimulator.simulate("caves", cfg, startXp = 0, random = Random(55))
+        assertEquals(a.frames, b.frames)
+        assertTrue(a.frames.all { (it.items["shard"] ?: 0) == 1 })
+        assertTrue(a.frames.all { it.xpGain in 4..10 })
+    }
+}


### PR DESCRIPTION
## What
Makes the gathering / mercantile / skilling-dungeon simulators testable by injecting the random source instead of using the global `Random`. Each `simulate*` function gains a `random: Random = Random.Default` parameter, so **every existing call site is unchanged and the shipping app behaves identically**.

Adds outcome tests that pin determinism: exact values where the roll is fixed (single-value XP ranges, drop chance 0.0/1.0) and seeded reproducibility + range invariants for the stochastic parts.

- `SkillSimulator`: mining / woodcutting / fishing / gathering / agility
- `MercantileSimulator`, `SkillingDungeonSimulator`

## Verification
`./gradlew testDebugUnitTest assembleDebug` green (defaults preserve all callers).

## Series
Stacked on #423 (CI). Until that merges, this PR's diff also shows the CI commit — please review/merge after #423.