### PR TITLE
feat: add gathering pets for all skills

### DIFF
--- a/app/src/main/assets/data/pets.json
+++ b/app/src/main/assets/data/pets.json
@@ -88,5 +88,105 @@
     "effect_type": "xp_boost",
     "boosted_skill": "combat",
     "boost_percent": 5
+  },
+  "graceling_sprite": {
+    "id": "graceling_sprite",
+    "display_name": "Graceling Sprite",
+    "emoji": "🧚",
+    "description": "A nimble fairy born from thousands of laps run in silence. Guides your feet with uncanny grace.",
+    "source": "Agility (1/1000 per session)",
+    "effect_type": "xp_boost",
+    "boosted_skill": "agility",
+    "boost_percent": 10
+  },
+  "shadow_fox": {
+    "id": "shadow_fox",
+    "display_name": "Shadow Fox",
+    "emoji": "🦊",
+    "description": "A cunning fox that materialised from the shadows of a thousand pickpocket attempts.",
+    "source": "Thieving (1/1000 per session)",
+    "effect_type": "xp_boost",
+    "boosted_skill": "thieving",
+    "boost_percent": 10
+  },
+  "ember_moth": {
+    "id": "ember_moth",
+    "display_name": "Ember Moth",
+    "emoji": "🦋",
+    "description": "Drawn to flame for so long it became one. Its wings shimmer with residual heat.",
+    "source": "Firemaking (1/1000 per session)",
+    "effect_type": "xp_boost",
+    "boosted_skill": "firemaking",
+    "boost_percent": 10
+  },
+  "herb_wisp": {
+    "id": "herb_wisp",
+    "display_name": "Herb Wisp",
+    "emoji": "🌿",
+    "description": "A spirit born from the vapour of a thousand brewed potions. Its presence sharpens the mind.",
+    "source": "Herblore (1/1000 per session)",
+    "effect_type": "xp_boost",
+    "boosted_skill": "herblore",
+    "boost_percent": 10
+  },
+  "rune_sprite": {
+    "id": "rune_sprite",
+    "display_name": "Rune Sprite",
+    "emoji": "🔮",
+    "description": "A crystallised fragment of magical energy that escaped the Runecrafting altar.",
+    "source": "Runecrafting (1/1000 per session)",
+    "effect_type": "xp_boost",
+    "boosted_skill": "runecrafting",
+    "boost_percent": 10
+  },
+  "gem_golem": {
+    "id": "gem_golem",
+    "display_name": "Gem Golem",
+    "emoji": "💎",
+    "description": "A tiny creature sculpted from gem shards and polishing dust. Keeps your tools sharp.",
+    "source": "Crafting (1/1000 per session)",
+    "effect_type": "xp_boost",
+    "boosted_skill": "crafting",
+    "boost_percent": 10
+  },
+  "feather_drake": {
+    "id": "feather_drake",
+    "display_name": "Feather Drake",
+    "emoji": "🪶",
+    "description": "A miniature dragon made entirely of arrow fletching. Surprisingly aerodynamic.",
+    "source": "Fletching (1/1000 per session)",
+    "effect_type": "xp_boost",
+    "boosted_skill": "fletching",
+    "boost_percent": 10
+  },
+  "forge_imp": {
+    "id": "forge_imp",
+    "display_name": "Forge Imp",
+    "emoji": "⚒️",
+    "description": "A mischievous imp that lives inside the forge. Its heat-hardened hide is impervious to burns.",
+    "source": "Smithing (1/1000 per session)",
+    "effect_type": "xp_boost",
+    "boosted_skill": "smithing",
+    "boost_percent": 10
+  },
+  "coin_drake": {
+    "id": "coin_drake",
+    "display_name": "Coin Drake",
+    "emoji": "🪙",
+    "description": "A dragon hatchling raised on a diet of gold coins. It has an uncanny nose for profit.",
+    "source": "Mercantile (1/1000 per session)",
+    "effect_type": "xp_boost",
+    "boosted_skill": "mercantile",
+    "boost_percent": 10
+  },
+  "timber_sprite": {
+    "id": "timber_sprite",
+    "display_name": "Timber Sprite",
+    "emoji": "🪵",
+    "description": "A wood spirit awakened from sawdust and lumber. It knows exactly where every nail should go.",
+    "source": "Construction (1/1000 per session)",
+    "effect_type": "xp_boost",
+    "boosted_skill": "construction",
+    "boost_percent": 10
   }
 }

--- a/app/src/main/kotlin/com/fantasyidler/repository/QueuedSessionStarter.kt
+++ b/app/src/main/kotlin/com/fantasyidler/repository/QueuedSessionStarter.kt
@@ -17,6 +17,7 @@ import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.serializer
+import kotlin.random.Random
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -178,6 +179,8 @@ class QueuedSessionStarter @Inject constructor(
                     startXp      = xpMap[Skills.AGILITY] ?: 0L,
                     agilityLevel = agilityLevel,
                     petBoostPct  = gatheringPetBoost(player.pets, Skills.AGILITY),
+                    petDropKey   = petDropKey(Skills.AGILITY),
+                    petDropChance = petDropChance(Skills.AGILITY),
                 )
                 startSession(action, result, offline, backdateMs)
             }
@@ -209,7 +212,8 @@ class QueuedSessionStarter @Inject constructor(
                 val logData = gameData.logs[logKey] ?: return
                 val qty     = action.qty.takeIf { it > 0 } ?: return
                 val ashKey  = ashForLog(logKey)
-                val frames  = buildCraftFrames(xpMap[Skills.FIREMAKING] ?: 0L, qty, logData.xpPerLog.toDouble(), 1, ashKey)
+                val frames  = buildCraftFrames(xpMap[Skills.FIREMAKING] ?: 0L, qty, logData.xpPerLog.toDouble(), 1, ashKey,
+                    petDropKey = petDropKey(Skills.FIREMAKING), petDropChance = petDropChance(Skills.FIREMAKING))
                 val perLogMs = SkillSimulator.sessionDurationMs(agilityLevel) / 60L
                 sessionRepo.startSession(
                     skillName         = Skills.FIREMAKING,
@@ -293,35 +297,40 @@ class QueuedSessionStarter @Inject constructor(
             Skills.SMITHING -> {
                 val r   = gameData.smithingRecipes[action.activityKey] ?: return
                 val qty = action.qty.takeIf { it > 0 } ?: return
-                val frames = buildCraftFrames(xpMap[Skills.SMITHING] ?: 0L, qty, r.xpPerItem, r.outputQuantity, action.activityKey)
+                val frames = buildCraftFrames(xpMap[Skills.SMITHING] ?: 0L, qty, r.xpPerItem, r.outputQuantity, action.activityKey,
+                    petDropKey = petDropKey(Skills.SMITHING), petDropChance = petDropChance(Skills.SMITHING))
                 val perItemMs = SkillSimulator.sessionDurationMs(agilityLevel) / 60
                 sessionRepo.startSession(Skills.SMITHING, action.activityKey, encodeFrames(frames), qty * perItemMs, action.skillDisplayName, insertAsCompleted = offline, backdateMs = backdateMs)
             }
             Skills.COOKING -> {
                 val r: CookingRecipe = gameData.cookingRecipes[action.activityKey] ?: return
                 val qty = action.qty.takeIf { it > 0 } ?: return
-                val frames = buildCraftFrames(xpMap[Skills.COOKING] ?: 0L, qty, r.xpPerItem, 1, r.cookedItem)
+                val frames = buildCraftFrames(xpMap[Skills.COOKING] ?: 0L, qty, r.xpPerItem, 1, r.cookedItem,
+                    petDropKey = petDropKey(Skills.COOKING), petDropChance = petDropChance(Skills.COOKING))
                 val perItemMs = SkillSimulator.sessionDurationMs(agilityLevel) / 60
                 sessionRepo.startSession(Skills.COOKING, action.activityKey, encodeFrames(frames), qty * perItemMs, action.skillDisplayName, insertAsCompleted = offline, backdateMs = backdateMs)
             }
             Skills.FLETCHING -> {
                 val r   = gameData.fletchingRecipes[action.activityKey] ?: return
                 val qty = action.qty.takeIf { it > 0 } ?: return
-                val frames = buildCraftFrames(xpMap[Skills.FLETCHING] ?: 0L, qty, r.xpPerItem, r.outputQuantity, r.itemName)
+                val frames = buildCraftFrames(xpMap[Skills.FLETCHING] ?: 0L, qty, r.xpPerItem, r.outputQuantity, r.itemName,
+                    petDropKey = petDropKey(Skills.FLETCHING), petDropChance = petDropChance(Skills.FLETCHING))
                 val perItemMs = SkillSimulator.sessionDurationMs(agilityLevel) / 60
                 sessionRepo.startSession(Skills.FLETCHING, action.activityKey, encodeFrames(frames), qty * perItemMs, action.skillDisplayName, insertAsCompleted = offline, backdateMs = backdateMs)
             }
             Skills.CRAFTING -> {
                 val r   = gameData.craftingRecipes[action.activityKey] ?: return
                 val qty = action.qty.takeIf { it > 0 } ?: return
-                val frames = buildCraftFrames(xpMap[Skills.CRAFTING] ?: 0L, qty, r.xpPerItem, r.outputQuantity, action.activityKey)
+                val frames = buildCraftFrames(xpMap[Skills.CRAFTING] ?: 0L, qty, r.xpPerItem, r.outputQuantity, action.activityKey,
+                    petDropKey = petDropKey(Skills.CRAFTING), petDropChance = petDropChance(Skills.CRAFTING))
                 val perItemMs = SkillSimulator.sessionDurationMs(agilityLevel) / 60
                 sessionRepo.startSession(Skills.CRAFTING, action.activityKey, encodeFrames(frames), qty * perItemMs, action.skillDisplayName, insertAsCompleted = offline, backdateMs = backdateMs)
             }
             Skills.CONSTRUCTION -> {
                 val r   = gameData.constructionRecipes[action.activityKey] ?: return
                 val qty = action.qty.takeIf { it > 0 } ?: return
-                val frames = buildCraftFrames(xpMap[Skills.CONSTRUCTION] ?: 0L, qty, r.xpPerItem, r.outputQuantity, action.activityKey)
+                val frames = buildCraftFrames(xpMap[Skills.CONSTRUCTION] ?: 0L, qty, r.xpPerItem, r.outputQuantity, action.activityKey,
+                    petDropKey = petDropKey(Skills.CONSTRUCTION), petDropChance = petDropChance(Skills.CONSTRUCTION))
                 val perItemMs = SkillSimulator.sessionDurationMs(agilityLevel) / 60
                 sessionRepo.startSession(Skills.CONSTRUCTION, action.activityKey, encodeFrames(frames), qty * perItemMs, action.skillDisplayName, insertAsCompleted = offline, backdateMs = backdateMs)
             }
@@ -331,16 +340,19 @@ class QueuedSessionStarter @Inject constructor(
                 val catalystKey = action.catalystKey
                 val outputKey   = if (catalystKey != null) "enhanced_${action.activityKey}" else action.activityKey
                 if (catalystKey != null) playerRepo.consumeItems(mapOf(catalystKey to qty))
-                val frames    = buildCraftFrames(xpMap[Skills.HERBLORE] ?: 0L, qty, r.xpPerItem, r.outputQuantity, outputKey)
+                val frames    = buildCraftFrames(xpMap[Skills.HERBLORE] ?: 0L, qty, r.xpPerItem, r.outputQuantity, outputKey,
+                    petDropKey = petDropKey(Skills.HERBLORE), petDropChance = petDropChance(Skills.HERBLORE))
                 val perItemMs = SkillSimulator.sessionDurationMs(agilityLevel) / 60
                 sessionRepo.startSession(Skills.HERBLORE, action.activityKey, encodeFrames(frames), qty * perItemMs, action.skillDisplayName, insertAsCompleted = offline, backdateMs = backdateMs)
             }
             Skills.MERCANTILE -> {
                 val route = gameData.tradeRoutes.firstOrNull { it.id == action.activityKey } ?: return
                 val result = MercantileSimulator.simulate(
-                    route        = route,
-                    startXp      = xpMap[Skills.MERCANTILE] ?: 0L,
-                    agilityLevel = agilityLevel,
+                    route         = route,
+                    startXp       = xpMap[Skills.MERCANTILE] ?: 0L,
+                    agilityLevel  = agilityLevel,
+                    petDropKey    = petDropKey(Skills.MERCANTILE),
+                    petDropChance = petDropChance(Skills.MERCANTILE),
                 )
                 sessionRepo.startSession(
                     skillName         = action.skillName,
@@ -571,7 +583,16 @@ class QueuedSessionStarter @Inject constructor(
         return if (tierDiff > 0) base * (1.0f + 0.25f * tierDiff) else base
     }
 
-    private fun buildCraftFrames(startXp: Long, qty: Int, xpPerItem: Double, outputQty: Int, outputKey: String): List<SessionFrame> {
+    private fun buildCraftFrames(
+        startXp: Long,
+        qty: Int,
+        xpPerItem: Double,
+        outputQty: Int,
+        outputKey: String,
+        petDropKey: String? = null,
+        petDropChance: Double = 0.0,
+        random: Random = Random.Default,
+    ): List<SessionFrame> {
         var xp = startXp
         val frameCount = minOf(qty, 60)
         return buildList {
@@ -581,10 +602,14 @@ class QueuedSessionStarter @Inject constructor(
                 val gain = (xpPerItem * itemsInBucket).toInt()
                 xp += gain
                 val levelAfter = XpTable.levelForXp(xp)
+                val items = mutableMapOf(outputKey to outputQty * itemsInBucket)
+                if (petDropKey != null && petDropChance > 0.0 && random.nextDouble() < petDropChance) {
+                    items[petDropKey] = 1
+                }
                 add(SessionFrame(
                     minute = bucket + 1, xpGain = gain, xpBefore = xp - gain, xpAfter = xp,
                     levelBefore = levelBefore, levelAfter = levelAfter,
-                    items = mapOf(outputKey to outputQty * itemsInBucket),
+                    items = items,
                     leveledUp = levelAfter > levelBefore,
                     kills = itemsInBucket,
                 ))

--- a/app/src/main/kotlin/com/fantasyidler/simulator/MercantileSimulator.kt
+++ b/app/src/main/kotlin/com/fantasyidler/simulator/MercantileSimulator.kt
@@ -17,6 +17,8 @@ object MercantileSimulator {
         route: TradeRouteData,
         startXp: Long,
         agilityLevel: Int = 1,
+        petDropKey: String? = null,
+        petDropChance: Double = 0.0,
         random: Random = Random.Default,
     ): Result {
         var currentXp = startXp
@@ -33,6 +35,10 @@ object MercantileSimulator {
             val levelAfter = XpTable.levelForXp(currentXp)
 
             val coinReturn = random.nextInt(coinRange.min, coinRange.max + 1)
+            val items = mutableMapOf("_coins" to coinReturn)
+            if (petDropKey != null && petDropChance > 0.0 && random.nextDouble() < petDropChance) {
+                items[petDropKey] = 1
+            }
 
             frames += SessionFrame(
                 minute      = minute,
@@ -42,7 +48,7 @@ object MercantileSimulator {
                 levelBefore = levelBefore,
                 levelAfter  = levelAfter,
                 leveledUp   = levelAfter > levelBefore,
-                items       = mapOf("_coins" to coinReturn),
+                items       = items,
             )
         }
 

--- a/app/src/main/kotlin/com/fantasyidler/simulator/SkillSimulator.kt
+++ b/app/src/main/kotlin/com/fantasyidler/simulator/SkillSimulator.kt
@@ -305,6 +305,8 @@ object SkillSimulator {
         startXp: Long,
         agilityLevel: Int = 1,
         petBoostPct: Int = 0,
+        petDropKey: String? = null,
+        petDropChance: Double = 0.0,
         random: Random = Random.Default,
     ): Result {
         var currentXp = startXp
@@ -324,6 +326,11 @@ object SkillSimulator {
             currentXp += xpGain
             val levelAfter = XpTable.levelForXp(currentXp)
 
+            val items = mutableMapOf<String, Int>()
+            if (petDropKey != null && petDropChance > 0.0 && random.nextDouble() < petDropChance) {
+                items[petDropKey] = 1
+            }
+
             frames.add(
                 SessionFrame(
                     minute      = minute,
@@ -332,6 +339,7 @@ object SkillSimulator {
                     xpAfter     = currentXp,
                     levelBefore = levelBefore,
                     levelAfter  = levelAfter,
+                    items       = items,
                     leveledUp   = levelAfter > levelBefore,
                     success     = successfulLaps > 0,
                 )


### PR DESCRIPTION
Adds 10 new skill pets to cover every skill that previously had no associated pet (Agility, Thieving, Firemaking, Herblore, Runecrafting, Crafting, Fletching, Smithing, Mercantile, Construction).

Each pet grants +10% XP to its skill and drops at 1/1000 per session, matching the rate of existing gathering pets (Rock Golem, Ent, etc.).

New pets:
  - Graceling Sprite  (Agility)
  - Shadow Fox        (Thieving)
  - Ember Moth        (Firemaking)
  - Herb Wisp         (Herblore)
  - Rune Sprite       (Runecrafting)
  - Gem Golem         (Crafting)
  - Feather Drake     (Fletching)
  - Forge Imp         (Smithing)
  - Coin Drake        (Mercantile)
  - Timber Sprite     (Construction)

Simulator changes:
  - SkillSimulator.simulateAgility: added petDropKey/petDropChance parameters and per-frame pet drop roll (previously missing).
  - QueuedSessionStarter.buildCraftFrames: added optional petDropKey/ petDropChance params; all 7 crafting skill call-sites updated.
  - MercantileSimulator.simulate: added petDropKey/petDropChance params and per-frame pet drop roll.
  - QueuedSessionStarter: wired petDropKey/petDropChance into Agility, Firemaking, Smithing, Cooking, Fletching, Crafting, Construction, Herblore, and Mercantile session starts.

No DB migration required. No new PlayerFlags fields. Fully backward-compatible — existing saves are unaffected.