### PR TITLE
Fix: Apply agility prestige to Crafting session durations (#784)

### DIFF
--- a/app/src/main/kotlin/com/fantasyidler/ui/viewmodel/CraftingViewModel.kt
+++ b/app/src/main/kotlin/com/fantasyidler/ui/viewmodel/CraftingViewModel.kt
@@ -344,10 +344,10 @@ class CraftingViewModel @Inject constructor(
         viewModelScope.launch {
             // Enqueue if a session is already running
             if (sessionRepo.getActiveSession() != null) {
-                val agility   = state.skillLevels[Skills.AGILITY] ?: 1
-                val perItemMs = SkillSimulator.sessionDurationMs(agility) / 60
-                val totalOutput = qty * recipe.outputQty
                 val craftFlags = playerRepo.getFlags()
+                val agility   = state.skillLevels[Skills.AGILITY] ?: 1
+                val perItemMs = SkillSimulator.sessionDurationMs(agility, craftFlags.skillPrestige[Skills.AGILITY] ?: 0) / 60
+                val totalOutput = qty * recipe.outputQty
                 val xpQueueMult = (if (craftFlags.xpBoostExpiresAt > System.currentTimeMillis()) 2.0 else 1.0) * ChurchRepository.xpMultiplier(craftFlags)
                 val action = QueuedAction(
                     skillName           = recipe.skillName,
@@ -401,9 +401,10 @@ class CraftingViewModel @Inject constructor(
             )
 
             val levels: Map<String, Int> = json.decodeFromString(player.skillLevels)
+            val flags = try { json.decodeFromString<PlayerFlags>(player.flags) } catch (_: Exception) { PlayerFlags() }
             val agilityLevel = levels[Skills.AGILITY] ?: 1
             // 1 item per minute, reduced by agility (same formula as gathering skills)
-            val perItemMs = SkillSimulator.sessionDurationMs(agilityLevel) / 60
+            val perItemMs = SkillSimulator.sessionDurationMs(agilityLevel, flags.skillPrestige[Skills.AGILITY] ?: 0) / 60
 
             val framesJson = json.encodeToString(
                 json.serializersModule.serializer<List<SessionFrame>>(),


### PR DESCRIPTION
## Description
This PR addresses the remaining portion of **Issue #784 ** by correctly applying the Agility Prestige time reduction factor to Crafting sessions.

While the upstream commit for `v1.10.9` resolved the issue for most session types (combat dungeons, boss fights, Infinite Tower, expeditions, Slayer tasks, Carnival games, and Mercantile routes), the agility prestige parameter was still missing from the `CraftingViewModel`. 

This change ensures that `agilityPrestige` from `PlayerFlags` is successfully parsed and fed into `SkillSimulator.sessionDurationMs` when initiating crafting sessions. Crafting will now properly benefit from the reduced session time (down to 30 minutes at Prestige 3).

## Related Issues
- Completes the fix for #784 

## Testing Instructions
1. Ensure your character has Agility level 99 and Prestige 3.
2. Start any crafting session from the UI.
3. Verify that the crafting session duration correctly drops from 40 minutes down to 30 minutes.
