### PR TITLE
Add missing buildings to the buildings pages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ out
 .venv
 keystore.p12
 scripts/release_apk.sh
+*.md.backup

--- a/wiki/src/pages.py
+++ b/wiki/src/pages.py
@@ -1295,11 +1295,22 @@ def gen_buildings() -> str:
         (55,   500_000, {"willow_plank": 500, "stone_block": 600, "steel_nail": 1500},     "Blessing 36h"),
         (80, 2_000_000, {"yew_plank": 800, "stone_block": 1000, "mithril_nail": 3000},     "Blessing 48h"),
     ]
+    fairgrounds_tiers = [
+        (35,   150_000, {"oak_plank": 250, "willow_plank": 100, "steel_nail": 600},         "Pick-a-Cup, 7.5 min cooldown, +5% idle tickets"),
+        (55,   600_000, {"willow_plank": 600, "maple_plank": 200, "steel_nail": 1500},      "Higher or Lower, +10% idle tickets"),
+        (75, 1_500_000, {"maple_plank": 800, "yew_plank": 400, "mithril_nail": 2500},       "5 min cooldown, +15% idle tickets"),
+    ]
+    garden_tiers = [
+        (30,    80_000, {"plank": 100, "oak_plank": 200, "iron_nail": 400},                  "+1 extra farm plot"),
+        (55,   400_000, {"oak_plank": 400, "willow_plank": 200, "steel_nail": 1000},         "+2 extra farm plots"),
+    ]
 
     return get_template("town/buildings").format(
         inn_table=building_table(inn_tiers, "Bonus", []),
         guild_hall_table=building_table(guild_hall_tiers, "Bonus", []),
         church_table=building_table(church_tiers, "Bonus", []),
+        fairgrounds_table=building_table(fairgrounds_tiers, "Bonus", []),
+        garden_table=building_table(garden_tiers, "Bonus", []),
     )
 
 

--- a/wiki/templates/town/buildings.md
+++ b/wiki/templates/town/buildings.md
@@ -1,8 +1,8 @@
 # Buildings
 
-The **Building Master** in the Town screen lets you upgrade three permanent town buildings. Each building provides a passive bonus that scales with its tier. Upgrades require coins and Construction materials crafted at the [Construction](Construction) skill.
+The **Building Master** in the Town screen lets you upgrade five permanent town buildings. Each building provides a passive bonus that scales with its tier. Upgrades require coins and Construction materials crafted at the [Construction](Construction) skill.
 
-Buildings start at Tier 0 (no bonus) and can be upgraded to Tier 3. Higher tiers require a higher Construction level.
+Buildings start at Tier 0 (no bonus) and can be upgraded to Tier 2 or 3. Higher tiers require a higher Construction level.
 
 ---
 
@@ -27,3 +27,19 @@ Reduces the quantity required for all guild quest targets.
 Extends the duration of the Prayer blessing activated from the [Prayer](Prayer) skill.
 
 {church_table}
+
+---
+
+## Fairgrounds
+
+Unlocks additional Carnival minigames, reduces minigame cooldowns, and increases idle ticket drop chance.
+
+{fairgrounds_table}
+
+---
+
+## Garden
+
+Grants extra [Farming](Farming) plots for growing crops.
+
+{garden_table}


### PR DESCRIPTION
Simple fix to add missing buildings to the buildings pages described in #763