### PR TITLE
fix: boss description not reflecting in other languages

### DIFF
--- a/app/src/main/res/value-es-rES/strings.xml
+++ b/app/src/main/res/value-es-rES/strings.xml
@@ -1200,4 +1200,11 @@
     <string name="armory_filter_armor">Armor</string>
     <string name="armory_filter_accessories">Accessories</string>
     <string name="armory_filter_tools">Tools</string>
+
+    <!-- Boss Descriptions -->
+    <string name="boss_king_black_dragon_desc">El legendario dragón de tres cabezas, temido en todo el reino.</string>
+    <string name="boss_demon_lord_desc">Un antiguo demonio del abismo, maestro de la magia oscura.</string>
+    <string name="boss_kraken_desc">El terror de las profundidades marinas, un colosal monstruo marino.</string>
+    <string name="boss_balrog_desc">Un antiguo demonio de llamas y sombras, despertado de su letargo en las profundidades de la tierra.</string>
+    <string name="boss_void_sovereign_desc">La entidad primordial detrás de las grietas del vacío. Antigua más allá de todo cálculo, mira a los retadores mortales con desprecio.</string>
 </resources>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -1192,4 +1192,11 @@
     <string name="armory_filter_armor">Rüstung</string>
     <string name="armory_filter_accessories">Accessoires</string>
     <string name="armory_filter_tools">Werkzeuge</string>
+
+    <!-- Boss Descriptions -->
+    <string name="boss_king_black_dragon_desc">Der legendäre dreiköpfige Drache, gefürchtet im ganzen Reich.</string>
+    <string name="boss_demon_lord_desc">Ein uralter Dämon aus dem Abgrund, Meister der dunklen Magie.</string>
+    <string name="boss_kraken_desc">Der Schrecken der Tiefsee, ein kolossales Seeungeheuer.</string>
+    <string name="boss_balrog_desc">Ein uralter Dämon aus Flamme und Schatten, erwacht aus seinem Schlaf tief unter der Erde.</string>
+    <string name="boss_void_sovereign_desc">Die ursprüngliche Entität hinter den Leerenrissen. Unermesslich alt, betrachtet sie sterbliche Herausforderer mit Verachtung.</string>
 </resources>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -1218,4 +1218,11 @@
     <string name="armory_filter_armor">Armadura</string>
     <string name="armory_filter_accessories">Accesorios</string>
     <string name="armory_filter_tools">Herramientas</string>
+
+    <!-- Boss Descriptions -->
+    <string name="boss_king_black_dragon_desc">El legendario dragón de tres cabezas, temido en todo el reino.</string>
+    <string name="boss_demon_lord_desc">Un antiguo demonio del abismo, maestro de la magia oscura.</string>
+    <string name="boss_kraken_desc">El terror de las profundidades marinas, un colosal monstruo marino.</string>
+    <string name="boss_balrog_desc">Un antiguo demonio de llamas y sombras, despertado de su letargo en las profundidades de la tierra.</string>
+    <string name="boss_void_sovereign_desc">La entidad primordial detrás de las grietas del vacío. Antigua más allá de todo cálculo, mira a los retadores mortales con desprecio.</string>
 </resources>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -1216,4 +1216,11 @@
     <string name="armory_filter_armor">Armure</string>
     <string name="armory_filter_accessories">Accessoires</string>
     <string name="armory_filter_tools">Outils</string>
+
+    <!-- Boss Descriptions -->
+    <string name="boss_king_black_dragon_desc">Le légendaire dragon à trois têtes, craint dans tout le royaume.</string>
+    <string name="boss_demon_lord_desc">Un ancien démon des abysses, maître de la magie noire.</string>
+    <string name="boss_kraken_desc">La terreur des mers profondes, un monstre marin colossal.</string>
+    <string name="boss_balrog_desc">Un ancien démon de flammes et d\'ombres, réveillé de son sommeil profond sous la terre.</string>
+    <string name="boss_void_sovereign_desc">L\'entité primordiale derrière les failles du vide. Ancienne au-delà de toute mesure, elle considère les challengers mortels avec mépris.</string>
 </resources>

--- a/app/src/main/res/values-fr/strings_items.xml
+++ b/app/src/main/res/values-fr/strings_items.xml
@@ -628,11 +628,6 @@
     <string name="item_starfruit_seed_name">Graine de fruit d\'étoile</string>
     <string name="item_void_lotus_seed_name">Graine de lotus du vide</string>
     <string name="boss_void_sovereign_name">Le Souverain du Vide</string>
-    <string name="boss_void_sovereign_desc">L\'entité primordiale à l\'origine des failles du vide. Ancienne au-delà de toute mesure, elle considère les challengers mortels avec mépris.</string>
-    <string name="boss_balrog_desc">Un ancien démon de flamme et d\'ombre, éveillé de son sommeil au plus profond de la terre.</string>
-    <string name="boss_demon_lord_desc">Un ancien démon des abysses, maître de la magie noire.</string>
-    <string name="boss_king_black_dragon_desc">Le légendaire dragon à trois têtes, redouté dans tout le royaume.</string>
-    <string name="boss_kraken_desc">La terreur des mers profondes, un monstre marin colossal.</string>
     <string name="item_abyssal_rod_name">Canne abyssale</string>
     <string name="item_adamantite_arrow_tip_name">Pointe de flèche en adamantite</string>
     <string name="item_adamantite_boots_name">Bottes en adamantite</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -1247,4 +1247,11 @@
     <string name="armory_filter_armor">Armatura</string>
     <string name="armory_filter_accessories">Accessori</string>
     <string name="armory_filter_tools">Strumenti</string>
+
+    <!-- Boss Descriptions -->
+    <string name="boss_king_black_dragon_desc">Il leggendario drago a tre teste, temuto in tutto il regno.</string>
+    <string name="boss_demon_lord_desc">Un antico demone dell\'abisso, maestro della magia oscura.</string>
+    <string name="boss_kraken_desc">Il terrore dei mari profondi, un colossale mostro marino.</string>
+    <string name="boss_balrog_desc">Un antico demone di fiamme e ombre, risvegliato dal suo sonno profondo sotto la terra.</string>
+    <string name="boss_void_sovereign_desc">L\'entità primordiale dietro gli squarci del vuoto. Antica oltre ogni misura, guarda agli sfidanti mortali con disprezzo.</string>
 </resources>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -1254,4 +1254,11 @@
     <string name="slayer_lamp_large_desc">+50.000 XP aan elke vaardigheid</string>
     <string name="slayer_lamp_pick_skill">Kies een vaardigheid</string>
     <string name="slayer_lamp_purchased">XP toegevoegd aan %1$s!</string>
+
+    <!-- Boss Descriptions -->
+    <string name="boss_king_black_dragon_desc">De legendarische driekoppige draak, gevreesd in het hele rijk.</string>
+    <string name="boss_demon_lord_desc">Een oeroude demon uit de afgrond, meester van duistere magie.</string>
+    <string name="boss_kraken_desc">De schrik van de diepzee, een kolossaal zeemonster.</string>
+    <string name="boss_balrog_desc">Een oeroude demon van vlam en schaduw, ontwaakt uit zijn sluimer diep onder de aarde.</string>
+    <string name="boss_void_sovereign_desc">De oorspronkelijke entiteit achter de leemtescheuren. Onmetelijk oud, bekijkt sterfelijke uitdagers met minachting.</string>
 </resources>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -1248,4 +1248,11 @@
     <string name="armory_filter_armor">Броня</string>
     <string name="armory_filter_accessories">Аксессуары</string>
     <string name="armory_filter_tools">Инструменты</string>
+
+    <!-- Boss Descriptions -->
+    <string name="boss_king_black_dragon_desc">Легендарный трехголовый дракон, которого боятся во всем королевстве.</string>
+    <string name="boss_demon_lord_desc">Древний демон из бездны, мастер темной магии.</string>
+    <string name="boss_kraken_desc">Ужас глубоких морей, колоссальный морской монстр.</string>
+    <string name="boss_balrog_desc">Древний демон пламени и тени, пробужденный от сна глубоко под землей.</string>
+    <string name="boss_void_sovereign_desc">Первобытная сущность, скрывающаяся за разломами пустоты. Неизмеримо древняя, она с презрением смотрит на смертных.</string>
 </resources>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -1223,4 +1223,11 @@
     <string name="armory_filter_armor">Zırh</string>
     <string name="armory_filter_accessories">Aksesuarlar</string>
     <string name="armory_filter_tools">Aletler</string>
+
+    <!-- Boss Descriptions -->
+    <string name="boss_king_black_dragon_desc">Tüm diyarda korkulan efsanevi üç başlı ejderha.</string>
+    <string name="boss_demon_lord_desc">Karanlık büyünün ustası, uçurumdan gelen kadim bir iblis.</string>
+    <string name="boss_kraken_desc">Derin denizlerin dehşeti, devasa bir deniz canavarı.</string>
+    <string name="boss_balrog_desc">Yerin derinliklerindeki uykusundan uyanan, alev ve gölgeden kadim bir iblis.</string>
+    <string name="boss_void_sovereign_desc">Hiçlik yarıklarının arkasındaki ilkel varlık. Ölçülemeyecek kadar yaşlı, ölümlü meydan okuyanlara küçümsemeyle bakar.</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1268,4 +1268,11 @@
     <string name="armory_filter_armor">Armor</string>
     <string name="armory_filter_accessories">Accessories</string>
     <string name="armory_filter_tools">Tools</string>
+
+    <!-- Boss Descriptions -->
+    <string name="boss_king_black_dragon_desc">The legendary three-headed dragon, feared across the realm.</string>
+    <string name="boss_demon_lord_desc">An ancient demon from the abyss, master of dark magic.</string>
+    <string name="boss_kraken_desc">The terror of the deep seas, a colossal sea monster.</string>
+    <string name="boss_balrog_desc">An ancient demon of flame and shadow, awakened from its slumber deep beneath the earth.</string>
+    <string name="boss_void_sovereign_desc">The primordial entity behind the void rifts. Ancient beyond reckoning, it regards mortal challengers with contempt.</string>
 </resources>

--- a/app/src/main/res/values/strings_items.xml
+++ b/app/src/main/res/values/strings_items.xml
@@ -631,12 +631,7 @@
 
 
     <!-- Additional item/boss/food names (English placeholders) -->
-    <string name="boss_balrog_desc" translatable="false">An ancient demon of flame and shadow, awakened from its slumber deep beneath the earth.</string>
-    <string name="boss_demon_lord_desc" translatable="false">An ancient demon from the abyss, master of dark magic.</string>
-    <string name="boss_king_black_dragon_desc" translatable="false">The legendary three-headed dragon, feared across the realm.</string>
-    <string name="boss_kraken_desc" translatable="false">The terror of the deep seas, a colossal sea monster.</string>
     <string name="boss_void_sovereign_name" translatable="false">The Void Sovereign</string>
-    <string name="boss_void_sovereign_desc" translatable="false">The primordial entity behind the void rifts. Ancient beyond reckoning, it regards mortal challengers with contempt.</string>
     <string name="item_abyssal_rod_name" translatable="false">Abyssal Rod</string>
     <string name="item_adamantite_arrow_tip_name" translatable="false">Adamantite Arrow Tips</string>
     <string name="item_adamantite_boots_name" translatable="false">Adamantite Boots</string>


### PR DESCRIPTION
The boss descriptions were still not visible in dutch and some other language only the hardcoded english version was shown I fixed that. The boss desciption are now fully visible in German, Spanish, Italian, Dutch, Russian, etc.