### PR TITLE
fix(combat): arrow fallback to next tier when current type runs out

### DIFF
--- a/app/src/main/kotlin/com/fantasyidler/repository/QueuedSessionStarter.kt
+++ b/app/src/main/kotlin/com/fantasyidler/repository/QueuedSessionStarter.kt
@@ -421,7 +421,9 @@ class QueuedSessionStarter @Inject constructor(
                 val preferredArrow = bossArrowKey?.takeIf { (inventory[it] ?: 0) > 0 }
                 val bestArrow = preferredArrow ?: ARROW_TIERS.firstOrNull { (inventory[it] ?: 0) > 0 }
                 val arrowBonus = bestArrow?.let { ARROW_STRENGTH_BONUS[it] } ?: 0
-                val availableArrows = if (bestArrow != null) mapOf(bestArrow to (inventory[bestArrow] ?: 0)) else emptyMap()
+                val availableArrows = ARROW_TIERS
+                    .filter { (inventory[it] ?: 0) > 0 }
+                    .associateWith { inventory[it]!! }
                 val pmBoss = flags.skillPrestige
                 val bossFrames = CombatSimulator.simulateBoss(
                     boss               = boss,
@@ -504,7 +506,9 @@ class QueuedSessionStarter @Inject constructor(
                 val preferredArrow = combatArrowKey?.takeIf { (inventory[it] ?: 0) > 0 }
                 val bestArrow = preferredArrow ?: ARROW_TIERS.firstOrNull { (inventory[it] ?: 0) > 0 }
                 val arrowBonus = bestArrow?.let { ARROW_STRENGTH_BONUS[it] } ?: 0
-                val availableArrows = if (bestArrow != null) mapOf(bestArrow to (inventory[bestArrow] ?: 0)) else emptyMap()
+                val availableArrows = ARROW_TIERS
+                    .filter { (inventory[it] ?: 0) > 0 }
+                    .associateWith { inventory[it]!! }
                 val equippedFoodKeys  = flags.equippedFood.keys
                 val prevFoodConsumed  = pendingFoodConsumed()
                 val availableFood     = inventory.filterKeys { it in equippedFoodKeys }
@@ -571,7 +575,9 @@ class QueuedSessionStarter @Inject constructor(
                 val totalMagicDmgBonus = if (combatStyle == "magic") EquipSlot.ARMOR_SLOTS.sumOf { gameData.equipment[equipped[it]]?.magicDamageBonus ?: 0 } + (weapon?.magicDamageBonus ?: 0) else 0
                 val bestArrow       = ARROW_TIERS.firstOrNull { (inventory[it] ?: 0) > 0 }
                 val arrowBonus      = bestArrow?.let { ARROW_STRENGTH_BONUS[it] } ?: 0
-                val availableArrows = if (bestArrow != null) mapOf(bestArrow to (inventory[bestArrow] ?: 0)) else emptyMap()
+                val availableArrows = ARROW_TIERS
+                    .filter { (inventory[it] ?: 0) > 0 }
+                    .associateWith { inventory[it]!! }
                 val spell           = gameData.spells[flags.activeSpell]
                 val equippedFoodKeys = flags.equippedFood.keys
                 val prevFoodConsumed = pendingFoodConsumed()

--- a/app/src/main/kotlin/com/fantasyidler/repository/WorkerQueuedSessionStarter.kt
+++ b/app/src/main/kotlin/com/fantasyidler/repository/WorkerQueuedSessionStarter.kt
@@ -251,7 +251,9 @@ class WorkerQueuedSessionStarter @Inject constructor(
                 val preferredArrow = flags.equippedArrows?.takeIf { (inventory[it] ?: 0) > 0 }
                 val bestArrow = preferredArrow ?: ARROW_TIERS.firstOrNull { (inventory[it] ?: 0) > 0 }
                 val arrowBonus = bestArrow?.let { ARROW_STRENGTH_BONUS[it] } ?: 0
-                val availableArrows = if (bestArrow != null) mapOf(bestArrow to (inventory[bestArrow] ?: 0)) else emptyMap()
+                val availableArrows = ARROW_TIERS
+                    .filter { (inventory[it] ?: 0) > 0 }
+                    .associateWith { inventory[it]!! }
                 val bossFrames = CombatSimulator.simulateBoss(
                     boss               = boss,
                     bossKey            = bossKey,
@@ -300,7 +302,9 @@ class WorkerQueuedSessionStarter @Inject constructor(
                 val preferredArrow = flags.equippedArrows?.takeIf { (inventory[it] ?: 0) > 0 }
                 val bestArrow = preferredArrow ?: ARROW_TIERS.firstOrNull { (inventory[it] ?: 0) > 0 }
                 val arrowBonus = bestArrow?.let { ARROW_STRENGTH_BONUS[it] } ?: 0
-                val availableArrows = if (bestArrow != null) mapOf(bestArrow to (inventory[bestArrow] ?: 0)) else emptyMap()
+                val availableArrows = ARROW_TIERS
+                    .filter { (inventory[it] ?: 0) > 0 }
+                    .associateWith { inventory[it]!! }
                 val result = CombatSimulator.simulateDungeon(
                     dungeon             = dungeon,
                     enemies             = gameData.enemies,

--- a/app/src/main/kotlin/com/fantasyidler/simulator/CombatSimulator.kt
+++ b/app/src/main/kotlin/com/fantasyidler/simulator/CombatSimulator.kt
@@ -65,8 +65,14 @@ object CombatSimulator {
             .map { it.key }
         var totalFoodEaten = 0
 
-        val arrowKey   = availableArrows.keys.firstOrNull()
-        var arrowsLeft = if (arrowKey != null) availableArrows[arrowKey] ?: 0 else Int.MAX_VALUE
+        // Build an ordered deque of (arrowKey, remaining) so the simulator falls back
+        // to the next tier automatically when the current type is exhausted.
+        // An empty deque means no arrows were provided (non-ranged or empty inventory).
+        val arrowSupply: ArrayDeque<Pair<String, Int>> = if (availableArrows.isEmpty()) {
+            ArrayDeque()
+        } else {
+            ArrayDeque(availableArrows.entries.map { (k, v) -> k to v })
+        }
 
         var runningTotal = 0L
         var carryoverEnemyKey: String? = null
@@ -79,7 +85,7 @@ object CombatSimulator {
             val frameXpBySkill = mutableMapOf<String, Long>()
             var frameXp        = 0L
             val frameFood      = mutableMapOf<String, Int>()
-            var frameArrowsUsed = 0
+            val frameArrowsUsedByType = mutableMapOf<String, Int>()
             var frameRunesUsed  = 0
 
             val enemyKey = carryoverEnemyKey ?: spawnPool[rnd.nextInt(spawnPool.size)]
@@ -138,14 +144,25 @@ object CombatSimulator {
             val frameEnemyHits  = mutableListOf<Int>()
 
             repeat(TICKS_PER_FRAME) {
-                // Player attacks (ranged is capped by arrow supply)
+                // Player attacks — for ranged, consume arrows in tier order (best first);
+                // fall back to the next available type when the current stack runs out.
                 val pDmg = when {
-                    combatStyle == "ranged" && arrowsLeft > 0 -> {
-                        arrowsLeft--
-                        frameArrowsUsed++
-                        if (rnd.nextDouble() < playerHitChance) rnd.nextInt(0, playerMaxHit + 1) else 0
+                    combatStyle == "ranged" -> {
+                        // Advance past any exhausted arrow types.
+                        while (arrowSupply.isNotEmpty() && arrowSupply.first().second <= 0)
+                            arrowSupply.removeFirst()
+
+                        if (arrowSupply.isNotEmpty()) {
+                            val (currentArrowKey, currentQty) = arrowSupply.first()
+                            arrowSupply[0] = currentArrowKey to (currentQty - 1)
+                            frameArrowsUsedByType[currentArrowKey] =
+                                (frameArrowsUsedByType[currentArrowKey] ?: 0) + 1
+                            if (rnd.nextDouble() < playerHitChance) rnd.nextInt(0, playerMaxHit + 1) else 0
+                        } else {
+                            // Completely out of all arrow types — player cannot attack.
+                            0
+                        }
                     }
-                    combatStyle == "ranged" -> 0
                     combatStyle == "magic" -> {
                         if (runeKey != null) frameRunesUsed++
                         if (rnd.nextDouble() < playerHitChance) rnd.nextInt(0, playerMaxHit + 1) else 0
@@ -225,7 +242,7 @@ object CombatSimulator {
                     killsByEnemy = if (kills > 0) mapOf(enemyKey to kills) else emptyMap(),
                     died           = diedThisMinute,
                     foodConsumed   = frameFood,
-                    arrowsConsumed = if (arrowKey != null && frameArrowsUsed > 0) mapOf(arrowKey to frameArrowsUsed) else emptyMap(),
+                    arrowsConsumed = frameArrowsUsedByType,
                     runesConsumed  = if (runeKey != null && frameRunesUsed > 0) mapOf(runeKey to frameRunesUsed * runeCostPerAttack) else emptyMap(),
                     enemyKey       = enemyKey,
                     hpAfter      = currentHp.coerceAtLeast(0),
@@ -328,8 +345,12 @@ object CombatSimulator {
                               else boss.defensiveStats.attackDefense
             }
         }
-        val arrowKey   = availableArrows.keys.firstOrNull()
-        var arrowsLeft = if (arrowKey != null) availableArrows[arrowKey] ?: 0 else Int.MAX_VALUE
+        // Build an ordered deque of (arrowKey, remaining) for tier-by-tier fallback.
+        val arrowSupply: ArrayDeque<Pair<String, Int>> = if (availableArrows.isEmpty()) {
+            ArrayDeque()
+        } else {
+            ArrayDeque(availableArrows.entries.map { (k, v) -> k to v })
+        }
         val playerHitChance = when {
             effAtk > bossDefence -> 1.0 - bossDefence / (2.0 * effAtk.coerceAtLeast(1))
             else                 -> effAtk / (2.0 * bossDefence.coerceAtLeast(1))
@@ -364,17 +385,25 @@ object CombatSimulator {
             val pHits          = mutableListOf<Int>()
             val eHits          = mutableListOf<Int>()
             val frameFood      = mutableMapOf<String, Int>()
-            var frameArrowsUsed = 0
+            val frameArrowsUsedByType = mutableMapOf<String, Int>()
             var frameRunesUsed  = 0
 
             for (tick in 0 until TICKS_PER_FRAME) {
                 val pDmg = when {
-                    combatStyle == "ranged" && arrowsLeft > 0 -> {
-                        arrowsLeft--
-                        frameArrowsUsed++
-                        if (rnd.nextDouble() < playerHitChance) rnd.nextInt(0, playerMax + 1) else 0
+                    combatStyle == "ranged" -> {
+                        while (arrowSupply.isNotEmpty() && arrowSupply.first().second <= 0)
+                            arrowSupply.removeFirst()
+
+                        if (arrowSupply.isNotEmpty()) {
+                            val (currentArrowKey, currentQty) = arrowSupply.first()
+                            arrowSupply[0] = currentArrowKey to (currentQty - 1)
+                            frameArrowsUsedByType[currentArrowKey] =
+                                (frameArrowsUsedByType[currentArrowKey] ?: 0) + 1
+                            if (rnd.nextDouble() < playerHitChance) rnd.nextInt(0, playerMax + 1) else 0
+                        } else {
+                            0
+                        }
                     }
-                    combatStyle == "ranged" -> 0
                     combatStyle == "magic" -> {
                         if (runeKey != null) frameRunesUsed++
                         if (rnd.nextDouble() < playerHitChance) rnd.nextInt(0, playerMax + 1) else 0
@@ -392,7 +421,7 @@ object CombatSimulator {
                         kills = 1, enemyKey = bossKey,
                         playerHits = pHits, enemyHits = eHits, hpAfter = currentHp,
                         foodConsumed  = frameFood,
-                        arrowsConsumed = if (arrowKey != null && frameArrowsUsed > 0) mapOf(arrowKey to frameArrowsUsed) else emptyMap(),
+                        arrowsConsumed = frameArrowsUsedByType,
                         runesConsumed  = if (runeKey != null && frameRunesUsed > 0) mapOf(runeKey to frameRunesUsed * runeCostPerAttack) else emptyMap(),
                     ))
                     break@outer
@@ -428,7 +457,7 @@ object CombatSimulator {
                         kills = 0, enemyKey = bossKey,
                         playerHits = pHits, enemyHits = eHits, hpAfter = 0,
                         foodConsumed  = frameFood,
-                        arrowsConsumed = if (arrowKey != null && frameArrowsUsed > 0) mapOf(arrowKey to frameArrowsUsed) else emptyMap(),
+                        arrowsConsumed = frameArrowsUsedByType,
                         runesConsumed  = if (runeKey != null && frameRunesUsed > 0) mapOf(runeKey to frameRunesUsed * runeCostPerAttack) else emptyMap(),
                     ))
                     break@outer
@@ -442,7 +471,7 @@ object CombatSimulator {
                     kills = 0, enemyKey = bossKey,
                     playerHits = pHits, enemyHits = eHits, hpAfter = currentHp,
                     foodConsumed  = frameFood,
-                    arrowsConsumed = if (arrowKey != null && frameArrowsUsed > 0) mapOf(arrowKey to frameArrowsUsed) else emptyMap(),
+                    arrowsConsumed = frameArrowsUsedByType,
                     runesConsumed  = if (runeKey != null && frameRunesUsed > 0) mapOf(runeKey to frameRunesUsed * runeCostPerAttack) else emptyMap(),
                 ))
             }

--- a/app/src/main/kotlin/com/fantasyidler/ui/viewmodel/CombatViewModel.kt
+++ b/app/src/main/kotlin/com/fantasyidler/ui/viewmodel/CombatViewModel.kt
@@ -445,8 +445,11 @@ class CombatViewModel @Inject constructor(
                 val availableFood      = inventory.filterKeys { it in equippedFoodKeys }
                 val foodHealValues     = gameData.foodHealValues
 
-                // Arrows: pass current supply to simulator; consumed at collect time from frames
-                val availableArrows = if (bestArrow != null) mapOf(bestArrow to (inventory[bestArrow] ?: 0)) else emptyMap()
+                // Arrows: pass all available tiers (best-first) so the simulator can fall
+                // back automatically when a higher-tier type runs out.
+                val availableArrows = ARROW_TIERS
+                    .filter { (inventory[it] ?: 0) > 0 }
+                    .associateWith { inventory[it]!! }
 
                 // Runes: determine key and cost for simulator tracking; consumed upfront below
                 val staffCoversRune = combatStyle == "magic" && selectedSpell != null && (weapon?.infiniteRunes == "all" || weapon?.infiniteRunes == selectedSpell.runeType)
@@ -614,7 +617,9 @@ class CombatViewModel @Inject constructor(
                 val preferredArrow = _extra.value.selectedArrowKey?.takeIf { (inventory[it] ?: 0) > 0 }
                 val bestArrow = preferredArrow ?: ARROW_TIERS.firstOrNull { (inventory[it] ?: 0) > 0 }
                 val arrowStrengthBonus = bestArrow?.let { ARROW_STRENGTH_BONUS[it] } ?: 0
-                val availableArrows = if (bestArrow != null) mapOf(bestArrow to (inventory[bestArrow] ?: 0)) else emptyMap()
+                val availableArrows = ARROW_TIERS
+                    .filter { (inventory[it] ?: 0) > 0 }
+                    .associateWith { inventory[it]!! }
 
                 val bossStaffCoversRune = combatStyle == "magic" && selectedSpell != null && (bossWeapon?.infiniteRunes == "all" || bossWeapon?.infiniteRunes == selectedSpell.runeType)
                 val bossRuneKey  = if (combatStyle == "magic" && selectedSpell != null && !bossStaffCoversRune) selectedSpell.runeType else null
@@ -1055,7 +1060,9 @@ class CombatViewModel @Inject constructor(
 
         val bestArrow      = ARROW_TIERS.firstOrNull { (inventory[it] ?: 0) > 0 }
         val arrowStrBonus  = bestArrow?.let { ARROW_STRENGTH_BONUS[it] } ?: 0
-        val availableArrows = if (bestArrow != null) mapOf(bestArrow to (inventory[bestArrow] ?: 0)) else emptyMap()
+        val availableArrows = ARROW_TIERS
+            .filter { (inventory[it] ?: 0) > 0 }
+            .associateWith { inventory[it]!! }
 
         val activeSpell = flags.activeSpell?.let { gameData.spells[it] }
         val spellMaxHit = if (combatStyle == "magic") activeSpell?.maxHit ?: 0 else 0

--- a/app/src/main/kotlin/com/fantasyidler/ui/viewmodel/TowerViewModel.kt
+++ b/app/src/main/kotlin/com/fantasyidler/ui/viewmodel/TowerViewModel.kt
@@ -238,7 +238,10 @@ class TowerViewModel @Inject constructor(
                 val enemies    = scaledEnemies()
                 val foodHeal   = gameData.foodHealValues
                 val availableFood   = inventory.filterKeys { it in flags.equippedFood.keys }
-                val availableArrows = if (bestArrow != null) mapOf(bestArrow to (inventory[bestArrow] ?: 0)) else emptyMap()
+                val availableArrows = ARROW_TIERS
+                    .filter { (inventory[it] ?: 0) > 0 }
+                    .associateWith { inventory[it]!! }
+
 
                 val staffCoversRune = combatStyle == "magic" && selectedSpell != null &&
                     (weapon?.infiniteRunes == "all" || weapon?.infiniteRunes == selectedSpell.runeType)


### PR DESCRIPTION
Fixes two reported bugs and one unreported bug in ranged combat:

Bug 1 (reported): When the selected arrow type was exhausted, all subsequent hits in the session were recorded as 0 damage ("misses") instead of falling back to the next available tier.

Bug 2 (reported): The number of projectiles was effectively capped at the quantity of the single best arrow type. Lower-tier arrows in the inventory were never used.

Bug 3 (unreported): arrowsConsumed in each SessionFrame always attributed all arrows to the initial best-tier key, even when multiple types were consumed. This caused incorrect reclaim calculations at collect time.

Fix in CombatSimulator (simulateDungeon + simulateBoss):
- Replace single arrowKey/arrowsLeft tracking with an ArrayDeque of (key, remaining) pairs ordered best-to-worst.
- Each tick, prune exhausted entries from the front of the deque and draw from the current head, automatically falling back to the next tier when a stack runs out.
- frameArrowsUsedByType (MutableMap) now accurately tracks per-type consumption within each frame.

Fix in all call sites (CombatViewModel, QueuedSessionStarter, WorkerQueuedSessionStarter, TowerViewModel):
- availableArrows now passes all arrow tiers present in inventory (best-first) instead of a single-entry map of just the best type.
- arrowStrengthBonus for the max-hit formula is still derived from the best available arrow (correct, unchanged behaviour).