### PR TITLE
fix: implement offline catch-up loop to bypass Android Doze Mode alarm throttling

### DIFF
--- a/app/src/main/kotlin/com/fantasyidler/receiver/SessionAlarmReceiver.kt
+++ b/app/src/main/kotlin/com/fantasyidler/receiver/SessionAlarmReceiver.kt
@@ -46,7 +46,13 @@ class SessionAlarmReceiver : BroadcastReceiver() {
                     val workerStarted = workerQueuedSessionStarter.startNextQueued(slot)
                     if (!workerStarted) notificationManager.showSessionComplete(skillDisplayName)
                 } else {
-                    val started = queuedSessionStarter.startNextQueued(backdateMs = backdateMs)
+                    var catchUpMs = backdateMs
+                    while (catchUpMs > 0) {
+                        val used = try { queuedSessionStarter.insertNextQueuedAsOffline(catchUpMs) } catch (_: Exception) { 0L }
+                        if (used == 0L) break
+                        catchUpMs -= used
+                    }
+                    val started = queuedSessionStarter.startNextQueued(backdateMs = catchUpMs)
                     if (!started) notificationManager.showSessionComplete(skillDisplayName)
                 }
             } finally {

--- a/app/src/main/kotlin/com/fantasyidler/repository/SessionRepository.kt
+++ b/app/src/main/kotlin/com/fantasyidler/repository/SessionRepository.kt
@@ -181,8 +181,13 @@ class SessionRepository @Inject constructor(
             return
         }
         if (session.completed) {
-            val backdateMs = maxOf(0L, System.currentTimeMillis() - session.endsAt)
-            try { starter.startNextQueued(backdateMs = backdateMs) } catch (_: Exception) { markCompleted(session.sessionId) }
+            var catchUpMs = maxOf(0L, System.currentTimeMillis() - session.endsAt)
+            while (catchUpMs > 0) {
+                val used = try { starter.insertNextQueuedAsOffline(catchUpMs) } catch (_: Exception) { 0L }
+                if (used == 0L) break
+                catchUpMs -= used
+            }
+            try { starter.startNextQueued(backdateMs = catchUpMs) } catch (_: Exception) { markCompleted(session.sessionId) }
             return
         }
         // Boss sessions: endsAt is cosmetic (full duration). The session really ends


### PR DESCRIPTION
### Problem
When the phone is locked, asleep, or enters Doze Mode, Android strictly throttles exact alarms (`setExactAndAllowWhileIdle`). In the previous implementation, when a session completed in the background, a new exact alarm was set in the past to backdate the next queued session. Because of Doze Mode throttling, this new alarm suffered severe delays (ranging from 15 minutes to 2+ hours), causing the queue to freeze or progress very slowly.

### Solution
Instead of scheduling sequential backdated alarms that trigger Doze Mode throttling, this PR changes how overdue queued tasks are handled:
1. **Instant Loop Catch-up**: A fast-forward catch-up loop has been implemented using `insertNextQueuedAsOffline()` inside the background broadcast receiver (`SessionAlarmReceiver`) to process all overdue time/sessions instantly within a single wake-lock window.
2. **Startup Catch-up Sync**: The same catch-up loop is also integrated into `recoverActiveSession` inside `SessionRepository` to ensure that any remaining elapsed offline queue progress is correctly caught up immediately when the user launches the app.

### Affected Files
* [SessionAlarmReceiver.kt](file:///home/bixpurr/Desktop/Study/IdleFantasy/app/src/main/kotlin/com/fantasyidler/receiver/SessionAlarmReceiver.kt)
* [SessionRepository.kt](file:///home/bixpurr/Desktop/Study/IdleFantasy/app/src/main/kotlin/com/fantasyidler/repository/SessionRepository.kt)