### PR TITLE
Fix dungeon safety calculator ignoring food (Issue #663)

### DIFF
--- a/app/src/main/kotlin/com/fantasyidler/simulator/CombatSimulator.kt
+++ b/app/src/main/kotlin/com/fantasyidler/simulator/CombatSimulator.kt
@@ -188,8 +188,8 @@ object CombatSimulator {
                         val qty  = foodSupply[foodKey] ?: 0
                         if (qty <= 0) continue
                         val heal = foodHealValues[foodKey] ?: continue
-                        if (currentHp + heal <= maxHp) {
-                            currentHp          += heal
+                        if (currentHp + heal <= maxHp || currentHp <= enemyMaxHit || currentHp <= maxHp * 0.5) {
+                            currentHp           = minOf(maxHp, currentHp + heal)
                             foodSupply[foodKey] = qty - 1
                             frameFood[foodKey]  = (frameFood[foodKey] ?: 0) + 1
                             totalFoodEaten++
@@ -410,8 +410,8 @@ object CombatSimulator {
                         val qty  = foodSupply[foodKey] ?: 0
                         if (qty <= 0) continue
                         val heal = foodHealValues[foodKey] ?: continue
-                        if (currentHp + heal <= maxHp) {
-                            currentHp           += heal
+                        if (currentHp + heal <= maxHp || currentHp <= bossMax || currentHp <= maxHp * 0.5) {
+                            currentHp           = minOf(maxHp, currentHp + heal)
                             foodSupply[foodKey]  = qty - 1
                             frameFood[foodKey]   = (frameFood[foodKey] ?: 0) + 1
                             totalFoodEaten++


### PR DESCRIPTION
This PR fixes the dungeon safety calculator and combat simulator food-consumption logic (Issue #663).

### Root Cause
In version 1.9.10, the difficulty estimator switched to running a full tick-by-tick combat simulation (`CombatSimulator.simulateDungeon` / `simulateBoss`). However, the simulator strictly enforced a "no waste" eating rule:
```kotlin
if (currentHp + heal <= maxHp)
```
If a player's `maxHp` is 100 and they equip food that heals more than their maximum hitpoints (e.g., Manta Ray heals 120), the condition `currentHp + 120 <= 100` can never be satisfied. Consequently, the simulator assumes the player never eats, leading to simulated death and displaying "Risky" or "Likely to die" even with top-tier food equipped.

### Solution
We expand the eating logic to consume food if:
1. The heal fits without waste (`currentHp + heal <= maxHp`), OR
2. The player is in danger of being defeated by the enemy/boss's maximum hit on the next tick (`currentHp <= enemyMaxHit` / `currentHp <= bossMax`), OR
3. The player's health drops below 50% (`currentHp <= maxHp * 0.5`).

If any of these conditions are met, the player consumes the food, and health is capped at maximum HP (`currentHp = minOf(maxHp, currentHp + heal)`).

This allows the simulator to properly consume high-healing foods, ensuring dungeon safety and combat simulations run correctly.

Fixes #663.