### PR TITLE
Fix quest progression bug

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@
 /local.properties
 /.idea
 .DS_Store
+.vscode
+.kilocode
 /build
 app/build
 /captures

--- a/app/src/main/kotlin/com/fantasyidler/repository/FarmingRepository.kt
+++ b/app/src/main/kotlin/com/fantasyidler/repository/FarmingRepository.kt
@@ -119,17 +119,19 @@ class FarmingRepository @Inject constructor(
             itemsGained = items,
         )
         
+        // Remove fertilizer entry BEFORE recording weekly progress so we don't
+        // overwrite the freshly-saved quest progress with the stale `flags` snapshot.
+        if (ashKey != null) {
+            playerRepo.updateFlags(flags.copy(
+                farmingFertilizer = flags.farmingFertilizer - patchNumber.toString()
+            ))
+        }
+
         playerRepo.recordWeeklyProgress("farming", "any", 1)
 
         val farmingPet = gameData.pets.values.firstOrNull { it.boostedSkill == Skills.FARMING }
         if (farmingPet != null && Random.nextDouble() < 1.0 / 1000.0) {
             playerRepo.addPetIfNew(farmingPet.id, farmingPet.boostPercent)
-        }
-
-        if (ashKey != null) {
-            playerRepo.updateFlags(flags.copy(
-                farmingFertilizer = flags.farmingFertilizer - patchNumber.toString()
-            ))
         }
 
         // 1-in-100 chance per patch harvest to drop the magic bean, once ever


### PR DESCRIPTION
The Season's Harvest weekly quest (and any other farming-type weekly quest)
never tracked progress from harvesting crops. The bug reproduced 100% of the
time whenever a patch was harvested with fertilizer (ash) applied.

Root cause — write-after-write on PlayerFlags in harvestPatch():

  FarmingRepository.harvestPatch() snapshotted PlayerFlags early in the
  function to read the fertilizer map (flags.farmingFertilizer). Later,
  recordWeeklyProgress() was called, which internally does a fresh
  read-modify-write of the flags to increment weeklyQuestProgress by 1 and
  persists that to the database correctly.

  However, immediately after, the old code ran:

      if (ashKey != null) {
          playerRepo.updateFlags(flags.copy(
              farmingFertilizer = flags.farmingFertilizer - patchNumber.toString()
          ))
      }

  This used the *original* stale snapshot of flags — the one captured before
  recordWeeklyProgress() ran. Calling updateFlags() with this snapshot
  overwrote the entire flags object in the database, silently rolling back
  the quest progress increment that had just been saved.

  Net effect: every fertilized harvest incremented progress and then
  immediately decremented it back, leaving the quest permanently stuck.

Fix:

  Reorder the operations so the fertilizer entry is removed from flags
  *before* recordWeeklyProgress() is called. Since recordWeeklyProgress()
  performs its own independent read-modify-write cycle, it reads the
  already-updated flags (fertilizer cleared) and layers the +1 quest
  progress on top with no risk of being overwritten.

  The stale `flags` variable is now only used for reading ashKey/ashMult
  and for the single updateFlags() call that precedes recordWeeklyProgress(),
  eliminating the conflicting write entirely.
  
  Please review carefully before merging. Thank you