### PR TITLE
Fix: Properly check pet ownership to prevent rebuying Carnival pets (#809)

### DIFF
--- a/app/src/main/kotlin/com/fantasyidler/ui/viewmodel/CarnivalViewModel.kt
+++ b/app/src/main/kotlin/com/fantasyidler/ui/viewmodel/CarnivalViewModel.kt
@@ -150,9 +150,11 @@ class CarnivalViewModel @Inject constructor(
             val inventory: Map<String, Int> = json.decodeFromString(player.inventory)
             val flags: PlayerFlags = json.decodeFromString(player.flags)
             val levels: Map<String, Int> = json.decodeFromString(player.skillLevels)
+            val pets: List<com.fantasyidler.data.model.OwnedPet> = try { json.decodeFromString(player.pets) } catch (_: Exception) { emptyList() }
+            val ownedPetIds = pets.map { it.id }.toSet()
             val ownedPrizeKeys = prizes
                 .filter { it.type == "equipment" || it.type == "pet" }
-                .filter { (inventory[it.key] ?: 0) > 0 }
+                .filter { (inventory[it.key] ?: 0) > 0 || it.key in ownedPetIds }
                 .map { it.key }
                 .toSet()
             val now = System.currentTimeMillis()


### PR DESCRIPTION
Fixes #809.
In the Carnival prize shop, players were able to repeatedly buy the "Juggling Imp" (wasting 4,000 tickets each time) because the UI was only checking the player's `inventory` for ownership. Pet prizes are stored in a separate `pets` list rather than the inventory.
**Fix:** Updated `CarnivalViewModel.kt` to also decode the player's `pets` list and check if the prize's ID exists in either the `inventory` or the `pets` list before marking it as available to redeem.