### PR TITLE
Fix: Remove non-existent Spectral Knight from slayer tasks (#799)

### DIFF
--- a/app/src/main/assets/data/slayer_tasks.json
+++ b/app/src/main/assets/data/slayer_tasks.json
@@ -131,12 +131,6 @@
     "slayer_level": 92,
     "xp_per_kill": 300
   },
-  "spectral_knight": {
-    "min_kills": 5,
-    "max_kills": 12,
-    "slayer_level": 95,
-    "xp_per_kill": 350
-  },
   "elder_lich": {
     "min_kills": 3,
     "max_kills": 8,


### PR DESCRIPTION
Fixed the issue with non-existent Spectral Knight from slayer tasks (#799)

Files changed:
-> slayer_tasks.json