### PR TITLE
Fix settings screen : frequency selector, strings

### DIFF
--- a/app/src/main/kotlin/com/fantasyidler/ui/screen/SettingsScreen.kt
+++ b/app/src/main/kotlin/com/fantasyidler/ui/screen/SettingsScreen.kt
@@ -444,25 +444,50 @@ fun SettingsScreen(
                 }
             )
 
-            val freqTitle = stringResource(R.string.settings_backup_frequency) +
-                if (backupFrequency == "daily" || backupFrequency == "weekly")
-                    " (${stringResource(R.string.settings_backup_at_5am)})" else ""
+            val freqSubtitle = if (backupFrequency == "daily" || backupFrequency == "weekly")
+                "${stringResource(R.string.settings_backup_at_5am)}" else ""
             SettingsRow(
-                title    = freqTitle,
-                subtitle = null,
+                title    = stringResource(R.string.settings_backup_frequency),
+                subtitle = freqSubtitle,
                 trailing = {
-                    Row(horizontalArrangement = Arrangement.spacedBy(4.dp)) {
-                        listOf(
-                            ""       to stringResource(R.string.settings_backup_off),
-                            "hourly" to stringResource(R.string.settings_backup_hourly),
-                            "daily"  to stringResource(R.string.settings_backup_daily),
-                            "weekly" to stringResource(R.string.settings_backup_weekly),
-                        ).forEach { (key, label) ->
-                            FilterChip(
-                                selected = backupFrequency == key,
-                                onClick  = { viewModel.setBackupFrequency(key) },
-                                label    = { Text(label, style = MaterialTheme.typography.labelSmall) },
-                            )
+                    val freqOptions = listOf(
+                        ""       to stringResource(R.string.settings_backup_off),
+                        "hourly" to stringResource(R.string.settings_backup_hourly),
+                        "daily"  to stringResource(R.string.settings_backup_daily),
+                        "weekly" to stringResource(R.string.settings_backup_weekly),
+                    )
+                    val freqLabel = freqOptions.firstOrNull { it.first == backupFrequency }?.second
+                        ?: stringResource(R.string.settings_backup_off)
+                    var freqExpanded by remember { mutableStateOf(false) }
+
+                    ExposedDropdownMenuBox(
+                        expanded = freqExpanded,
+                        onExpandedChange = { freqExpanded = it }
+                    ) {
+                        OutlinedTextField(
+                            value = freqLabel,
+                            onValueChange = {},
+                            readOnly = true,
+                            trailingIcon =  { ExposedDropdownMenuDefaults.TrailingIcon(expanded = freqExpanded) },
+                            modifier = Modifier
+                                .menuAnchor()
+                                .width(150.dp),
+                            textStyle = MaterialTheme.typography.bodySmall,
+                            singleLine = true,
+                        )
+                        ExposedDropdownMenu(
+                            expanded = freqExpanded,
+                            onDismissRequest = { freqExpanded = false },
+                        ) {
+                            freqOptions.forEach { (freq, label) ->
+                                DropdownMenuItem(
+                                    text = { Text(label) },
+                                    onClick = {
+                                        viewModel.setBackupFrequency(freq)
+                                        freqExpanded = false
+                                    }
+                                )
+                            }
                         }
                     }
                 }

--- a/app/src/main/kotlin/com/fantasyidler/ui/screen/SettingsScreen.kt
+++ b/app/src/main/kotlin/com/fantasyidler/ui/screen/SettingsScreen.kt
@@ -314,7 +314,7 @@ fun SettingsScreen(
             )
 
             SettingsRow(
-                title    = "Recent Activity Log",
+                title    = stringResource(R.string.settings_recent_activity),
                 subtitle = stringResource(R.string.settings_recent_activity_desc),
                 trailing = {
                     Switch(

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -240,6 +240,7 @@
     <string name="label_shop_desc">Acheter et vendre des objets</string>
     <string name="label_no_session_hint">Allez dans Compétences ou Combat pour commencer l’entraînement.</string>
     <string name="label_recent_activity">Activité Récente</string>
+    <string name="settings_recent_activity">Journal d’activité récente</string>
     <string name="settings_recent_activity_desc">Afficher le bouton Activité Récente dans l’en-tête de l’écran d’accueil</string>
     <string name="label_no_sessions_yet">Aucune session terminée pour l’instant.</string>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -249,6 +249,7 @@
     <string name="label_shop_desc">Buy equipment and sell loot</string>
     <string name="label_no_session_hint">Head to Skills or Combat to start training.</string>
     <string name="label_recent_activity">Recent Activity</string>
+    <string name="settings_recent_activity">Recent Activity Log</string>
     <string name="settings_recent_activity_desc">Show Recent Activity button in the home screen header</string>
     <string name="label_no_sessions_yet">No sessions completed yet.</string>
 


### PR DESCRIPTION
Hi, 
- Changed the backup frequency selector because the display was broken depending on the selected language (see photos below)
- Extract "Journal Activity Log" string to resource file for translation

Before :

<img width="540" height="1170" alt="Screenshot_20260612_134537_Idle Fantasy" src="https://github.com/user-attachments/assets/f112bdac-c4a6-417a-b315-e81d3b01af44" />

After :

<img width="516" height="654" alt="image" src="https://github.com/user-attachments/assets/7723f352-7f86-4e43-9900-86838dc0cb4b" />
<img width="526" height="488" alt="image" src="https://github.com/user-attachments/assets/13f11ed1-e951-4dc3-93c4-a02ec8958e3e" />

