### PR TITLE
feat: Add Weekly Challenges

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "java.configuration.updateBuildConfiguration": "interactive"
+}

--- a/agents.md
+++ b/agents.md
@@ -1,0 +1,170 @@
+# IdleFantasy — Agents
+
+This file defines specialized agent roles for working on the IdleFantasy codebase.
+Reference the [context.md](context.md) alongside these agents for full project awareness.
+
+---
+
+## 🎨 UI Agent — Compose & Navigation
+
+**Role:** Responsible for all Jetpack Compose UI, screen layouts, theming, and navigation changes.
+
+**Primary Files:**
+- `app/src/main/kotlin/com/fantasyidler/ui/screen/` — 24 screen composables
+- `app/src/main/kotlin/com/fantasyidler/ui/viewmodel/` — 22 ViewModels
+- `app/src/main/kotlin/com/fantasyidler/ui/navigation/Screen.kt`
+- `app/src/main/kotlin/com/fantasyidler/ui/navigation/AppNavigation.kt`
+- `app/src/main/kotlin/com/fantasyidler/ui/theme/` — Color, Theme, Type
+
+**Key Constraints:**
+- Use Material 3 components (`MaterialTheme`, `Card`, `NavigationBar`, etc.)
+- Respect the `LocalDensity` font-scale override set in `MainActivity`
+- All strings must use `stringResource()` — never hardcode user-visible text
+- New screens: register in `Screen.kt` + `AppNavigation.kt`, create ViewModel with `@HiltViewModel`
+- Bottom nav always shows exactly 5 tabs (`Screen.bottomNavItems`)
+- Sub-screens (accessible from a tab) must be in `tabSubScreens` map in `AppNavigation.kt` for correct back-press behavior
+- Dark/light theme is driven by `SettingsViewModel.themePreference` → `FantasyIdlerTheme`
+
+**Common Patterns:**
+```kotlin
+// ViewModel injection in a screen
+@HiltViewModel
+class MyViewModel @Inject constructor(
+    private val playerRepo: PlayerRepository,
+    private val gameData: GameDataRepository,
+) : ViewModel()
+
+// State collection in a composable
+val state by viewModel.uiState.collectAsStateWithLifecycle()
+```
+
+---
+
+## ⚔️ Game Mechanics Agent — Skills, Combat & Balance
+
+**Role:** Responsible for game logic, balance, skill rules, quest conditions, item/equipment effects, and simulation output.
+
+**Primary Files:**
+- `app/src/main/kotlin/com/fantasyidler/simulator/` — all 6 simulators
+- `app/src/main/assets/data/` — all JSON game data files
+- `app/src/main/kotlin/com/fantasyidler/data/json/` — Kotlin data classes for JSON
+- `app/src/main/kotlin/com/fantasyidler/data/model/PlayerModels.kt` — `Skills`, `EquipSlot`, `WorkerTier`
+
+**Key Constraints:**
+- Sessions are pre-simulated into 60 `SessionFrame` objects at start time — **not computed live**
+- XP caps at level 99 per skill; prestige (0–3) adds +10% XP per tier
+- Simulator output must be deterministic for the same inputs (no random seeds stored)
+- Adding a new skill: add key to `Skills` object, update `Skills.ALL` and `DEFAULT_LEVELS`/`DEFAULT_XP`, add JSON asset
+- Adding a new item: add to the relevant JSON file (e.g. `equipment.json`, `ores.json`), update `GameDataRepository.usefulItemKeys` if it's a "useful" item
+- Multiplier chain: `efficiencyMultiplier` (worker) → XP boost (2×) → church blessing → prestige
+
+**Simulator Contract:**
+```kotlin
+// Each simulator returns List<SessionFrame> (60 frames, one per minute)
+// SessionFrame contains: xpGained, itemsGained, events, coinsGained, etc.
+// Called once when session starts; result JSON stored in SkillSession.frames
+```
+
+---
+
+## 💾 Data & Persistence Agent — Room, Repository & Save System
+
+**Role:** Responsible for database schema, migrations, repository layer, save/import/export, and background alarm scheduling.
+
+**Primary Files:**
+- `app/src/main/kotlin/com/fantasyidler/data/db/AppDatabase.kt`
+- `app/src/main/kotlin/com/fantasyidler/data/db/dao/`
+- `app/src/main/kotlin/com/fantasyidler/repository/` — all 15 repositories
+- `app/src/main/kotlin/com/fantasyidler/data/model/Player.kt`
+- `app/src/main/kotlin/com/fantasyidler/data/model/PlayerModels.kt`
+
+**Key Constraints:**
+- **Never** write to `PlayerDao` directly from a ViewModel — always go through `PlayerRepository`
+- All complex player state lives in JSON columns on the single `Player` row (id=1)
+- Adding a new `PlayerFlags` field: add with a default value (backward-compatible JSON deserialization)
+- Adding a new DB column/table: write a `MIGRATION_N_(N+1)` and bump `@Database(version = ...)`
+- Schema is exported to `app/schemas/` — commit these files
+- `PlayerRepository.exportSave()` / `importSave()` must include any new persistent state
+
+**DB Migration Template:**
+```kotlin
+val MIGRATION_3_4 = object : Migration(3, 4) {
+    override fun migrate(db: SupportSQLiteDatabase) {
+        db.execSQL("ALTER TABLE skill_sessions ADD COLUMN new_col TEXT NOT NULL DEFAULT ''")
+    }
+}
+// Then add to AppDatabase: .addMigrations(MIGRATION_3_4)
+```
+
+**Repository Write Pattern:**
+```kotlin
+suspend fun updateSomething(value: SomeType) {
+    val player = getOrCreatePlayer()
+    val flags: PlayerFlags = json.decodeFromString(player.flags)
+    val updated = flags.copy(someField = value)
+    playerDao.upsert(player.copy(flags = json.encode<PlayerFlags>(updated)))
+}
+```
+
+---
+
+## 🔔 Notifications & Background Agent — Alarms, Receivers & Scheduling
+
+**Role:** Responsible for session timers, farming patch timers, backup scheduling, buff expiry notifications, and boot-time rescheduling.
+
+**Primary Files:**
+- `app/src/main/kotlin/com/fantasyidler/receiver/` — 5 BroadcastReceivers
+- `app/src/main/kotlin/com/fantasyidler/notification/SessionNotificationManager.kt`
+- `app/src/main/kotlin/com/fantasyidler/repository/SessionRepository.kt`
+- `app/src/main/kotlin/com/fantasyidler/repository/BackupScheduler.kt`
+- `app/src/main/kotlin/com/fantasyidler/repository/BuffNotificationScheduler.kt`
+- `app/src/main/AndroidManifest.xml`
+
+**Key Constraints:**
+- Uses `AlarmManager` with `USE_EXACT_ALARM` for precise session timers (not WorkManager)
+- New receivers must be registered in `AndroidManifest.xml` with `android:exported="false"`
+- `BootReceiver` must reschedule ALL active timers on `BOOT_COMPLETED`
+- Notification channels must be created before sending (done in `SessionNotificationManager`)
+- Deep-link navigation on notification tap: use `EXTRA_NAVIGATE_TO` in the pending intent; handled in `MainActivity.onNewIntent()`
+
+**Notification Deep-Link Pattern:**
+```kotlin
+// In SessionNotificationManager
+const val EXTRA_NAVIGATE_TO = "navigate_to"
+const val NAVIGATE_FARMING  = "farming"
+
+// MainActivity reads it and passes to AppNavigation via pendingNavigateTo state
+```
+
+---
+
+## 🌍 Localization Agent — Strings & Translations
+
+**Role:** Responsible for string resources, adding new translatable strings, and supporting existing translations.
+
+**Primary Files:**
+- `app/src/main/res/values/strings.xml` (English base)
+- `app/src/main/res/values-de/`, `values-fr/`, `values-es/`, `values-tr/`
+- `app/src/main/kotlin/com/fantasyidler/util/GameStrings.kt`
+
+**Key Constraints:**
+- All user-visible text MUST use `@StringRes` / `stringResource()` in Compose
+- Add new keys to `values/strings.xml` first; other languages will get the English fallback until translated
+- `GameStrings.kt` has helpers for converting skill/item keys to localized display names — use these instead of hardcoding
+- Weblate-compatible: do not change existing key names without updating all language files
+
+---
+
+## 📋 Feature Change Checklist
+
+When implementing any feature change, verify:
+
+- [ ] **UI layer**: New/modified composable + ViewModel added/updated
+- [ ] **State**: New flags added to `PlayerFlags` with default values (backward-compatible)
+- [ ] **Persistence**: If new DB column needed, write migration + bump version
+- [ ] **Game data**: If new JSON content needed, add asset file + update `GameDataRepository`
+- [ ] **Export/Import**: If new persistent state, include in `exportSave()` / `importSave()`
+- [ ] **Strings**: All user-facing text uses string resources
+- [ ] **Navigation**: New screen registered in `Screen.kt` + `AppNavigation.kt`
+- [ ] **Boot rescheduling**: If new alarm type, add to `BootReceiver`
+- [ ] **Tests**: Run `./gradlew :app:testDebugUnitTest` to confirm nothing broken

--- a/app/src/main/assets/data/weekly_quests.json
+++ b/app/src/main/assets/data/weekly_quests.json
@@ -1,0 +1,102 @@
+[
+  {
+    "id": "weekly_mine_runite",
+    "display_name": "Deep Core Miner",
+    "skill": "mining",
+    "type": "gather",
+    "target": "runite_ore",
+    "amount": 100,
+    "description": "Mine 100 runite ore this week.",
+    "level_required": 85
+  },
+  {
+    "id": "weekly_craft_addy_plate",
+    "display_name": "Armour Forger",
+    "skill": "smithing",
+    "type": "craft",
+    "target": "adamantite_platebody",
+    "amount": 30,
+    "description": "Smith 30 adamantite platebodies.",
+    "level_required": 88
+  },
+  {
+    "id": "weekly_boss_kills",
+    "display_name": "Monster Hunter",
+    "skill": "combat",
+    "type": "boss",
+    "target": "any",
+    "amount": 5,
+    "description": "Defeat any raid boss 5 times.",
+    "level_required": 50
+  },
+  {
+    "id": "weekly_farm_harvests",
+    "display_name": "Seasoned Farmer",
+    "skill": "farming",
+    "type": "farming",
+    "target": "any",
+    "amount": 10,
+    "description": "Harvest 10 farming patches.",
+    "level_required": 10
+  },
+  {
+    "id": "weekly_guild_dailies",
+    "display_name": "Guild Loyalist",
+    "skill": "combat",
+    "type": "guild_daily",
+    "target": "any",
+    "amount": 15,
+    "description": "Complete 15 guild daily requests.",
+    "level_required": 10
+  },
+  {
+    "id": "weekly_cook_sharks",
+    "display_name": "Master Chef",
+    "skill": "cooking",
+    "type": "craft",
+    "target": "cooked_shark",
+    "amount": 100,
+    "description": "Cook 100 sharks.",
+    "level_required": 80
+  },
+  {
+    "id": "weekly_agility_sessions",
+    "display_name": "Marathon Runner",
+    "skill": "agility",
+    "type": "agility",
+    "target": "any",
+    "amount": 5,
+    "description": "Complete 5 agility sessions.",
+    "level_required": 1
+  },
+  {
+    "id": "weekly_slayer_tasks",
+    "display_name": "Slayer Champion",
+    "skill": "slayer",
+    "type": "slayer_task",
+    "target": "any",
+    "amount": 5,
+    "description": "Complete 5 Slayer tasks.",
+    "level_required": 1
+  },
+  {
+    "id": "weekly_trade_routes",
+    "display_name": "Trade Baron",
+    "skill": "mercantile",
+    "type": "mercantile",
+    "target": "any",
+    "amount": 10,
+    "description": "Complete 10 trade route sessions.",
+    "level_required": 1
+  },
+  {
+    "id": "weekly_prayer_bones",
+    "display_name": "Pious Devotee",
+    "skill": "prayer",
+    "type": "prayer",
+    "target": "any",
+    "amount": 500,
+    "description": "Bury 500 bones at the bone altar.",
+    "level_required": 1
+  }
+]

--- a/app/src/main/kotlin/com/fantasyidler/data/json/WeeklyQuestData.kt
+++ b/app/src/main/kotlin/com/fantasyidler/data/json/WeeklyQuestData.kt
@@ -1,0 +1,16 @@
+package com.fantasyidler.data.json
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class WeeklyQuestTemplate(
+    val id: String,
+    @SerialName("display_name") val displayName: String,
+    val skill: String,
+    val type: String,
+    val target: String,
+    val amount: Int,
+    val description: String,
+    @SerialName("level_required") val levelRequired: Int = 1,
+)

--- a/app/src/main/kotlin/com/fantasyidler/data/model/PlayerModels.kt
+++ b/app/src/main/kotlin/com/fantasyidler/data/model/PlayerModels.kt
@@ -40,6 +40,18 @@ data class PlayerFlags(
     @SerialName("daily_quest_claimed") val dailyQuestClaimed: List<String> = emptyList(),
     /** Epoch ms when today's daily quests were generated (used to detect 6am rollover). */
     @SerialName("daily_quest_generated_at") val dailyQuestGeneratedAt: Long = 0L,
+
+    /** IDs of the 5 active weekly challenge template IDs. */
+    @SerialName("weekly_quest_ids") val weeklyQuestIds: List<String> = emptyList(),
+    /** Progress map: templateId → count accumulated this week. */
+    @SerialName("weekly_quest_progress") val weeklyQuestProgress: Map<String, Int> = emptyMap(),
+    /** Template IDs whose individual reward has been claimed. */
+    @SerialName("weekly_quest_claimed") val weeklyQuestClaimed: List<String> = emptyList(),
+    /** Epoch ms when the current weekly set was generated (used to detect Monday 6am rollover). */
+    @SerialName("weekly_quest_generated_at") val weeklyQuestGeneratedAt: Long = 0L,
+    /** True if the full weekly bonus chest has been claimed this week. */
+    @SerialName("weekly_bonus_claimed") val weeklyBonusClaimed: Boolean = false,
+
     /** Currently hired worker, or null if none. */
     @SerialName("hired_worker") val hiredWorker: HiredWorker? = null,
     /** Second worker slot (Apprentice / Journeyman / Master), or null if none. */

--- a/app/src/main/kotlin/com/fantasyidler/repository/FarmingRepository.kt
+++ b/app/src/main/kotlin/com/fantasyidler/repository/FarmingRepository.kt
@@ -99,6 +99,8 @@ class FarmingRepository @Inject constructor(
             xpGained    = crop.harvestXp.toLong() * yield,
             itemsGained = items,
         )
+        
+        playerRepo.recordWeeklyProgress("farming", "any", 1)
 
         val farmingPet = gameData.pets.values.firstOrNull { it.boostedSkill == Skills.FARMING }
         if (farmingPet != null && Random.nextDouble() < 1.0 / 1000.0) {

--- a/app/src/main/kotlin/com/fantasyidler/repository/GameDataRepository.kt
+++ b/app/src/main/kotlin/com/fantasyidler/repository/GameDataRepository.kt
@@ -22,6 +22,7 @@ import com.fantasyidler.data.json.MarketplaceJson
 import com.fantasyidler.data.json.OreData
 import com.fantasyidler.data.json.PetData
 import com.fantasyidler.data.json.DailyQuestTemplate
+import com.fantasyidler.data.json.WeeklyQuestTemplate
 import com.fantasyidler.data.json.GuildDailyTemplate
 import com.fantasyidler.data.json.GuildQuestData
 import com.fantasyidler.data.json.QuestData
@@ -112,6 +113,10 @@ class GameDataRepository @Inject constructor(
 
     val dailyQuestPool: List<DailyQuestTemplate> by lazy {
         asset("data/daily_quests.json")
+    }
+
+    val weeklyQuestPool: List<WeeklyQuestTemplate> by lazy {
+        asset("data/weekly_quests.json")
     }
 
     val guildQuests: Map<String, GuildQuestData> by lazy {

--- a/app/src/main/kotlin/com/fantasyidler/repository/PlayerRepository.kt
+++ b/app/src/main/kotlin/com/fantasyidler/repository/PlayerRepository.kt
@@ -34,6 +34,7 @@ class PlayerRepository @Inject constructor(
     private val farmingPatchDao: FarmingPatchDao,
     private val json: Json,
     private val dailyQuestRepo: DailyQuestRepository,
+    private val weeklyQuestRepo: WeeklyQuestRepository,
     private val buffNotifScheduler: BuffNotificationScheduler,
 ) {
     /**
@@ -709,29 +710,32 @@ class PlayerRepository @Inject constructor(
     // Daily quest helpers
     // ------------------------------------------------------------------
 
-    /** Refresh daily quests if past 6am, then record progress for a gather session. */
+    /** Refresh daily and weekly quests if past 6am, then record progress for a gather session. */
     suspend fun recordDailyGathering(items: Map<String, Int>) {
         var flags = getRefreshedDailyFlags()
         for ((target, amount) in items) {
             flags = dailyQuestRepo.recordProgress(flags, "gather", target, amount)
+            flags = weeklyQuestRepo.recordProgress(flags, "gather", target, amount)
         }
         updateFlags(flags)
     }
 
-    /** Refresh daily quests if past 6am, then record progress for a crafting session. */
+    /** Refresh daily and weekly quests if past 6am, then record progress for a crafting session. */
     suspend fun recordDailyCrafting(items: Map<String, Int>) {
         var flags = getRefreshedDailyFlags()
         for ((target, amount) in items) {
             flags = dailyQuestRepo.recordProgress(flags, "craft", target, amount)
+            flags = weeklyQuestRepo.recordProgress(flags, "craft", target, amount)
         }
         updateFlags(flags)
     }
 
-    /** Refresh daily quests if past 6am, then record progress for combat kills. */
+    /** Refresh daily and weekly quests if past 6am, then record progress for combat kills. */
     suspend fun recordDailyKills(killsByEnemy: Map<String, Int>) {
         var flags = getRefreshedDailyFlags()
         for ((enemy, count) in killsByEnemy) {
             flags = dailyQuestRepo.recordProgress(flags, "kill_enemy", enemy, count)
+            flags = weeklyQuestRepo.recordProgress(flags, "kill_enemy", enemy, count)
         }
         updateFlags(flags)
     }
@@ -740,19 +744,38 @@ class PlayerRepository @Inject constructor(
     suspend fun recordDailyPrayer(amount: Int) {
         var flags = getRefreshedDailyFlags()
         flags = dailyQuestRepo.recordPrayerProgress(flags, amount)
+        flags = weeklyQuestRepo.recordPrayerProgress(flags, amount)
         updateFlags(flags)
     }
 
-    /** Returns current flags after refreshing daily quests if the 6am boundary has passed. */
+    /** Record arbitrary weekly progress (for new weekly quest types). */
+    suspend fun recordWeeklyProgress(type: String, target: String, amount: Int) {
+        var flags = getRefreshedDailyFlags()
+        flags = weeklyQuestRepo.recordProgress(flags, type, target, amount)
+        updateFlags(flags)
+    }
+
+    /** Returns current flags after refreshing daily and weekly quests if the boundary has passed. */
     suspend fun getRefreshedDailyFlags(): PlayerFlags {
         val player = getOrCreatePlayer()
-        val flags: PlayerFlags = json.decodeFromString(player.flags)
-        return if (dailyQuestRepo.shouldRefresh(flags.dailyQuestGeneratedAt)) {
-            val skillLevels: Map<String, Int> = json.decodeFromString(player.skillLevels)
-            val refreshed = dailyQuestRepo.refreshFlags(flags, skillLevels)
-            updateFlags(refreshed)
-            refreshed
-        } else flags
+        var flags: PlayerFlags = json.decodeFromString(player.flags)
+        var changed = false
+        val skillLevels: Map<String, Int> by lazy { json.decodeFromString(player.skillLevels) }
+
+        if (dailyQuestRepo.shouldRefresh(flags.dailyQuestGeneratedAt)) {
+            flags = dailyQuestRepo.refreshFlags(flags, skillLevels)
+            changed = true
+        }
+        
+        if (weeklyQuestRepo.shouldRefresh(flags.weeklyQuestGeneratedAt)) {
+            flags = weeklyQuestRepo.refreshFlags(flags, skillLevels)
+            changed = true
+        }
+
+        if (changed) {
+            updateFlags(flags)
+        }
+        return flags
     }
 
     /** Adds [qty] of [itemKey] to inventory. */

--- a/app/src/main/kotlin/com/fantasyidler/repository/SlayerRepository.kt
+++ b/app/src/main/kotlin/com/fantasyidler/repository/SlayerRepository.kt
@@ -72,6 +72,7 @@ class SlayerRepository @Inject constructor(
                 )
             )
             questRepo.recordSlayerTaskCompleted()
+            playerRepo.recordWeeklyProgress("slayer_task", "any", 1)
         } else {
             playerRepo.updateFlags(
                 flags.copy(

--- a/app/src/main/kotlin/com/fantasyidler/repository/WeeklyQuestRepository.kt
+++ b/app/src/main/kotlin/com/fantasyidler/repository/WeeklyQuestRepository.kt
@@ -1,0 +1,182 @@
+package com.fantasyidler.repository
+
+import com.fantasyidler.data.json.WeeklyQuestTemplate
+import com.fantasyidler.data.model.PlayerFlags
+import java.util.Calendar
+import javax.inject.Inject
+import javax.inject.Singleton
+import kotlin.random.Random
+
+data class WeeklyQuestWithProgress(
+    val template: WeeklyQuestTemplate,
+    val progress: Int,
+    val claimed: Boolean,
+)
+
+@Singleton
+class WeeklyQuestRepository @Inject constructor(
+    private val gameData: GameDataRepository,
+) {
+
+    /** Returns epoch ms of the next Monday 6am in local time after [fromMs]. */
+    fun nextResetMs(fromMs: Long = System.currentTimeMillis()): Long {
+        val cal = Calendar.getInstance().apply { timeInMillis = fromMs }
+        cal.set(Calendar.HOUR_OF_DAY, 6)
+        cal.set(Calendar.MINUTE, 0)
+        cal.set(Calendar.SECOND, 0)
+        cal.set(Calendar.MILLISECOND, 0)
+        
+        // If we are exactly at Monday 6am or earlier today, and it is Monday, we advance if we are strictly <= fromMs.
+        // Actually, just advance until it's Monday and time > fromMs.
+        if (cal.timeInMillis <= fromMs) cal.add(Calendar.DAY_OF_YEAR, 1)
+        while (cal.get(Calendar.DAY_OF_WEEK) != Calendar.MONDAY) {
+            cal.add(Calendar.DAY_OF_YEAR, 1)
+        }
+        return cal.timeInMillis
+    }
+
+    fun shouldRefresh(generatedAt: Long): Boolean {
+        if (generatedAt == 0L) return true
+        val now = System.currentTimeMillis()
+        val nextReset = nextResetMs(generatedAt)
+        return now >= nextReset
+    }
+
+    private val combatSkills = listOf("attack", "strength", "defense", "ranged", "magic", "hitpoints")
+
+    /** Pick 5 distinct quest IDs from the pool using a date-seeded RNG (same quests all week). */
+    fun selectFiveQuests(skillLevels: Map<String, Int>): List<String> {
+        // Seed based on the most recent Monday 6am
+        val now = System.currentTimeMillis()
+        val cal = Calendar.getInstance().apply { timeInMillis = now }
+        cal.set(Calendar.HOUR_OF_DAY, 6)
+        cal.set(Calendar.MINUTE, 0)
+        cal.set(Calendar.SECOND, 0)
+        cal.set(Calendar.MILLISECOND, 0)
+        if (cal.timeInMillis > now) cal.add(Calendar.DAY_OF_YEAR, -1)
+        while (cal.get(Calendar.DAY_OF_WEEK) != Calendar.MONDAY) {
+            cal.add(Calendar.DAY_OF_YEAR, -1)
+        }
+        val seed = cal.timeInMillis
+
+        val rng = Random(seed)
+        val pool = gameData.weeklyQuestPool
+        val eligible = pool.filter { quest ->
+            val playerLevel = if (quest.skill == "combat") {
+                combatSkills.maxOf { skillLevels[it] ?: 1 }
+            } else {
+                skillLevels[quest.skill] ?: 1
+            }
+            playerLevel >= quest.levelRequired
+        }.shuffled(rng).take(5).toMutableList()
+        if (eligible.size < 5) {
+            val remaining = pool.sortedBy { it.levelRequired }
+                .filter { q -> eligible.none { it.id == q.id } }
+            eligible += remaining.take(5 - eligible.size)
+        }
+        return eligible.map { it.id }
+    }
+
+    fun refreshFlags(flags: PlayerFlags, skillLevels: Map<String, Int>): PlayerFlags {
+        val ids = selectFiveQuests(skillLevels)
+        return flags.copy(
+            weeklyQuestIds = ids,
+            weeklyQuestProgress = emptyMap(),
+            weeklyQuestClaimed = emptyList(),
+            weeklyBonusClaimed = false,
+            weeklyQuestGeneratedAt = System.currentTimeMillis(),
+        )
+    }
+
+    fun getActiveWeeklyQuests(flags: PlayerFlags): List<WeeklyQuestWithProgress> {
+        val pool = gameData.weeklyQuestPool.associateBy { it.id }
+        return flags.weeklyQuestIds.mapNotNull { id ->
+            val template = pool[id] ?: return@mapNotNull null
+            WeeklyQuestWithProgress(
+                template = template,
+                progress = flags.weeklyQuestProgress[id] ?: 0,
+                claimed = id in flags.weeklyQuestClaimed,
+            )
+        }
+    }
+
+    fun recordProgress(
+        flags: PlayerFlags,
+        type: String,
+        target: String,
+        amount: Int,
+    ): PlayerFlags {
+        val pool = gameData.weeklyQuestPool.associateBy { it.id }
+        val activeUnclaimed = flags.weeklyQuestIds.filter { it !in flags.weeklyQuestClaimed }
+        if (activeUnclaimed.isEmpty()) return flags
+
+        var updated = flags.weeklyQuestProgress.toMutableMap()
+        var changed = false
+
+        for (id in activeUnclaimed) {
+            val quest = pool[id] ?: continue
+            if (quest.type != type) continue
+            if (quest.type == "kill_enemy" && quest.target != target && quest.target != "any") continue
+            if (quest.type in listOf("gather", "craft") && quest.target != target && quest.target != "any") continue
+            if (quest.type == "boss" && quest.target != target && quest.target != "any") continue
+            if (quest.type == "slayer_task" && quest.target != target && quest.target != "any") continue
+            if (quest.type == "mercantile" && quest.target != target && quest.target != "any") continue
+            if (quest.type == "farming" && quest.target != target && quest.target != "any") continue
+            if (quest.type == "guild_daily" && quest.target != target && quest.target != "any") continue
+            if (quest.type == "agility" && quest.target != target && quest.target != "any") continue
+            val current = updated[id] ?: 0
+            val max = quest.amount
+            if (current >= max) continue
+            updated[id] = minOf(current + amount, max)
+            changed = true
+        }
+
+        return if (changed) flags.copy(weeklyQuestProgress = updated) else flags
+    }
+
+    fun recordPrayerProgress(flags: PlayerFlags, amount: Int): PlayerFlags {
+        val pool = gameData.weeklyQuestPool.associateBy { it.id }
+        val activeUnclaimed = flags.weeklyQuestIds.filter { it !in flags.weeklyQuestClaimed }
+        if (activeUnclaimed.isEmpty()) return flags
+
+        var updated = flags.weeklyQuestProgress.toMutableMap()
+        var changed = false
+
+        for (id in activeUnclaimed) {
+            val quest = pool[id] ?: continue
+            if (quest.type != "prayer") continue
+            val current = updated[id] ?: 0
+            val max = quest.amount
+            if (current >= max) continue
+            updated[id] = minOf(current + amount, max)
+            changed = true
+        }
+
+        return if (changed) flags.copy(weeklyQuestProgress = updated) else flags
+    }
+
+    fun claimQuest(
+        flags: PlayerFlags,
+        templateId: String,
+    ): Pair<PlayerFlags, Long> {
+        val pool = gameData.weeklyQuestPool.associateBy { it.id }
+        val template = pool[templateId] ?: return flags to 10_000L
+        val progress = flags.weeklyQuestProgress[templateId] ?: 0
+        check(progress >= template.amount) { "Quest not complete yet" }
+        check(templateId !in flags.weeklyQuestClaimed) { "Quest already claimed" }
+
+        val newFlags = flags.copy(
+            weeklyQuestClaimed = flags.weeklyQuestClaimed + templateId,
+        )
+        return newFlags to 10_000L
+    }
+
+    fun claimWeeklyBonus(flags: PlayerFlags): PlayerFlags {
+        check(flags.weeklyQuestClaimed.size == 5) { "Not all weekly quests claimed" }
+        check(!flags.weeklyBonusClaimed) { "Weekly bonus already claimed" }
+
+        return flags.copy(
+            weeklyBonusClaimed = true,
+        )
+    }
+}

--- a/app/src/main/kotlin/com/fantasyidler/ui/screen/QuestsScreen.kt
+++ b/app/src/main/kotlin/com/fantasyidler/ui/screen/QuestsScreen.kt
@@ -56,11 +56,12 @@ import com.fantasyidler.repository.DailyQuestWithProgress
 import com.fantasyidler.ui.theme.GoldPrimary
 import com.fantasyidler.ui.viewmodel.QuestWithProgress
 import com.fantasyidler.ui.viewmodel.QuestsViewModel
+import com.fantasyidler.repository.WeeklyQuestWithProgress
 import com.fantasyidler.util.GameStrings
 import com.fantasyidler.util.formatCoins
 import com.fantasyidler.util.formatXp
 
-private val TAB_GROUPS = listOf("Daily", "Gathering", "Crafting", "Combat", "Special")
+private val TAB_GROUPS = listOf("Daily", "Weekly", "Gathering", "Crafting", "Combat", "Special")
 
 @Composable
 private fun tabGroupLabel(group: String): String = when (group) {
@@ -69,6 +70,7 @@ private fun tabGroupLabel(group: String): String = when (group) {
     "Combat"    -> stringResource(R.string.label_combat)
     "Special"   -> stringResource(R.string.label_special)
     "Daily"     -> stringResource(R.string.label_daily)
+    "Weekly"    -> "Weekly"
     else        -> group
 }
 
@@ -137,6 +139,8 @@ fun QuestsScreen(
                 TAB_GROUPS.forEachIndexed { index, group ->
                     val claimableInGroup = if (group == "Daily") {
                         state.dailyQuests.count { it.progress >= it.template.amount && !it.claimed }
+                    } else if (group == "Weekly") {
+                        state.weeklyQuests.count { it.progress >= it.template.amount && !it.claimed }
                     } else {
                         (state.questsByGroup[group] ?: emptyList()).count { it.isClaimable }
                     }
@@ -163,6 +167,14 @@ fun QuestsScreen(
                         nextReset     = state.nextDailyReset,
                         hideCompleted = state.hideCompleted,
                         onClaimQuest  = { viewModel.claimDailyQuest(it) },
+                    )
+                } else if (currentGroup == "Weekly") {
+                    WeeklyQuestsContent(
+                        quests        = state.weeklyQuests,
+                        nextReset     = state.nextWeeklyReset,
+                        hideCompleted = state.hideCompleted,
+                        onClaimQuest  = { viewModel.claimWeeklyQuest(it) },
+                        onClaimBonus  = { viewModel.claimWeeklyBonus() },
                     )
                 } else {
                     val quests = state.questsByGroup[currentGroup] ?: emptyList()
@@ -234,6 +246,71 @@ private fun DailyQuestsContent(
         item {
             Text(
                 text     = stringResource(R.string.label_daily_reset),
+                style    = MaterialTheme.typography.labelSmall,
+                color    = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 16.dp, vertical = 12.dp),
+            )
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Weekly quests content
+// ---------------------------------------------------------------------------
+
+@Composable
+private fun WeeklyQuestsContent(
+    quests: List<WeeklyQuestWithProgress>,
+    nextReset: Long,
+    hideCompleted: Boolean = false,
+    onClaimQuest: (String) -> Unit,
+    onClaimBonus: () -> Unit,
+) {
+    val visibleQuests = if (hideCompleted) quests.filter { !it.claimed } else quests
+    val allQuestsClaimed = quests.isNotEmpty() && quests.all { it.claimed }
+    
+    LazyColumn(Modifier.fillMaxSize()) {
+        if (visibleQuests.isEmpty()) {
+            item {
+                Box(
+                    Modifier
+                        .fillMaxWidth()
+                        .padding(32.dp),
+                    contentAlignment = Alignment.Center,
+                ) {
+                    Text(
+                        text  = stringResource(R.string.quests_none_in_category),
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+            }
+        } else {
+            items(visibleQuests, key = { it.template.id }) { q ->
+                WeeklyQuestCard(quest = q, onClaim = { onClaimQuest(q.template.id) })
+                HorizontalDivider(modifier = Modifier.padding(horizontal = 16.dp))
+            }
+        }
+        if (allQuestsClaimed) {
+            item {
+                Column(Modifier.padding(horizontal = 16.dp, vertical = 12.dp)) {
+                    Text(
+                        text = "Weekly Bonus!",
+                        style = MaterialTheme.typography.bodyLarge,
+                        color = GoldPrimary,
+                    )
+                    Spacer(Modifier.height(8.dp))
+                    Button(onClick = onClaimBonus, modifier = Modifier.fillMaxWidth()) {
+                        Text("Claim Weekly Bonus")
+                    }
+                }
+            }
+        }
+        item {
+            Text(
+                text     = "Resets Monday at 6am",
                 style    = MaterialTheme.typography.labelSmall,
                 color    = MaterialTheme.colorScheme.onSurfaceVariant,
                 modifier = Modifier
@@ -481,6 +558,81 @@ private fun QuestRow(
             }
             Button(
                 onClick  = onClaimReward,
+                modifier = Modifier.fillMaxWidth(),
+            ) {
+                Text(stringResource(R.string.label_claim_reward))
+            }
+        }
+    }
+}
+
+@Composable
+private fun WeeklyQuestCard(
+    quest: WeeklyQuestWithProgress,
+    onClaim: () -> Unit,
+) {
+    val isComplete = quest.progress >= quest.template.amount
+    val isClaimed  = quest.claimed
+    val name      = quest.template.displayName
+    val objective = quest.template.description
+
+    Column(
+        Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp, vertical = 12.dp),
+    ) {
+        Text(
+            text       = name,
+            style      = MaterialTheme.typography.bodyLarge,
+            fontWeight = FontWeight.Bold,
+        )
+        Spacer(Modifier.height(2.dp))
+        Text(
+            text  = objective,
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+
+        if (!isClaimed) {
+            Spacer(Modifier.height(8.dp))
+            val fraction = (quest.progress.toFloat() / quest.template.amount.toFloat()).coerceIn(0f, 1f)
+            LinearProgressIndicator(
+                progress = { fraction },
+                modifier = Modifier.fillMaxWidth(),
+                color    = GoldPrimary,
+            )
+            Spacer(Modifier.height(4.dp))
+            val displayProgress = quest.progress.coerceAtMost(quest.template.amount)
+            Text(
+                text  = "$displayProgress / ${quest.template.amount}",
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+
+        if (isClaimed) {
+            Spacer(Modifier.height(8.dp))
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Icon(
+                    imageVector        = Icons.Filled.CheckCircle,
+                    contentDescription = stringResource(R.string.label_completed),
+                    tint               = Color(0xFF4CAF50),
+                    modifier           = Modifier
+                        .height(18.dp)
+                        .width(18.dp),
+                )
+                Spacer(Modifier.width(6.dp))
+                Text(
+                    text       = stringResource(R.string.label_completed),
+                    style      = MaterialTheme.typography.labelMedium,
+                    color      = Color(0xFF4CAF50),
+                    fontWeight = FontWeight.SemiBold,
+                )
+            }
+        } else if (isComplete) {
+            Spacer(Modifier.height(6.dp))
+            Button(
+                onClick  = onClaim,
                 modifier = Modifier.fillMaxWidth(),
             ) {
                 Text(stringResource(R.string.label_claim_reward))

--- a/app/src/main/kotlin/com/fantasyidler/ui/viewmodel/CombatViewModel.kt
+++ b/app/src/main/kotlin/com/fantasyidler/ui/viewmodel/CombatViewModel.kt
@@ -703,6 +703,7 @@ class CombatViewModel @Inject constructor(
                 loot         = loot,
             )
             playerRepo.recordDailyKills(mapOf(session.activityKey to 1))
+            playerRepo.recordWeeklyProgress("boss", session.activityKey, 1)
             guildRepo.recordGuildCombat(mapOf(session.activityKey to 1), detectCombatStyle(last.xpBySkill))
         }
         val xpDisplayBySkill = last.xpBySkill.mapValues { (_, xp) -> xp * boostMult }

--- a/app/src/main/kotlin/com/fantasyidler/ui/viewmodel/GuildDetailViewModel.kt
+++ b/app/src/main/kotlin/com/fantasyidler/ui/viewmodel/GuildDetailViewModel.kt
@@ -140,6 +140,7 @@ class GuildDetailViewModel @Inject constructor(
             val flags = playerRepo.getFlags()
             val (newFlags, rewards) = guildRepo.claimGuildDaily(flags, templateId) ?: return@launch
             playerRepo.updateFlags(newFlags)
+            playerRepo.recordWeeklyProgress("guild_daily", "any", 1)
             if (rewards.xp > 0 && rewards.xpSkill.isNotBlank()) {
                 playerRepo.applySessionResults(rewards.xpSkill, rewards.xp.toLong(), rewards.items)
             } else if (rewards.items.isNotEmpty()) {

--- a/app/src/main/kotlin/com/fantasyidler/ui/viewmodel/HomeViewModel.kt
+++ b/app/src/main/kotlin/com/fantasyidler/ui/viewmodel/HomeViewModel.kt
@@ -494,6 +494,7 @@ class HomeViewModel @Inject constructor(
                         awardedCapes += playerRepo.applySessionResults(Skills.MERCANTILE, totalXp, emptyMap())
                         playerRepo.addCoins(coinReturnBoosted)
                         guildRepo.recordGuildTrade(coinReturnBoosted)
+                        playerRepo.recordWeeklyProgress("mercantile", session.activityKey, frames.size)
                         combinedXpBySkill[Skills.MERCANTILE] = (combinedXpBySkill[Skills.MERCANTILE] ?: 0L) + totalXp
                         combinedCoins += coinReturnBoosted
                     }
@@ -512,7 +513,10 @@ class HomeViewModel @Inject constructor(
                                 questRepo.recordGathering(session.skillName, regular)
                                 playerRepo.recordDailyGathering(regular)
                                 when (session.skillName) {
-                                    Skills.AGILITY      -> guildRepo.recordGuildSessions()
+                                    Skills.AGILITY      -> {
+                                        guildRepo.recordGuildSessions()
+                                        playerRepo.recordWeeklyProgress("agility", session.activityKey, frames.size)
+                                    }
                                     Skills.RUNECRAFTING -> guildRepo.recordGuildCrafting(session.skillName, regular)
                                     else                -> guildRepo.recordGuildGathering(session.skillName, regular)
                                 }

--- a/app/src/main/kotlin/com/fantasyidler/ui/viewmodel/QuestsViewModel.kt
+++ b/app/src/main/kotlin/com/fantasyidler/ui/viewmodel/QuestsViewModel.kt
@@ -12,6 +12,7 @@ import com.fantasyidler.repository.DailyReward
 import com.fantasyidler.repository.GameDataRepository
 import com.fantasyidler.repository.PlayerRepository
 import com.fantasyidler.repository.QuestRepository
+import com.fantasyidler.repository.WeeklyQuestWithProgress
 import com.fantasyidler.util.formatCoins
 import com.fantasyidler.util.formatXp
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -47,6 +48,8 @@ data class QuestsUiState(
     val completedCount: Int = 0,
     val dailyQuests: List<DailyQuestWithProgress> = emptyList(),
     val nextDailyReset: Long = 0L,
+    val weeklyQuests: List<WeeklyQuestWithProgress> = emptyList(),
+    val nextWeeklyReset: Long = 0L,
     val snackbarMessage: String? = null,
     val hideCompleted: Boolean = false,
 )
@@ -61,6 +64,7 @@ class QuestsViewModel @Inject constructor(
     private val gameData: GameDataRepository,
     private val playerRepo: PlayerRepository,
     private val dailyQuestRepo: DailyQuestRepository,
+    private val weeklyQuestRepo: WeeklyQuestRepository,
     private val json: Json,
 ) : ViewModel() {
 
@@ -72,7 +76,12 @@ class QuestsViewModel @Inject constructor(
             _extra.update { it.copy(hideCompleted = flags.hideCompletedQuests) }
             // Trigger a DB refresh if daily quests have rolled over, and seed nextDailyReset.
             playerRepo.getRefreshedDailyFlags()
-            _extra.update { it.copy(nextDailyReset = dailyQuestRepo.nextResetMs()) }
+            _extra.update { 
+                it.copy(
+                    nextDailyReset = dailyQuestRepo.nextResetMs(),
+                    nextWeeklyReset = weeklyQuestRepo.nextResetMs()
+                )
+            }
         }
     }
 
@@ -113,12 +122,19 @@ class QuestsViewModel @Inject constructor(
             extra.dailyQuests
         }
 
+        val weeklyQuests = if (player != null) {
+            weeklyQuestRepo.getActiveWeeklyQuests(flags)
+        } else {
+            extra.weeklyQuests
+        }
+
         extra.copy(
             isLoading      = false,
             questsByGroup  = questsByGroup,
             claimableCount = claimable,
             completedCount = completed,
             dailyQuests    = dailyQuests,
+            weeklyQuests   = weeklyQuests,
         )
     }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), QuestsUiState())
 
@@ -212,6 +228,31 @@ class QuestsViewModel @Inject constructor(
                 }
             }
             _extra.update { it.copy(snackbarMessage = message) }
+        }
+    }
+
+    fun claimWeeklyQuest(templateId: String) {
+        viewModelScope.launch {
+            val flags = playerRepo.getFlags()
+            val (newFlags, rewardCoins) = weeklyQuestRepo.claimQuest(flags, templateId)
+            playerRepo.updateFlags(newFlags)
+            playerRepo.addCoins(rewardCoins)
+            _extra.update { it.copy(snackbarMessage = "Weekly challenge complete! +${rewardCoins.formatCoins()} coins") }
+        }
+    }
+
+    fun claimWeeklyBonus() {
+        viewModelScope.launch {
+            val flags = playerRepo.getFlags()
+            if (flags.weeklyQuestClaimed.size < 5 || flags.weeklyBonusClaimed) return@launch
+            
+            val newFlags = weeklyQuestRepo.claimWeeklyBonus(flags)
+            playerRepo.updateFlags(newFlags)
+            
+            // Grand prize for completing all 5 weekly quests
+            val coins = 100_000L
+            playerRepo.addCoins(coins)
+            _extra.update { it.copy(snackbarMessage = "All weekly challenges complete! +${coins.formatCoins()} coins") }
         }
     }
 

--- a/build_output.log
+++ b/build_output.log
@@ -1,0 +1,18 @@
+WARNING: A restricted method in java.lang.System has been called
+WARNING: java.lang.System::load has been called by net.rubygrapefruit.platform.internal.NativeLibraryLoader in an unnamed module (file:/home/bixpurr/.gradle/wrapper/dists/gradle-8.7-bin/bhs2wmbdwecv87pi65oeuq5iu/gradle-8.7/lib/native-platform-0.22-milestone-25.jar)
+WARNING: Use --enable-native-access=ALL-UNNAMED to avoid a warning for callers in this module
+WARNING: Restricted methods will be blocked in a future release unless native access is enabled
+
+
+FAILURE: Build failed with an exception.
+
+* What went wrong:
+25.0.3
+
+* Try:
+> Run with --stacktrace option to get the stack trace.
+> Run with --info or --debug option to get more log output.
+> Run with --scan to get full insights.
+> Get more help at https://help.gradle.org.
+
+BUILD FAILED in 758ms

--- a/context.md
+++ b/context.md
@@ -1,0 +1,366 @@
+# IdleFantasy — Project Context
+
+## Overview
+
+**IdleFantasy** is a free, open-source, offline idle RPG for Android.
+- No internet, no account, no ads
+- Set hero to work, close app, come back to loot
+- App ID: `com.tristinbaker.idlefantasy`
+- Package: `com.fantasyidler`
+- Current version: `1.8.8` (versionCode 69)
+- Min SDK: 26 | Target SDK: 35
+- Distributed via F-Droid and GitHub Releases
+
+---
+
+## Tech Stack
+
+| Concern | Library |
+|---|---|
+| Language | Kotlin |
+| UI | Jetpack Compose + Material 3 |
+| Database | Room (SQLite) v3 |
+| DI | Hilt |
+| JSON | kotlinx.serialization |
+| Architecture | MVVM + Repository |
+| Background work | AlarmManager + BroadcastReceivers |
+| Notifications | NotificationCompat |
+| Localization | Android string resources (Weblate-compatible) |
+
+---
+
+## Repository Root Structure
+
+```
+IdleFantasy/
+├── app/                        # Android application module
+│   ├── build.gradle.kts        # Build config (SDK, deps, signing)
+│   ├── proguard-rules.pro
+│   ├── lint-baseline.xml
+│   └── src/main/
+│       ├── AndroidManifest.xml
+│       ├── assets/data/        # All static game JSON data
+│       └── kotlin/com/fantasyidler/
+├── wiki/                       # Python wiki site generator
+├── docs/                       # F-Droid metadata
+├── build.gradle.kts            # Root build
+├── settings.gradle.kts
+└── gradle/                     # Version catalog (libs.versions.toml)
+```
+
+---
+
+## Kotlin Package Structure
+
+```
+com.fantasyidler/
+├── FantasyIdlerApp.kt          # Hilt Application class
+├── MainActivity.kt             # Single Activity; handles notification deep-links, theme, font scale
+│
+├── data/
+│   ├── db/
+│   │   ├── AppDatabase.kt      # Room database (v3); holds migrations 1→2, 2→3
+│   │   └── dao/
+│   │       ├── PlayerDao.kt
+│   │       ├── SkillSessionDao.kt
+│   │       ├── QuestProgressDao.kt
+│   │       ├── FarmingPatchDao.kt
+│   │       ├── GlobalStateDao.kt
+│   │       └── ArenaRecordDao.kt
+│   ├── json/                   # Kotlin data classes for assets/data JSON
+│   │   ├── BlessingData.kt, BoneData.kt, BossData.kt, CropData.kt
+│   │   ├── DailyQuestData.kt, DungeonData.kt, EnemyData.kt
+│   │   ├── EquipmentData.kt, GatheringData.kt, GuildDailyData.kt
+│   │   ├── GuildQuestData.kt, HerbloreData.kt, MarketplaceData.kt
+│   │   ├── PetData.kt, QuestData.kt, RecipeData.kt, RuneData.kt
+│   │   ├── SkillData.kt, SkillingDungeonData.kt, SlayerTaskData.kt
+│   │   ├── SpellData.kt, ThievingNpcData.kt, TradeRouteData.kt
+│   └── model/                  # Room entities + domain models
+│       ├── Player.kt           # Room entity; JSON columns for complex fields
+│       ├── PlayerModels.kt     # PlayerFlags, QueuedAction, HiredWorker, WorkerTier, OwnedPet, Skills, EquipSlot
+│       ├── SkillSession.kt     # Room entity; 60-frame pre-simulated session
+│       ├── SessionFrame.kt     # Single minute of a session (items, xp, events)
+│       ├── QuestProgress.kt    # Room entity; quest completion tracking
+│       ├── FarmingPatch.kt     # Room entity; crop patch state
+│       ├── GlobalState.kt      # Room entity; app-wide state
+│       ├── ArenaRecord.kt      # Room entity; game corner scores
+│       └── TownBuildingDef.kt  # Data for Inn/GuildHall/Church upgrade tiers
+│
+├── di/
+│   ├── AppModule.kt            # Hilt: provides Json, Context
+│   └── DatabaseModule.kt      # Hilt: provides AppDatabase + all DAOs
+│
+├── notification/
+│   └── SessionNotificationManager.kt   # Creates/cancels session-complete notifications; EXTRA_NAVIGATE_TO
+│
+├── receiver/                   # BroadcastReceivers
+│   ├── SessionAlarmReceiver.kt # Fired when a session ends; triggers collection
+│   ├── FarmPatchAlarmReceiver.kt
+│   ├── BackupAlarmReceiver.kt
+│   ├── BuffAlarmReceiver.kt    # XP boost / church blessing expiry
+│   └── BootReceiver.kt         # Reschedules alarms on device reboot
+│
+├── repository/
+│   ├── PlayerRepository.kt         # Core: XP, inventory, coins, flags, import/export
+│   ├── SessionRepository.kt        # Active session CRUD, timer scheduling
+│   ├── QueuedSessionStarter.kt     # Auto-starts next queued action after session ends
+│   ├── WorkerQueuedSessionStarter.kt
+│   ├── GameDataRepository.kt       # Lazy-loads all JSON assets; singleton cache
+│   ├── QuestRepository.kt          # Quest progress update logic
+│   ├── DailyQuestRepository.kt     # Daily quest roll + progress
+│   ├── GuildRepository.kt          # Guild rep, rank, quest logic
+│   ├── ChurchRepository.kt         # Blessing activation/expiry; xpMultiplier, coinMultiplier
+│   ├── FarmingRepository.kt        # Crop plant/harvest scheduling
+│   ├── SlayerRepository.kt         # Slayer task assignment
+│   ├── TownRepository.kt           # Town building upgrades
+│   ├── GlobalStateRepository.kt
+│   ├── BackupScheduler.kt          # Auto-backup WorkManager scheduling
+│   └── BuffNotificationScheduler.kt
+│
+├── simulator/
+│   ├── SkillSimulator.kt           # Generates 60 frames for gathering/crafting sessions
+│   ├── CombatSimulator.kt          # Generates 60 frames for dungeon/boss combat
+│   ├── ThievingSimulator.kt        # Generates frames for thieving sessions
+│   ├── MercantileSimulator.kt      # Generates frames for trade route sessions
+│   ├── SkillingDungeonSimulator.kt # Generates frames for expedition sessions
+│   └── XpTable.kt                  # levelForXp(), xpForLevel()
+│
+├── ui/
+│   ├── navigation/
+│   │   ├── Screen.kt               # Sealed class for all route definitions
+│   │   └── AppNavigation.kt        # NavHost, bottom nav bar, composable registrations
+│   ├── theme/
+│   │   ├── Color.kt                # Material 3 color scheme
+│   │   ├── Theme.kt                # FantasyIdlerTheme (dark/light/system)
+│   │   └── Type.kt                 # Typography
+│   ├── screen/                     # 24 composable screens
+│   └── viewmodel/                  # 22 ViewModels (one per screen)
+│
+└── util/
+    ├── Extensions.kt               # Kotlin extensions (formatting, etc.)
+    └── GameStrings.kt              # Localizable display name helpers
+```
+
+---
+
+## Database Entities (Room v3)
+
+| Entity | Table | Description |
+|---|---|---|
+| `Player` | `players` | Single row (id=1); all complex fields as JSON strings |
+| `SkillSession` | `skill_sessions` | Active/past sessions with 60 pre-simulated frames |
+| `QuestProgress` | `quest_progress` | Per-quest completion + counter tracking |
+| `FarmingPatch` | `farming_patches` | Crop patches with timers |
+| `GlobalState` | `global_state` | App-wide state flags |
+| `ArenaRecord` | `arena_records` | Game corner high scores |
+
+**DB Migrations:** 1→2 adds `is_worker_session` + `efficiency_multiplier`; 2→3 adds `worker_slot`.
+
+---
+
+## Key Data Models
+
+### `Player` (Room entity)
+All complex state stored as JSON strings inside a single row:
+- `skillLevels: String` → `Map<String, Int>` (skill key → 1–99)
+- `skillXp: String` → `Map<String, Long>`
+- `inventory: String` → `Map<String, Int>` (item key → qty)
+- `equipped: String` → `Map<String, String?>` (slot → item key)
+- `flags: String` → `PlayerFlags` (HP, active food, queue, settings...)
+- `pets: String` → `List<OwnedPet>`
+- `coins: Long`
+
+### `PlayerFlags` (serialized into `flags` column)
+Contains: currentHp, equippedFood, equippedArrows, equippedRunes, activeSpell, activeWeaponSlot, xpBoostExpiresAt, characterName/gender/race, sessionQueue (up to 3), hiredWorker, hiredWorker2, guildReputation, dailyQuestIds/progress/claimed, skillingDungeonNotes, unlockedDungeons, activeBlessingKey, slayerTask, recentSessions, skillPrestige, farmingFertilizer, townBuildingTiers, lotteryTickets, etc.
+
+### `SkillSession` (Room entity)
+- `sessionId: String` (UUID)
+- `skillName: String` (canonical skill key)
+- `activityKey: String` (ore/dungeon/etc.)
+- `startedAt / endsAt: Long` (epoch ms; session = up to 1 hour)
+- `frames: String` → `List<SessionFrame>` (60 pre-simulated frames)
+- `isWorkerSession: Boolean`
+- `workerSlot: Int` (0=player, 1=long laborer, 2=second worker)
+
+### `Skills` object — canonical skill keys
+Gathering: `mining`, `fishing`, `woodcutting`, `farming`, `agility`, `thieving`
+Crafting: `smithing`, `cooking`, `fletching`, `crafting`, `firemaking`, `runecrafting`, `herblore`, `construction`
+Combat: `attack`, `strength`, `defense`, `ranged`, `magic`, `hitpoints`, `prayer`
+Support: `mercantile`, `slayer`
+
+### `EquipSlot` object — equipment slot keys
+Weapons: `weapon_atk`, `weapon_str`, `weapon_ranged`, `weapon_magic`
+Armor: `head`, `body`, `legs`, `boots`, `cape`, `ring`, `necklace`, `shield`
+Tools: `pickaxe`, `axe`, `fishing_rod`, `hoe`
+
+---
+
+## Navigation & Screens
+
+### Bottom Nav (5 tabs)
+`Skills` | `Combat` | `Home` (center circle) | `Quests` | `Profile`
+
+### All Screens (routes)
+| Screen | Route | Entry Point |
+|---|---|---|
+| Home | `home` | Bottom nav |
+| Skills | `skills` | Bottom nav |
+| Combat | `combat` | Bottom nav |
+| Quests | `quests` | Bottom nav |
+| Profile | `profile` | Bottom nav |
+| Settings | `settings` | From Home |
+| Shop | `shop` | From Home |
+| Inn | `inn` | From Home |
+| WorkerSkills | `worker_skills?initialSlot={initialSlot}` | From Home/Inn |
+| GuildHall | `guild_hall` | From Home |
+| GuildDetail | `guild_detail/{guild}` | From GuildHall |
+| Church | `church` | From Home |
+| Slayer | `slayer` | From Home/Skills |
+| Builder | `builder` | From Home |
+| GameCorner | `game_corner` | From Home |
+| Farming | `farming` | From Skills (also notification deep-link) |
+| BoneAltar | `bone_altar` | From Skills |
+| Combat Gear | `combat/gear` | From Profile |
+| Onboarding | Full-screen overlay | First launch |
+
+---
+
+## Session Lifecycle
+
+1. User picks skill + activity → VM calls `SessionRepository.startSession()`
+2. Simulator pre-generates 60 `SessionFrame`s and stores full `SkillSession` in DB
+3. `AlarmManager` schedules exact alarm at `endsAt`
+4. `SessionAlarmReceiver` fires → marks session complete → sends notification
+5. User opens app → ViewModel calls `collectSession()` → `PlayerRepository.applySessionResults()`
+6. `QueuedSessionStarter` auto-starts next action in queue
+
+---
+
+## Worker System
+
+- **Long Laborer** (slot 1): 8h, 0.5× efficiency, uncapped craft qty
+- **Apprentice** (slot 2): 8h, 1.0× efficiency, max 480 crafts
+- **Journeyman** (slot 2): 6h, 1.25× efficiency, max 360 crafts
+- **Master** (slot 2): 4h, 2.0× efficiency, max 240 crafts
+- Each worker has its own queue (1 queued item max)
+
+---
+
+## Boosts & Multipliers
+
+- **XP Boost**: 2× XP for 48h, costs 250,000 coins (`PlayerRepository.XP_BOOST_COST`)
+- **Church Blessings**: XP boost (up to 1.5×), Defense bonus, or Coin multiplier
+- **Skill Prestige**: 0–3 tiers, each adds 10% XP bonus; requires level 99; resets XP/level to 1
+- **Pets**: Passive XP bonus per pet
+
+---
+
+## Game Data Assets (`assets/data/`)
+
+| File | Contents |
+|---|---|
+| `enemies.json` | Enemy stats (34 KB) |
+| `equipment.json` | All equipment (88 KB) |
+| `quests.json` | 170+ quests (68 KB) |
+| `guild_daily_quests.json` | Guild daily pool (101 KB) |
+| `guild_quests.json` | Guild progression quests (83 KB) |
+| `marketplace.json` | Shop items (11 KB) |
+| `dungeons/` | 20 dungeon JSON files |
+| `skilling_dungeons/` | Expedition JSON files |
+| `skills/` | Per-skill data |
+| `trade_routes/` | Mercantile route data |
+| `recipes/` | smithing, cooking, fletching, crafting, herblore, construction |
+| `daily_quests.json` | Daily quest pool |
+| `crops.json` | Farming crop data |
+| `bones.json` | Prayer bones |
+| `pets.json` | Collectible pets |
+| `spells.json` | Magic spells |
+| `agility_courses.json` | Agility courses |
+| `slayer_tasks.json` | Slayer assignment pool |
+| `raid_bosses.json` | Boss encounter data |
+
+---
+
+## Important Patterns
+
+### Repository Writes
+All writes go through `PlayerRepository`. Never touch `PlayerDao` directly from a ViewModel.
+Pattern:
+```kotlin
+val player = getOrCreatePlayer()
+val inventory: MutableMap<String, Int> = json.decodeFromString(player.inventory)
+// ... mutate ...
+playerDao.upsert(player.copy(inventory = json.encode<Map<String, Int>>(inventory)))
+```
+
+### JSON Encoding Helper
+```kotlin
+private inline fun <reified T> Json.encode(value: T): String =
+    encodeToString(serializersModule.serializer<T>(), value)
+```
+
+### GameDataRepository (static data)
+All JSON assets are `lazy`-loaded singletons. Access via `gameDataRepository.equipment`, `.dungeons`, etc.
+
+### Adding a New Screen
+1. Add `object MyScreen : Screen(route, labelRes, icon)` to `Screen.kt`
+2. Add `composable(Screen.MyScreen.route)` in `AppNavigation.kt`
+3. Create `MyScreen.kt` in `ui/screen/`
+4. Create `MyScreenViewModel.kt` in `ui/viewmodel/`
+
+### Adding a New DB Column / Migration
+1. Modify entity data class
+2. Add `MIGRATION_N_(N+1)` in `AppDatabase.kt`
+3. Bump `version` in `@Database`
+4. Regenerate schema: `./gradlew :app:kspDebugKotlin`
+
+### Permissions (Manifest)
+- `POST_NOTIFICATIONS` — session complete alerts
+- `RECEIVE_BOOT_COMPLETED` — reschedule alarms on reboot
+- `WAKE_LOCK` — keep CPU alive during alarm processing
+- `USE_EXACT_ALARM` + `SCHEDULE_EXACT_ALARM` — precise session timers
+
+---
+
+## Build
+
+```bash
+# Debug APK
+./gradlew :app:assembleDebug
+# Output: app/build/outputs/apk/debug/app-debug.apk
+
+# Run tests
+./gradlew :app:testDebugUnitTest
+
+# Regenerate lint baseline
+./gradlew lintDebug
+```
+
+Requirements: Android Studio Hedgehog+, JDK 17+, Android SDK 34/35
+
+---
+
+## Localization
+
+Languages: English, German, French, Spanish, Turkish.
+String resources in `app/src/main/res/values-*/strings.xml`.
+Weblate-compatible.
+
+---
+
+## Key Files Quick-Reference
+
+| File | Purpose |
+|---|---|
+| [Player.kt](file:///home/bixpurr/Desktop/Study/IdleFantasy/app/src/main/kotlin/com/fantasyidler/data/model/Player.kt) | Room entity — all player state |
+| [PlayerModels.kt](file:///home/bixpurr/Desktop/Study/IdleFantasy/app/src/main/kotlin/com/fantasyidler/data/model/PlayerModels.kt) | PlayerFlags, Skills, EquipSlot, WorkerTier, QueuedAction |
+| [PlayerRepository.kt](file:///home/bixpurr/Desktop/Study/IdleFantasy/app/src/main/kotlin/com/fantasyidler/repository/PlayerRepository.kt) | All player write operations |
+| [GameDataRepository.kt](file:///home/bixpurr/Desktop/Study/IdleFantasy/app/src/main/kotlin/com/fantasyidler/repository/GameDataRepository.kt) | Lazy JSON asset cache |
+| [AppDatabase.kt](file:///home/bixpurr/Desktop/Study/IdleFantasy/app/src/main/kotlin/com/fantasyidler/data/db/AppDatabase.kt) | Room DB + migrations |
+| [Screen.kt](file:///home/bixpurr/Desktop/Study/IdleFantasy/app/src/main/kotlin/com/fantasyidler/ui/navigation/Screen.kt) | All route definitions |
+| [AppNavigation.kt](file:///home/bixpurr/Desktop/Study/IdleFantasy/app/src/main/kotlin/com/fantasyidler/ui/navigation/AppNavigation.kt) | NavHost + bottom nav bar |
+| [HomeScreen.kt](file:///home/bixpurr/Desktop/Study/IdleFantasy/app/src/main/kotlin/com/fantasyidler/ui/screen/HomeScreen.kt) | Town hub, session status |
+| [HomeViewModel.kt](file:///home/bixpurr/Desktop/Study/IdleFantasy/app/src/main/kotlin/com/fantasyidler/ui/viewmodel/HomeViewModel.kt) | Core session + player state |
+| [CombatSimulator.kt](file:///home/bixpurr/Desktop/Study/IdleFantasy/app/src/main/kotlin/com/fantasyidler/simulator/CombatSimulator.kt) | Dungeon session pre-simulation |
+| [SkillSimulator.kt](file:///home/bixpurr/Desktop/Study/IdleFantasy/app/src/main/kotlin/com/fantasyidler/simulator/SkillSimulator.kt) | Gathering/crafting pre-simulation |
+| [app/build.gradle.kts](file:///home/bixpurr/Desktop/Study/IdleFantasy/app/build.gradle.kts) | Dependencies + build config |


### PR DESCRIPTION
## Overview
This PR implements **Weekly Challenges**, giving players meaningful long-term tasks to work towards throughout the week, offering much larger rewards than standard daily quests.

## Feature Breakdown
* **Weekly Reset Mechanics**: New `WeeklyQuestRepository` selects 5 random weekly quests every Monday at 6 am (based on player skill levels) from a new dedicated quest pool.
* **New Quest Pool**: Added `weekly_quests.json` and `WeeklyQuestData.kt` which introduce various weekly-scale tasks across all major activities (e.g., Deep Core Miner, Armor Forger, Slayer Champion, Trade Baron).
* **Progress Tracking**: Hooked up the `PlayerRepository` and various ViewModels (such as `HomeViewModel`, `CombatViewModel`, `GuildDetailViewModel`) to correctly record weekly progress as the player completes actions like defeating bosses, gathering items, and harvesting crops.
* **Weekly Bonus Chest**: If a player completes all 5 challenges within the week, they can claim a massive grand prize of 100,000 coins directly from the Quests screen.

## State Changes
* Updated `PlayerFlags` in `PlayerModels.kt` to include non-breaking fields for progress persistence:
  * `weeklyQuestIds`
  * `weeklyQuestProgress`
  * `weeklyQuestClaimed`
  * `weeklyBonusClaimed`
  * `weeklyQuestGeneratedAt`

## UI Additions
* **Weekly Tab**: Added a new "Weekly" tab alongside the existing "Daily" tab in `QuestsScreen.kt`.
* **Challenge Cards**: Implemented a new `WeeklyQuestCard` component to show current progress bars, completion checkmarks, and a claim button.
* Added "Resets Monday at 6am" footer notice for clarity.

Also the current weekly-quests.json is just a placeholder please add your own Weekly quests @tristinbaker 