### PR TITLE
Fix herblore cape misclassification and add missing capes

### DIFF
--- a/app/src/main/assets/data/equipment.json
+++ b/app/src/main/assets/data/equipment.json
@@ -2517,6 +2517,58 @@
     "requirements": {},
     "cape_bonus": 0.1
   },
+  "herblore_cape": {
+    "name": "herblore_cape",
+    "display_name": "Herblore Cape",
+    "slot": "cape",
+    "combat_style": null,
+    "description": "Awarded for reaching level 99 Herblore. Grants 10% more potions per session.",
+    "attack_bonus": 0,
+    "strength_bonus": 0,
+    "defense_bonus": 5,
+    "cape_skill": "herblore",
+    "requirements": {},
+    "cape_bonus": 0.1
+  },
+  "thieving_cape": {
+    "name": "thieving_cape",
+    "display_name": "Thieving Cape",
+    "slot": "cape",
+    "combat_style": null,
+    "description": "Awarded for reaching level 99 Thieving. Grants 10% more successful pickpockets per session.",
+    "attack_bonus": 0,
+    "strength_bonus": 0,
+    "defense_bonus": 5,
+    "cape_skill": "thieving",
+    "requirements": {},
+    "cape_bonus": 0.1
+  },
+  "construction_cape": {
+    "name": "construction_cape",
+    "display_name": "Construction Cape",
+    "slot": "cape",
+    "combat_style": null,
+    "description": "Awarded for reaching level 99 Construction. Grants 10% more items per session.",
+    "attack_bonus": 0,
+    "strength_bonus": 0,
+    "defense_bonus": 5,
+    "cape_skill": "construction",
+    "requirements": {},
+    "cape_bonus": 0.1
+  },
+  "slayer_cape": {
+    "name": "slayer_cape",
+    "display_name": "Slayer Cape",
+    "slot": "cape",
+    "combat_style": null,
+    "description": "Awarded for reaching level 99 Slayer. Grants 10% more Slayer points.",
+    "attack_bonus": 0,
+    "strength_bonus": 0,
+    "defense_bonus": 5,
+    "cape_skill": "slayer",
+    "requirements": {},
+    "cape_bonus": 0.1
+  },
   "bronze_boots": {
     "name": "bronze_boots",
     "display_name": "Bronze Boots",

--- a/app/src/main/kotlin/com/fantasyidler/ui/viewmodel/ShopViewModel.kt
+++ b/app/src/main/kotlin/com/fantasyidler/ui/viewmodel/ShopViewModel.kt
@@ -521,9 +521,9 @@ class ShopViewModel @Inject constructor(
         }
         if (itemKey in gameData.foodHealValues) return "Food"
         return when {
-            "ore"     in itemKey || "bar"     in itemKey ||
-            "gem"     in itemKey || "log"     in itemKey ||
-            "bone"    in itemKey || "essence" in itemKey ||
+            itemKey.endsWith("_ore") || itemKey == "ore" || itemKey.endsWith("_bar") || itemKey == "bar" ||
+            itemKey.endsWith("_gem") || itemKey == "gem" || itemKey.endsWith("_log") || itemKey == "log" ||
+            itemKey.endsWith("_bone") || itemKey == "bone" || "essence" in itemKey ||
             "arrow"   in itemKey ||
             "raw_"    in itemKey || "cooked"  in itemKey -> "Materials"
             else                              -> "Misc"


### PR DESCRIPTION
* **What was going wrong:** The shop categorization logic (`sellCategoryFor` in `ShopViewModel.kt`) checked for `"ore" in itemKey` to classify items under "Materials." This broadly matched `"herblore_cape"` and `"herblore_guild_cape"`, which contain the letters "ore." Additionally, a few level 99 skill capes (`herblore_cape`, `thieving_cape`, `construction_cape`, and `slayer_cape`) were entirely missing from the `equipment.json` file. Because they were missing, the game couldn't recognize them as equipment (which normally forces them into the "Armor" category), causing them to fall back to the faulty substring match and get classified as "Materials".

* **How it was fixed:** 
  1. Updated the substring matching logic in `ShopViewModel.kt` to only check for exact trailing suffixes like `itemKey.endsWith("_ore") || itemKey == "ore"`, preventing accidental matches for completely unrelated items containing those sequences.
  2. Added the missing 99 skill capes (`herblore_cape`, `thieving_cape`, `construction_cape`, `slayer_cape`) to `equipment.json` with the appropriate 10% bonuses, ensuring they are correctly treated as equippable gear and grouped into the "Armor" section of the shop.