### PR TITLE
feat(carnival): Add shell game swapping animations and logic

### DIFF
--- a/app/src/main/kotlin/com/fantasyidler/ui/screen/CarnivalScreen.kt
+++ b/app/src/main/kotlin/com/fantasyidler/ui/screen/CarnivalScreen.kt
@@ -1,5 +1,9 @@
 package com.fantasyidler.ui.screen
 
+import androidx.compose.animation.core.FastOutSlowInEasing
+import androidx.compose.animation.core.animateDpAsState
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Arrangement
@@ -753,6 +757,49 @@ private fun ShellGameCard(gameState: ActiveGameState, difficulty: Difficulty, vi
                                         text  = if (i == gemPos) "💎" else "🥤",
                                         style = MaterialTheme.typography.bodyLarge,
                                     )
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+            is ActiveGameState.ShellGameSwapping -> {
+                val cupCount = gameState.cupCount
+                val delayMs = if (difficulty == Difficulty.HARD) 350L else 600L
+
+                LaunchedEffect(gameState.swaps.size) {
+                    delay(delayMs)
+                    viewModel.executeNextShellSwap()
+                }
+
+                Column(
+                    modifier            = Modifier.fillMaxWidth(),
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                    verticalArrangement = Arrangement.spacedBy(8.dp),
+                ) {
+                    Text(
+                        text  = stringResource(R.string.carnival_active_shell_desc),
+                        style = MaterialTheme.typography.bodyMedium,
+                        fontWeight = FontWeight.SemiBold,
+                    )
+                    Box(modifier = Modifier.width((cupCount * 56 + (cupCount - 1) * 8).dp).height(56.dp)) {
+                        (0 until cupCount).forEach { c ->
+                            val visualIndex = gameState.positions.indexOf(c)
+                            val targetOffsetX = (visualIndex * 64).dp
+                            val animatedOffsetX by animateDpAsState(
+                                targetValue = targetOffsetX,
+                                animationSpec = tween(durationMillis = (delayMs * 0.8).toInt(), easing = FastOutSlowInEasing),
+                                label = "cupOffset"
+                            )
+                            Surface(
+                                shape  = RoundedCornerShape(8.dp),
+                                color  = MaterialTheme.colorScheme.surface,
+                                modifier = Modifier
+                                    .offset(x = animatedOffsetX)
+                                    .size(56.dp)
+                            ) {
+                                Box(contentAlignment = Alignment.Center) {
+                                    Text(text = "🥤", style = MaterialTheme.typography.bodyLarge)
                                 }
                             }
                         }

--- a/app/src/main/kotlin/com/fantasyidler/ui/viewmodel/CarnivalViewModel.kt
+++ b/app/src/main/kotlin/com/fantasyidler/ui/viewmodel/CarnivalViewModel.kt
@@ -38,6 +38,7 @@ sealed class ActiveGameState {
     data class AppraisalPlaying(val quadIndex: Int) : ActiveGameState()
     data class OnCooldown(val resumesAtMs: Long) : ActiveGameState()
     data class ShellGameShowing(val cupCount: Int, val gemPos: Int) : ActiveGameState()
+    data class ShellGameSwapping(val cupCount: Int, val gemPos: Int, val positions: List<Int>, val swaps: List<Pair<Int, Int>>) : ActiveGameState()
     data class ShellGamePicking(val cupCount: Int, val gemPos: Int) : ActiveGameState()
     data class HigherOrLowerPlaying(val numbers: List<Int>, val currentIdx: Int, val correctCount: Int) : ActiveGameState()
 }
@@ -435,14 +436,38 @@ class CarnivalViewModel @Inject constructor(
         val s = _extra.value.shellGameState
         if (s !is ActiveGameState.ShellGameShowing) return
         val positions = (0 until s.cupCount).toMutableList()
-        val swaps = s.cupCount * 3 + Random.nextInt(s.cupCount + 1)
-        repeat(swaps) {
-            val i = Random.nextInt(positions.size)
-            val j = Random.nextInt(positions.size)
-            val tmp = positions[i]; positions[i] = positions[j]; positions[j] = tmp
+        val diff = _extra.value.shellGameDifficulty
+        val numSwaps = if (diff == Difficulty.HARD) 7 + Random.nextInt(4) else 4 + Random.nextInt(3)
+        
+        val swaps = mutableListOf<Pair<Int, Int>>()
+        var lastI = -1
+        var lastJ = -1
+        repeat(numSwaps) {
+            var i = Random.nextInt(positions.size)
+            var j = Random.nextInt(positions.size)
+            while (i == j || (i == lastI && j == lastJ) || (i == lastJ && j == lastI)) {
+                i = Random.nextInt(positions.size)
+                j = Random.nextInt(positions.size)
+            }
+            lastI = i
+            lastJ = j
+            swaps.add(i to j)
         }
-        val newGemPos = positions.indexOf(s.gemPos)
-        _extra.update { it.copy(shellGameState = ActiveGameState.ShellGamePicking(s.cupCount, newGemPos)) }
+        _extra.update { it.copy(shellGameState = ActiveGameState.ShellGameSwapping(s.cupCount, s.gemPos, positions, swaps)) }
+    }
+
+    fun executeNextShellSwap() {
+        val s = _extra.value.shellGameState
+        if (s !is ActiveGameState.ShellGameSwapping) return
+        if (s.swaps.isEmpty()) {
+            val newGemPos = s.positions.indexOf(s.gemPos)
+            _extra.update { it.copy(shellGameState = ActiveGameState.ShellGamePicking(s.cupCount, newGemPos)) }
+            return
+        }
+        val (i, j) = s.swaps.first()
+        val newPositions = s.positions.toMutableList()
+        val tmp = newPositions[i]; newPositions[i] = newPositions[j]; newPositions[j] = tmp
+        _extra.update { it.copy(shellGameState = ActiveGameState.ShellGameSwapping(s.cupCount, s.gemPos, newPositions, s.swaps.drop(1))) }
     }
 
     fun submitShellGuess(pickedPos: Int) {


### PR DESCRIPTION
This PR addresses the community discussion and implements the feature requested in #718 .

### The Problem
As discussed in the community, the Pick-a-Cup game in the Carnival was previously purely luck-based. After the initial gem reveal, the game instantly randomized the final position without showing any of the cup movements. Because players couldn't actually track the gem, winning felt entirely dependent on a lucky guess.

### What Changed
I've completely overhauled the underlying mechanics to turn this into a true skill-based tracking game! 

* **New `ShellGameSwapping` State:** Added a new intermediate state to `CarnivalViewModel.kt` that generates a discrete queue of swap pairs (e.g., Cup 0 swaps with Cup 2).
* **Smooth UI Animations:** Updated `CarnivalScreen.kt` to visually animate the cups trading places using Jetpack Compose (`animateDpAsState`). The UI now gracefully reads the logical positions of the cups and slides them horizontally step-by-step.
* **Difficulty Scaling:** Tied the visual tracking difficulty directly to the player's selected difficulty:
  * **Normal:** The cups perform 4 to 6 swaps with a slightly slower transition time, making it easier to track.
  * **Hard:** The cups perform 7 to 10 swaps much faster, providing a genuine challenge for the player's reflexes and focus!

### Effect
Players will now experience a highly polished, interactive shell game. Instead of just tapping a random cup, they now have to actively focus on the screen and track the gem through a sequence of smooth visual swaps. We kept the ticket payouts the same, so it's a great, rewarding skill-check for players who are paying attention!