### PR TITLE
Add "keep_files: true" to wiki-site.yml to preserve F-Droid repo

### DIFF
--- a/.github/workflows/wiki-site.yml
+++ b/.github/workflows/wiki-site.yml
@@ -33,3 +33,4 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: out/IdleFantasy-site
           cname: idlefantasy.tristinbaker.xyz
+          keep_files: true


### PR DESCRIPTION
Workflow-only fix. Should fix #627. The developers who know this code better than I do should test this pull request before accepting it.