### PR TITLE
Fix: Add contribute button to regular farming quests and fix dailies

### DIFF
--- a/app/src/main/kotlin/com/fantasyidler/repository/GuildRepository.kt
+++ b/app/src/main/kotlin/com/fantasyidler/repository/GuildRepository.kt
@@ -201,10 +201,34 @@ class GuildRepository @Inject constructor(
         val available = inventory[t.target] ?: 0
         if (available == 0) return 0
         val toConsume = minOf(needed, available)
-        playerRepo.consumeItemsUnlocked(mapOf(t.target to toConsume))
+        if (!playerRepo.consumeItemsUnlocked(mapOf(t.target to toConsume))) return 0
         val newProgress = flags.guildDailyProgress.toMutableMap()
         newProgress[templateId] = current + toConsume
         playerRepo.updateFlagsUnlocked(flags.copy(guildDailyProgress = newProgress))
+        return toConsume
+    }
+
+    /**
+     * Lets the player submit crops from their inventory toward a regular farming gather quest.
+     * Returns the number of items actually consumed.
+     */
+    suspend fun contributeFarmingQuest(questId: String, inventory: Map<String, Int>): Int = playerRepo.playerMutex.withLock {
+        val quest = gameData.guildQuests[questId] ?: return 0
+        if (quest.guild != "farming" || quest.type != "gather") return 0
+        val row = questProgressDao.getQuestProgress(questId) ?: QuestProgress(questId)
+        if (row.completed) return 0
+        
+        val effectiveAmt = effectiveQuestAmount(quest)
+        val needed = (effectiveAmt - row.progress).coerceAtLeast(0)
+        if (needed == 0) return 0
+        
+        val available = inventory[quest.target] ?: 0
+        if (available == 0) return 0
+        
+        val toConsume = minOf(needed, available)
+        if (!playerRepo.consumeItemsUnlocked(mapOf(quest.target to toConsume))) return 0
+        
+        questProgressDao.upsert(row.copy(progress = row.progress + toConsume))
         return toConsume
     }
 

--- a/app/src/main/kotlin/com/fantasyidler/ui/screen/GuildDetailScreen.kt
+++ b/app/src/main/kotlin/com/fantasyidler/ui/screen/GuildDetailScreen.kt
@@ -185,8 +185,10 @@ fun GuildDetailScreen(
                     0 -> GuildQuestsTab(
                         quests        = state.quests,
                         guildLevel    = state.guildLevel,
+                        inventory     = state.inventory,
                         hideCompleted = state.hideCompleted,
                         onClaim       = { viewModel.claimGuildQuest(it) },
+                        onContribute  = { viewModel.contributeFarmingQuest(it) },
                     )
                     else -> GuildDailiesTab(
                         dailies       = state.dailies,
@@ -262,8 +264,10 @@ private fun GuildRepHeader(
 private fun GuildQuestsTab(
     quests: List<GuildQuestWithProgress>,
     guildLevel: Int,
+    inventory: Map<String, Int>,
     hideCompleted: Boolean = false,
     onClaim: (String) -> Unit,
+    onContribute: (String) -> Unit,
 ) {
     val visibleQuests = if (hideCompleted) quests.filter { !it.completed } else quests
     LazyColumn(Modifier.fillMaxSize()) {
@@ -283,9 +287,12 @@ private fun GuildQuestsTab(
         } else {
             items(visibleQuests, key = { it.quest.id }) { qwp ->
                 GuildQuestRow(
-                    qwp        = qwp,
-                    guildLevel = guildLevel,
-                    onClaim    = { onClaim(qwp.quest.id) },
+                    qwp          = qwp,
+                    guildLevel   = guildLevel,
+                    inventoryQty = if (qwp.quest.guild == "farming" && qwp.quest.type == "gather")
+                        inventory[qwp.quest.target] ?: 0 else 0,
+                    onClaim      = { onClaim(qwp.quest.id) },
+                    onContribute = { onContribute(qwp.quest.id) },
                 )
                 HorizontalDivider(modifier = Modifier.padding(horizontal = 16.dp))
             }
@@ -298,7 +305,9 @@ private fun GuildQuestsTab(
 private fun GuildQuestRow(
     qwp: GuildQuestWithProgress,
     guildLevel: Int,
+    inventoryQty: Int = 0,
     onClaim: () -> Unit,
+    onContribute: () -> Unit = {},
 ) {
     val locked   = guildLevel < qwp.quest.guildLevelRequired
     val dimColor = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.38f)
@@ -376,6 +385,11 @@ private fun GuildQuestRow(
                 Spacer(Modifier.height(8.dp))
                 Button(onClick = onClaim, modifier = Modifier.fillMaxWidth()) {
                     Text(stringResource(R.string.label_claim_reward))
+                }
+            } else if (inventoryQty > 0) {
+                Spacer(Modifier.height(8.dp))
+                OutlinedButton(onClick = onContribute, modifier = Modifier.fillMaxWidth()) {
+                    Text(stringResource(R.string.guild_contribute_inventory, inventoryQty))
                 }
             }
         }

--- a/app/src/main/kotlin/com/fantasyidler/ui/viewmodel/GuildDetailViewModel.kt
+++ b/app/src/main/kotlin/com/fantasyidler/ui/viewmodel/GuildDetailViewModel.kt
@@ -173,6 +173,16 @@ class GuildDetailViewModel @Inject constructor(
         }
     }
 
+    fun contributeFarmingQuest(questId: String) {
+        viewModelScope.launch {
+            val inventory: Map<String, Int> = json.decodeFromString(playerRepo.getOrCreatePlayer().inventory)
+            val consumed = guildRepo.contributeFarmingQuest(questId, inventory)
+            if (consumed > 0) {
+                _extra.update { it.copy(snackbarMessage = context.getString(R.string.guild_contributed_items, consumed)) }
+            }
+        }
+    }
+
     fun snackbarConsumed() = _extra.update { it.copy(snackbarMessage = null) }
 
     fun toggleHideCompleted() {


### PR DESCRIPTION
### What changed
- **Regular Quest Donations:** Added the `contributeFarmingQuest` method to `GuildRepository` and wired it through the `GuildDetailViewModel`. The regular farming quests UI in `GuildDetailScreen` now features the "Contribute from inventory" button, bringing it to feature parity with the daily quests tab.
- **Daily Donations Bug Fix:** Investigated the daily donate button bug where the UI wouldn't properly update or consume items. Hardened the `contributeFarmingDaily` backend logic by adding an explicit failure check during the inventory update transaction. Previously, if `consumeItemsUnlocked` failed to deduct the items due to an inventory state mismatch or data race, it silently failed but falsely advanced the quest progress. The fix ensures progress only advances if the inventory is successfully decremented, ensuring data consistency and reactive UI updates.