### PR TITLE
feat: allow players to deactivate active church blessings

### DIFF
--- a/app/src/main/kotlin/com/fantasyidler/repository/ChurchRepository.kt
+++ b/app/src/main/kotlin/com/fantasyidler/repository/ChurchRepository.kt
@@ -153,4 +153,15 @@ class ChurchRepository @Inject constructor(
         buffNotifScheduler.scheduleBlessingExpiry(newExpiresAt)
         return BlessingActivateResult.Success
     }
+
+    suspend fun deactivateBlessing() {
+        val flags = playerRepo.getFlags()
+        playerRepo.updateFlags(
+            flags.copy(
+                activeBlessingKey       = "",
+                activeBlessingExpiresAt = 0L,
+            )
+        )
+        buffNotifScheduler.cancelBlessingExpiry()
+    }
 }

--- a/app/src/main/kotlin/com/fantasyidler/ui/screen/ChurchScreen.kt
+++ b/app/src/main/kotlin/com/fantasyidler/ui/screen/ChurchScreen.kt
@@ -111,6 +111,24 @@ fun ChurchScreen(
         }
     }
 
+    if (state.showDeactivateConfirm) {
+        AlertDialog(
+            onDismissRequest = viewModel::dismissDeactivate,
+            title = { Text(stringResource(R.string.church_confirm_deactivate_title), fontWeight = FontWeight.Bold) },
+            text = { Text(stringResource(R.string.church_confirm_deactivate_body)) },
+            confirmButton = {
+                Button(onClick = viewModel::confirmDeactivate) {
+                    Text(stringResource(R.string.btn_deactivate))
+                }
+            },
+            dismissButton = {
+                OutlinedButton(onClick = viewModel::dismissDeactivate) {
+                    Text(stringResource(R.string.btn_cancel))
+                }
+            },
+        )
+    }
+
     Scaffold(
         topBar = {
             TopAppBar(
@@ -141,9 +159,10 @@ fun ChurchScreen(
             item {
                 if (anyBlessingActive) {
                     ActiveBlessingBanner(
-                        blessing    = state.activeBlessing!!,
-                        remainingMs = state.activeBlessingRemainingMs,
-                        churchTier  = state.churchTier,
+                        blessing     = state.activeBlessing!!,
+                        remainingMs  = state.activeBlessingRemainingMs,
+                        churchTier   = state.churchTier,
+                        onDeactivate = viewModel::deactivateBlessing,
                     )
                 } else {
                     Text(
@@ -191,7 +210,12 @@ fun ChurchScreen(
 }
 
 @Composable
-private fun ActiveBlessingBanner(blessing: BlessingData, remainingMs: Long, churchTier: Int) {
+private fun ActiveBlessingBanner(
+    blessing: BlessingData,
+    remainingMs: Long,
+    churchTier: Int,
+    onDeactivate: () -> Unit,
+) {
     val context   = LocalContext.current
     val nameResId = context.resources.getIdentifier(
         "blessing_${blessing.key}_name", "string", context.packageName,
@@ -199,34 +223,41 @@ private fun ActiveBlessingBanner(blessing: BlessingData, remainingMs: Long, chur
     val name = if (nameResId != 0) stringResource(nameResId) else blessing.key
     val effectText = blessingEffectText(blessing, churchTier)
 
-    Column(
+    Row(
         modifier = Modifier
             .fillMaxWidth()
             .padding(horizontal = 16.dp, vertical = 12.dp),
+        verticalAlignment = Alignment.CenterVertically,
     ) {
-        Text(
-            text       = stringResource(R.string.church_active_label),
-            style      = MaterialTheme.typography.labelSmall,
-            color      = MaterialTheme.colorScheme.onSurfaceVariant,
-        )
-        Spacer(Modifier.height(2.dp))
-        Text(
-            text       = name,
-            style      = MaterialTheme.typography.titleMedium,
-            fontWeight = FontWeight.Bold,
-            color      = GoldPrimary,
-        )
-        Text(
-            text  = effectText,
-            style = MaterialTheme.typography.bodySmall,
-            color = MaterialTheme.colorScheme.onSurfaceVariant,
-        )
-        Spacer(Modifier.height(4.dp))
-        Text(
-            text  = stringResource(R.string.church_expires_in, remainingMs.formatDurationMs()),
-            style = MaterialTheme.typography.labelSmall,
-            color = MaterialTheme.colorScheme.onSurfaceVariant,
-        )
+        Column(modifier = Modifier.weight(1f)) {
+            Text(
+                text       = stringResource(R.string.church_active_label),
+                style      = MaterialTheme.typography.labelSmall,
+                color      = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            Spacer(Modifier.height(2.dp))
+            Text(
+                text       = name,
+                style      = MaterialTheme.typography.titleMedium,
+                fontWeight = FontWeight.Bold,
+                color      = GoldPrimary,
+            )
+            Text(
+                text  = effectText,
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            Spacer(Modifier.height(4.dp))
+            Text(
+                text  = stringResource(R.string.church_expires_in, remainingMs.formatDurationMs()),
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+        Spacer(Modifier.width(12.dp))
+        OutlinedButton(onClick = onDeactivate) {
+            Text(stringResource(R.string.btn_deactivate))
+        }
     }
 }
 

--- a/app/src/main/kotlin/com/fantasyidler/ui/viewmodel/ChurchViewModel.kt
+++ b/app/src/main/kotlin/com/fantasyidler/ui/viewmodel/ChurchViewModel.kt
@@ -32,6 +32,7 @@ data class ChurchUiState(
     val activeBlessingRemainingMs: Long = 0L,
     val totalBoneEquivalent: Int = 0,
     val pendingBlessingKey: String? = null,
+    val showDeactivateConfirm: Boolean = false,
     val snackbarMessage: String? = null,
 )
 
@@ -88,6 +89,21 @@ class ChurchViewModel @Inject constructor(
     }
 
     fun dismissConfirm() = _extra.update { it.copy(pendingBlessingKey = null) }
+
+    fun deactivateBlessing() {
+        _extra.update { it.copy(showDeactivateConfirm = true) }
+    }
+
+    fun confirmDeactivate() {
+        _extra.update { it.copy(showDeactivateConfirm = false) }
+        viewModelScope.launch {
+            churchRepo.deactivateBlessing()
+        }
+    }
+
+    fun dismissDeactivate() {
+        _extra.update { it.copy(showDeactivateConfirm = false) }
+    }
 
     fun snackbarConsumed() = _extra.update { it.copy(snackbarMessage = null) }
 }

--- a/app/src/main/res/value-es-rES/strings.xml
+++ b/app/src/main/res/value-es-rES/strings.xml
@@ -768,6 +768,8 @@
     <string name="church_bones_available">You have %1$d bones</string>
     <string name="church_not_enough_bones">Not enough bones (need %1$d)</string>
     <string name="church_already_active">A blessing is already active</string>
+    <string name="church_confirm_deactivate_title">¿Desactivar bendición?</string>
+    <string name="church_confirm_deactivate_body">¿Estás seguro de que quieres desactivar tu bendición activa? No recuperarás tus huesos.</string>
     <string name="blessing_blessed_focus_name">Blessed Focus</string>
     <string name="blessing_stone_skin_name">Stone Skin</string>
     <string name="blessing_blessed_focus_ii_name">Blessed Focus II</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -800,6 +800,8 @@
     <string name="church_bones_available">Ihr habt %1$d Knochen (alle Arten)</string>
     <string name="church_not_enough_bones">Nicht genug Knochen (benötigt %1$d)</string>
     <string name="church_already_active">Ihr seid bereits gesegnet</string>
+    <string name="church_confirm_deactivate_title">Segen deaktivieren?</string>
+    <string name="church_confirm_deactivate_body">Bist du sicher, dass du deinen aktiven Segen deaktivieren möchtest? Du erhältst deine Knochen nicht zurück.</string>
 
     <!-- Blessing names -->
     <string name="blessing_blessed_focus_name">Segen der Konzentration</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -792,6 +792,8 @@
     <string name="church_bones_available">You have %1$d bones (all types)</string>
     <string name="church_not_enough_bones">Not enough bones (need %1$d)</string>
     <string name="church_already_active">A blessing is already active</string>
+    <string name="church_confirm_deactivate_title">¿Desactivar bendición?</string>
+    <string name="church_confirm_deactivate_body">¿Estás seguro de que quieres desactivar tu bendición activa? No recuperarás tus huesos.</string>
     <string name="blessing_blessed_focus_name">Blessed Focus</string>
     <string name="blessing_stone_skin_name">Stone Skin</string>
     <string name="blessing_blessed_focus_ii_name">Blessed Focus II</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -832,6 +832,8 @@
     <string name="church_bones_available">Vous avez %1$d os (tous types)</string>
     <string name="church_not_enough_bones">Os insuffisants (besoin de %1$d)</string>
     <string name="church_already_active">Une bénédiction est déjà active</string>
+    <string name="church_confirm_deactivate_title">Désactiver la bénédiction ?</string>
+    <string name="church_confirm_deactivate_body">Es-tu sûr de vouloir désactiver ta bénédiction active ? Tu ne récupéreras pas tes os.</string>
     <string name="blessing_blessed_focus_name">Concentration bénie</string>
     <string name="blessing_stone_skin_name">Peau de Pierre</string>
     <string name="blessing_blessed_focus_ii_name">Concentration Bénie II</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -857,6 +857,8 @@
     <string name="church_bones_available">Hai %1$d ossa (tutti i tipi)</string>
     <string name="church_not_enough_bones">Non hai abbastanza ossa (ne servono %1$d)</string>
     <string name="church_already_active">Una benedizione è già attiva</string>
+    <string name="church_confirm_deactivate_title">Disattivare la benedizione?</string>
+    <string name="church_confirm_deactivate_body">Sei sicuro di voler disattivare la benedizione attiva? Non riavrai indietro le tue ossa.</string>
 
     <!-- Blessing names -->
     <string name="blessing_blessed_focus_name">Concentrazione</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -841,6 +841,8 @@
     <string name="church_bones_available">Je hebt %1$d botten (alle soorten)</string>
     <string name="church_not_enough_bones">Niet genoeg botten (je hebt %1$d nodig)</string>
     <string name="church_already_active">Er is al een zegen actief</string>
+    <string name="church_confirm_deactivate_title">Zegen deactiveren?</string>
+    <string name="church_confirm_deactivate_body">Weet je zeker dat je je actieve zegen wilt deactiveren? Je krijgt je botten niet terug.</string>
 
     <!-- Blessing names -->
     <string name="blessing_blessed_focus_name">Gezegende Focus</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -857,6 +857,8 @@
     <string name="church_bones_available">У вас %1$d костей (все виды)</string>
     <string name="church_not_enough_bones">Недостаточно костей (нужно %1$d)</string>
     <string name="church_already_active">Благословение уже активно</string>
+    <string name="church_confirm_deactivate_title">Деактивировать благословение?</string>
+    <string name="church_confirm_deactivate_body">Вы уверены, что хотите деактивировать активное благословение? Вы не получите кости обратно.</string>
 
     <!-- Blessing names -->
     <string name="blessing_blessed_focus_name">Благословенный фокус</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -797,6 +797,8 @@
     <string name="church_bones_available">You have %1$d bones (all types)</string>
     <string name="church_not_enough_bones">Not enough bones (need %1$d)</string>
     <string name="church_already_active">A blessing is already active</string>
+    <string name="church_confirm_deactivate_title">Kutsamayı Devre Dışı Bırak?</string>
+    <string name="church_confirm_deactivate_body">Aktif kutsamanızı devre dışı bırakmak istediğinizden emin misiniz? Kemiklerinizi geri alamayacaksınız.</string>
     <string name="blessing_blessed_focus_name">Blessed Focus</string>
     <string name="blessing_stone_skin_name">Stone Skin</string>
     <string name="blessing_blessed_focus_ii_name">Blessed Focus II</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -859,6 +859,8 @@
     <string name="church_bones_available">You have %1$d bones (all types)</string>
     <string name="church_not_enough_bones">Not enough bones (need %1$d)</string>
     <string name="church_already_active">A blessing is already active</string>
+    <string name="church_confirm_deactivate_title">Deactivate Blessing?</string>
+    <string name="church_confirm_deactivate_body">Are you sure you want to deactivate your active blessing? You will not get your bones back.</string>
 
     <!-- Blessing names -->
     <string name="blessing_blessed_focus_name">Blessed Focus</string>


### PR DESCRIPTION
Currently, players are stuck with a blessing until it runs out. This PR adds a 'Deactivate' button on the active blessing banner in the Church screen, letting the player turn off the active blessing early. Bones will not be returned. All modified strings have been updated across the 9 translation resource files.