### PR TITLE
Fix gathering tool multiplier rounding error

### DIFF
--- a/app/src/main/kotlin/com/fantasyidler/simulator/SkillSimulator.kt
+++ b/app/src/main/kotlin/com/fantasyidler/simulator/SkillSimulator.kt
@@ -59,6 +59,7 @@ object SkillSimulator {
     ): Result {
         var currentXp = startXp
         val frames = mutableListOf<SessionFrame>()
+        var oreAccumulator = 0.0
 
         for (minute in 1..60) {
             val xpBefore = currentXp
@@ -71,7 +72,9 @@ object SkillSimulator {
             val levelAfter = XpTable.levelForXp(currentXp)
 
             // Ore quantity this minute
-            val oreQty = max(1, toolEfficiency.roundToInt())
+            oreAccumulator += toolEfficiency.toDouble()
+            val oreQty = max(1, oreAccumulator.toInt())
+            oreAccumulator -= oreQty
             val items = mutableMapOf(oreKey to oreQty)
 
             // Bonus gem rolls — one independent roll per ore mined per gem type
@@ -125,6 +128,7 @@ object SkillSimulator {
     ): Result {
         var currentXp = startXp
         val frames = mutableListOf<SessionFrame>()
+        var logAccumulator = 0.0
 
         for (minute in 1..60) {
             val xpBefore = currentXp
@@ -136,7 +140,9 @@ object SkillSimulator {
             currentXp += xpGain
             val levelAfter = XpTable.levelForXp(currentXp)
 
-            val logQty = max(1, toolEfficiency.roundToInt())
+            logAccumulator += toolEfficiency.toDouble()
+            val logQty = max(1, logAccumulator.toInt())
+            logAccumulator -= logQty
             val items = mutableMapOf(treeData.logName to logQty)
             if (petDropKey != null && petDropChance > 0.0 && random.nextDouble() < petDropChance) {
                 items[petDropKey] = 1
@@ -178,6 +184,7 @@ object SkillSimulator {
     ): Result {
         var currentXp = startXp
         val frames = mutableListOf<SessionFrame>()
+        var fishAccumulator = 0.0
 
         for (minute in 1..60) {
             val xpBefore    = currentXp
@@ -189,7 +196,9 @@ object SkillSimulator {
             currentXp += xpGain
             val levelAfter = XpTable.levelForXp(currentXp)
 
-            val fishQty = max(1, rodEfficiency.roundToInt())
+            fishAccumulator += rodEfficiency.toDouble()
+            val fishQty = max(1, fishAccumulator.toInt())
+            fishAccumulator -= fishQty
             val items = mutableMapOf<String, Int>()
             if (fishingSkillData != null && random.nextDouble() > 0.8) {
                 val dropTable = getTierData(fishingSkillData.dropTables, levelBefore)
@@ -364,7 +373,7 @@ object SkillSimulator {
 
     /** Estimated total item yield for a 60-frame gathering session. */
     fun estimateGatheringQty(efficiency: Float = 1f): Int =
-        max(1, efficiency.roundToInt()) * 60
+        (max(1.0f, efficiency) * 60).roundToInt()
 
     /** Estimated total XP for a 60-frame agility session. */
     fun estimateAgilityXp(xpPerSuccess: Int, levelRequired: Int, currentAgilityLevel: Int): Long {

--- a/app/src/test/kotlin/com/fantasyidler/simulator/SkillSimulatorPureTest.kt
+++ b/app/src/test/kotlin/com/fantasyidler/simulator/SkillSimulatorPureTest.kt
@@ -21,6 +21,15 @@ class SkillSimulatorPureTest {
     }
 
     @Test
+    fun `estimateGatheringQty estimates correct quantity with efficiency`() {
+        assertEquals(60, SkillSimulator.estimateGatheringQty(1.0f))
+        assertEquals(75, SkillSimulator.estimateGatheringQty(1.25f))
+        assertEquals(90, SkillSimulator.estimateGatheringQty(1.5f))
+        assertEquals(60, SkillSimulator.estimateGatheringQty(0.5f))
+    }
+
+
+    @Test
     fun `estimateAgilityXp grows with level then caps at the 0_95 success rate`() {
         // At the minimum level the success rate is the base 0.80.
         assertEquals(960L, SkillSimulator.estimateAgilityXp(10, 1, 1))

--- a/app/src/test/kotlin/com/fantasyidler/simulator/SkillSimulatorRngTest.kt
+++ b/app/src/test/kotlin/com/fantasyidler/simulator/SkillSimulatorRngTest.kt
@@ -50,6 +50,25 @@ class SkillSimulatorRngTest {
     }
 
     @Test
+    fun `mining with fractional tool efficiency accumulates items correctly`() {
+        val res = SkillSimulator.simulateMining(
+            "iron_ore", ore(10), emptyMap(), startXp = 0,
+            toolEfficiency = 1.25f, random = Random(42)
+        )
+        // Over 60 frames, efficiency 1.25 should yield exactly 75 ores.
+        val totalOres = res.frames.sumOf { it.items["iron_ore"] ?: 0 }
+        assertEquals(75, totalOres)
+
+        // The pattern of item counts should alternatingly yield 1, 1, 1, 2.
+        val quantities = res.frames.map { it.items["iron_ore"] ?: 0 }
+        // Verify we only have 1s and 2s
+        assertTrue(quantities.all { it in 1..2 })
+        // Check the pattern for the first 8 frames: 1, 1, 1, 2, 1, 1, 1, 2
+        assertEquals(listOf(1, 1, 1, 2, 1, 1, 1, 2), quantities.take(8))
+    }
+
+
+    @Test
     fun `gem drop chance of 1 always drops and 0 never drops regardless of seed`() {
         val always = GemData("Diamond", "", dropRate = 1.0, rarity = "rare")
         val never = GemData("Diamond", "", dropRate = 0.0, rarity = "rare")


### PR DESCRIPTION
This PR fixes the gathering tool multiplier rounding issue for Mining, Woodcutting, and Fishing (Issue #657).

### Root Cause

In `SkillSimulator.kt`, gathering item quantities were calculated per minute using:

```kotlin
val oreQty = max(1, toolEfficiency.roundToInt())
```

Because the speed multiplier was rounded to the nearest integer every single minute (frame) of the session:
1. Tool efficiencies like `1.25` (Bronze Pickaxe) rounded down to `1`, resulting in no yield increase (+0% instead of +25%).
2. Tool efficiencies like `1.5` (Iron Pickaxe) rounded up to `2`, doubling the yield (+100% instead of +50%).

### Solution

We replaced the per-minute rounding logic in `simulateMining`, `simulateWoodcutting`, and `simulateFishing` with a running fractional accumulator (`Double`):
* Every minute, the tool/rod efficiency is added to the accumulator.
* The integer part of the accumulator is harvested as the item quantity for that minute (capped to a minimum of 1).
* The remaining fraction is carried over to the next minute's calculation.

For example, with a **Bronze Pickaxe (1.25x efficiency)**, the yield pattern alternates as `1, 1, 1, 2, 1, 1, 1, 2...` over the session, producing exactly **75** items per 60 minutes (+25% increase) instead of **60** items. For an **Iron Pickaxe (1.5x efficiency)**, the pattern alternates as `1, 2, 1, 2...`, producing exactly **90** items (+50% increase) instead of **120** items.

We also updated `estimateGatheringQty` to correctly estimate total session yields using the clamped efficiency, and added unit tests in `SkillSimulatorPureTest` and `SkillSimulatorRngTest` to verify the new behaviors.

Fixes #657.
