### PR TITLE
Fix blessing stacking

### DIFF
--- a/app/src/main/kotlin/com/fantasyidler/repository/ChurchRepository.kt
+++ b/app/src/main/kotlin/com/fantasyidler/repository/ChurchRepository.kt
@@ -115,7 +115,8 @@ class ChurchRepository @Inject constructor(
 
     suspend fun activateBlessing(key: String): BlessingActivateResult {
         val flags     = playerRepo.getFlags()
-        if (activeBlessing(flags) != null) return BlessingActivateResult.AlreadyActive
+        val active    = activeBlessing(flags)
+        if (active != null && active.key != key) return BlessingActivateResult.AlreadyActive
         val blessing  = BY_KEY[key] ?: return BlessingActivateResult.AlreadyActive
         val cost      = boneCostFor(blessing)
         val inventory = playerRepo.getInventory()
@@ -138,13 +139,18 @@ class ChurchRepository @Inject constructor(
 
         val now = System.currentTimeMillis()
         val durationMs = townRepoProvider.get().blessingDurationMs(flags)
+        val newExpiresAt = if (active != null && active.key == key) {
+            flags.activeBlessingExpiresAt + durationMs
+        } else {
+            now + durationMs
+        }
         playerRepo.updateFlags(
             flags.copy(
                 activeBlessingKey       = key,
-                activeBlessingExpiresAt = now + durationMs,
+                activeBlessingExpiresAt = newExpiresAt,
             )
         )
-        buffNotifScheduler.scheduleBlessingExpiry(now + durationMs)
+        buffNotifScheduler.scheduleBlessingExpiry(newExpiresAt)
         return BlessingActivateResult.Success
     }
 }

--- a/app/src/main/kotlin/com/fantasyidler/ui/screen/ChurchScreen.kt
+++ b/app/src/main/kotlin/com/fantasyidler/ui/screen/ChurchScreen.kt
@@ -284,8 +284,8 @@ private fun BlessingRow(
         }
         Spacer(Modifier.width(12.dp))
         when {
-            isActive                      -> OutlinedButton(onClick = {}, enabled = false) {
-                Text(stringResource(R.string.church_active_chip))
+            isActive                      -> Button(onClick = onActivate) {
+                Text(stringResource(R.string.btn_extend))
             }
             isUnlocked && !anyBlessingActive -> Button(onClick = onActivate) {
                 Text(stringResource(R.string.church_activate))

--- a/app/src/main/res/value-es-rES/strings.xml
+++ b/app/src/main/res/value-es-rES/strings.xml
@@ -36,6 +36,7 @@
     <string name="btn_enter_dungeon">Entrar</string>
     <string name="btn_enter_arena">Entrar a la arena</string>
     <string name="btn_activate">Activar</string>
+    <string name="btn_extend">Extender</string>
     <string name="btn_deactivate">Desactivar</string>
     <string name="btn_close">Cerrar</string>
     <string name="btn_back">Atrás</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -37,6 +37,7 @@
     <string name="btn_enter_dungeon">Dungeon betreten</string>
     <string name="btn_enter_arena">Arena betreten</string>
     <string name="btn_activate">Aktivieren</string>
+    <string name="btn_extend">Verlängern</string>
     <string name="btn_deactivate">Deaktivieren</string>
     <string name="btn_close">Schließen</string>
     <string name="btn_back">Zurück</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -36,6 +36,7 @@
     <string name="btn_enter_dungeon">Entrar</string>
     <string name="btn_enter_arena">Entrar a la arena</string>
     <string name="btn_activate">Activar</string>
+    <string name="btn_extend">Extender</string>
     <string name="btn_deactivate">Desactivar</string>
     <string name="btn_close">Cerrar</string>
     <string name="btn_back">Atrás</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -36,6 +36,7 @@
     <string name="btn_enter_dungeon">Entrer dans le donjon</string>
     <string name="btn_enter_arena">Entrer dans l’arène</string>
     <string name="btn_activate">Activer</string>
+    <string name="btn_extend">Prolonger</string>
     <string name="btn_deactivate">Désactiver</string>
     <string name="btn_close">Fermer</string>
     <string name="btn_back">Retour</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -37,6 +37,7 @@
     <string name="btn_enter_dungeon">Entra nel Dungeon</string>
     <string name="btn_enter_arena">Entra nell\'Arena</string>
     <string name="btn_activate">Attiva</string>
+    <string name="btn_extend">Estendere</string>
     <string name="btn_deactivate">Disattiva</string>
     <string name="btn_close">Chiudi</string>
     <string name="btn_back">Indietro</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -37,6 +37,7 @@
     <string name="btn_enter_dungeon">Dungeon Betreden</string>
     <string name="btn_enter_arena">Arena Betreden</string>
     <string name="btn_activate">Activeren</string>
+    <string name="btn_extend">Verlengen</string>
     <string name="btn_deactivate">Deactiveren</string>
     <string name="btn_close">Sluiten</string>
     <string name="btn_back">Terug</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -37,6 +37,7 @@
     <string name="btn_enter_dungeon">Войти в подземелье</string>
     <string name="btn_enter_arena">Войти на арену</string>
     <string name="btn_activate">Активировать</string>
+    <string name="btn_extend">Продлить</string>
     <string name="btn_deactivate">Деактивировать</string>
     <string name="btn_close">Закрыть</string>
     <string name="btn_back">Назад</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -36,6 +36,7 @@
     <string name="btn_enter_dungeon">Zindana Gir</string>
     <string name="btn_enter_arena">Arenaya Gir</string>
     <string name="btn_activate">Etkinleştir</string>
+    <string name="btn_extend">Uzat</string>
     <string name="btn_deactivate">Devre Dışı Bırak</string>
     <string name="btn_close">Kapat</string>
     <string name="btn_back">Geri</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -37,6 +37,7 @@
     <string name="btn_enter_dungeon">Enter Dungeon</string>
     <string name="btn_enter_arena">Enter Arena</string>
     <string name="btn_activate">Activate</string>
+    <string name="btn_extend">Extend</string>
     <string name="btn_deactivate">Deactivate</string>
     <string name="btn_close">Close</string>
     <string name="btn_back">Back</string>


### PR DESCRIPTION
# Fix: Blessing Time Overwritten Instead of Stacking (Bug Fix & QoL)

## What was the bug?
When a player had an active blessing (e.g., with 44 minutes remaining) and managed to activate the *same kind* of blessing again, the game logic calculated the new expiration time as `System.currentTimeMillis() + durationMs`. This behavior completely overwrote the player's existing remaining time, effectively destroying their 44 minutes and resetting the timer to a flat 24 hours.

## How it was solved
The fix required coordinated changes to both the repository logic and the UI presentation:

1. **Backend Time Stacking (`ChurchRepository.kt`)**: 
   - Adjusted `activateBlessing()` to intercept the activation request and check if the requested blessing matches the currently active blessing (`active.key == key`).
   - If it matches, the new expiration time is calculated by adding the new duration directly to the *existing expiration timestamp* (`flags.activeBlessingExpiresAt + durationMs`).
   - If it differs, it safely falls back to returning an `AlreadyActive` error to prevent cross-blessing overwrites.

2. **Explicit UI Support (`ChurchScreen.kt` & `strings.xml`)**:
   - Replaced the disabled `<OutlinedButton>` ("Active") for the currently active blessing with an enabled `<Button>` labeled **"Extend"**.
   - Added the new `btn_extend` string resource to `strings.xml`.

## Why it was solved that way
This approach transforms what was previously a frustrating bug into an explicit Quality of Life (QoL) mechanic. By explicitly labeling the button "Extend" and appending the duration in the backend, the player's intent to "top up" their buffs is fully supported. It leverages the existing single-timestamp architecture (`activeBlessingExpiresAt`), meaning no complex database migrations were required to support arrays of buffs.

## Alternative approaches considered
- **Alternative 1: Block reactivation completely.** 
  We could have rigidly enforced the `AlreadyActive` state, completely disabling the button so the player *must* wait for the timer to hit 0 before renewing. 
  *Why not use it?* Restricting player freedom in an idle game is poor UX. Players frequently want to "top off" their buffs before going to sleep or stepping away so their progression isn't interrupted while AFK.
- **Alternative 2: Store an array of active blessing instances.** 
  We could have tracked multiple instances of the same blessing and depleted them sequentially. 
  *Why not use it?* Severe over-engineering. Because identical blessings do not stack their magnitude (only their duration), keeping a single scalar timestamp (`activeBlessingExpiresAt`) extending further into the future achieves the exact same result with vastly lower complexity and zero risk of breaking old save files.

## How the implemented solution fixes the bug
By changing the assignment from `now + durationMs` to `currentExpirationTime + durationMs`, the math is strictly cumulative. If the player has 44 minutes left and buys a 24-hour extension, the new expiration target is set to `24 hours and 44 minutes from now`. The player's previously invested bones and time are mathematically preserved.

## Can this bug arise in the future?
No. The core logic now inherently relies on the future timestamp rather than the present moment. The only edge case is if the user clicks "Extend" at the *exact millisecond* the blessing expires. If that happens, the `activeBlessing()` check will return `null` (since it expired), and the game will process it as a fresh activation (`now + durationMs`)—which resolves perfectly accurately without any dropped frames of time.

P.S. I have translated the Extend button to other languages for other languages for your convenience. 
