### PR TITLE
fix(shop): exclude skill capes from Sell Old Gear

### DIFF
--- a/app/src/main/kotlin/com/fantasyidler/ui/viewmodel/ShopViewModel.kt
+++ b/app/src/main/kotlin/com/fantasyidler/ui/viewmodel/ShopViewModel.kt
@@ -347,42 +347,7 @@ class ShopViewModel @Inject constructor(
             val inventory = state.inventory
             val allEquip  = gameData.equipment
 
-            val toolSlots = setOf(EquipSlot.PICKAXE, EquipSlot.AXE, EquipSlot.FISHING_ROD, EquipSlot.HOE)
-            val toSell = mutableMapOf<String, Int>()
-            for (slot in EquipSlot.ALL) {
-                val equippedKey  = equipped[slot] ?: continue
-                val equippedItem = allEquip[equippedKey] ?: continue
-
-                val allKeysInSlot = buildList {
-                    add(equippedKey)
-                    inventory.keys
-                        .filter { k -> k != equippedKey && allEquip[k]?.slot == slot }
-                        .forEach { add(it) }
-                }
-
-                for ((itemKey, qty) in inventory) {
-                    if (itemKey == equippedKey) continue
-                    val item = allEquip[itemKey] ?: continue
-                    if (item.slot != slot) continue
-
-                    val shouldSell = if (slot in toolSlots) {
-                        scoreFor(item, slot) < scoreFor(equippedItem, slot)
-                    } else {
-                        allKeysInSlot
-                            .filter { it != itemKey }
-                            .any { k -> allEquip[k]?.let { o -> combatDominates(o, item) } == true }
-                    }
-                    if (shouldSell) toSell[itemKey] = (toSell[itemKey] ?: 0) + qty
-                }
-            }
-
-            // Suggest selling extra copies of equipped items (you only need 1)
-            for ((itemKey, inInv) in inventory) {
-                val equippedCount = equipped.values.count { it == itemKey }
-                if (equippedCount == 0) continue
-                val extras = inInv - equippedCount
-                if (extras > 0) toSell[itemKey] = (toSell[itemKey] ?: 0) + extras
-            }
+            val toSell = computeOldEquipmentToSell(equipped, inventory, allEquip)
 
             if (toSell.isEmpty()) {
                 _extra.update { it.copy(snackbarMessage = context.getString(R.string.shop_no_old_equipment)) }
@@ -530,31 +495,6 @@ class ShopViewModel @Inject constructor(
         }
     }
 
-    private fun scoreFor(item: com.fantasyidler.data.json.EquipmentData, slot: String): Float = when (slot) {
-        EquipSlot.PICKAXE     -> item.miningEfficiency ?: 0f
-        EquipSlot.AXE         -> item.woodcuttingEfficiency ?: 0f
-        EquipSlot.FISHING_ROD -> item.fishingEfficiency ?: 0f
-        EquipSlot.HOE         -> item.farmingEfficiency ?: 0f
-        else                  -> (item.attackBonus + item.strengthBonus + item.defenseBonus).toFloat()
-    }
-
-    private fun combatDominates(a: com.fantasyidler.data.json.EquipmentData, b: com.fantasyidler.data.json.EquipmentData): Boolean {
-        if (a.attackBonus          < b.attackBonus)                       return false
-        if (a.strengthBonus        < b.strengthBonus)                     return false
-        if (a.defenseBonus         < b.defenseBonus)                      return false
-        if ((a.rangedAttackBonus   ?: 0) < (b.rangedAttackBonus   ?: 0)) return false
-        if ((a.rangedStrengthBonus ?: 0) < (b.rangedStrengthBonus ?: 0)) return false
-        if ((a.magicAttackBonus    ?: 0) < (b.magicAttackBonus    ?: 0)) return false
-        if ((a.magicDamageBonus    ?: 0) < (b.magicDamageBonus    ?: 0)) return false
-        return a.attackBonus > b.attackBonus ||
-               a.strengthBonus > b.strengthBonus ||
-               a.defenseBonus > b.defenseBonus ||
-               (a.rangedAttackBonus   ?: 0) > (b.rangedAttackBonus   ?: 0) ||
-               (a.rangedStrengthBonus ?: 0) > (b.rangedStrengthBonus ?: 0) ||
-               (a.magicAttackBonus    ?: 0) > (b.magicAttackBonus    ?: 0) ||
-               (a.magicDamageBonus    ?: 0) > (b.magicDamageBonus    ?: 0)
-    }
-
     private fun Long.toCoinsString(): String =
         if (this >= 1_000_000) "${"%.1f".format(this / 1_000_000.0)}M"
         else if (this >= 1_000) "${"%.1f".format(this / 1_000.0)}k"
@@ -562,6 +502,89 @@ class ShopViewModel @Inject constructor(
 
     companion object {
         const val XP_BOOST_KEY = "xp_boost_48h"
+
+        private val TOOL_SLOTS = setOf(EquipSlot.PICKAXE, EquipSlot.AXE, EquipSlot.FISHING_ROD, EquipSlot.HOE)
+
+        /**
+         * Pure logic for computing which old equipment items to suggest selling.
+         * Extracted from [previewSellOldEquipment] for testability.
+         *
+         * @param equipped  current equipped items: slot → item key
+         * @param inventory player's inventory: item key → quantity
+         * @param allEquip  all equipment data: item key → [EquipmentData]
+         * @return map of item key → quantity to sell
+         */
+        fun computeOldEquipmentToSell(
+            equipped: Map<String, String?>,
+            inventory: Map<String, Int>,
+            allEquip: Map<String, com.fantasyidler.data.json.EquipmentData>,
+        ): Map<String, Int> {
+            val toSell = mutableMapOf<String, Int>()
+            for (slot in EquipSlot.ALL) {
+                val equippedKey  = equipped[slot] ?: continue
+                val equippedItem = allEquip[equippedKey] ?: continue
+
+                val allKeysInSlot = buildList {
+                    add(equippedKey)
+                    inventory.keys
+                        .filter { k -> k != equippedKey && allEquip[k]?.slot == slot }
+                        .forEach { add(it) }
+                }
+
+                for ((itemKey, qty) in inventory) {
+                    if (itemKey == equippedKey) continue
+                    val item = allEquip[itemKey] ?: continue
+                    if (item.slot != slot) continue
+
+                    // Skill capes are rare level-99 rewards — never auto-sell them (issue #821)
+                    if (item.capeSkill != null) continue
+
+                    val shouldSell = if (slot in TOOL_SLOTS) {
+                        scoreForItem(item, slot) < scoreForItem(equippedItem, slot)
+                    } else {
+                        allKeysInSlot
+                            .filter { it != itemKey }
+                            .any { k -> allEquip[k]?.let { o -> combatDominatesStatic(o, item) } == true }
+                    }
+                    if (shouldSell) toSell[itemKey] = (toSell[itemKey] ?: 0) + qty
+                }
+            }
+
+            // Suggest selling extra copies of equipped items (you only need 1)
+            for ((itemKey, inInv) in inventory) {
+                val equippedCount = equipped.values.count { it == itemKey }
+                if (equippedCount == 0) continue
+                val extras = inInv - equippedCount
+                if (extras > 0) toSell[itemKey] = (toSell[itemKey] ?: 0) + extras
+            }
+
+            return toSell
+        }
+
+        private fun scoreForItem(item: com.fantasyidler.data.json.EquipmentData, slot: String): Float = when (slot) {
+            EquipSlot.PICKAXE     -> item.miningEfficiency ?: 0f
+            EquipSlot.AXE         -> item.woodcuttingEfficiency ?: 0f
+            EquipSlot.FISHING_ROD -> item.fishingEfficiency ?: 0f
+            EquipSlot.HOE         -> item.farmingEfficiency ?: 0f
+            else                  -> (item.attackBonus + item.strengthBonus + item.defenseBonus).toFloat()
+        }
+
+        private fun combatDominatesStatic(a: com.fantasyidler.data.json.EquipmentData, b: com.fantasyidler.data.json.EquipmentData): Boolean {
+            if (a.attackBonus          < b.attackBonus)                       return false
+            if (a.strengthBonus        < b.strengthBonus)                     return false
+            if (a.defenseBonus         < b.defenseBonus)                      return false
+            if ((a.rangedAttackBonus   ?: 0) < (b.rangedAttackBonus   ?: 0)) return false
+            if ((a.rangedStrengthBonus ?: 0) < (b.rangedStrengthBonus ?: 0)) return false
+            if ((a.magicAttackBonus    ?: 0) < (b.magicAttackBonus    ?: 0)) return false
+            if ((a.magicDamageBonus    ?: 0) < (b.magicDamageBonus    ?: 0)) return false
+            return a.attackBonus > b.attackBonus ||
+                   a.strengthBonus > b.strengthBonus ||
+                   a.defenseBonus > b.defenseBonus ||
+                   (a.rangedAttackBonus   ?: 0) > (b.rangedAttackBonus   ?: 0) ||
+                   (a.rangedStrengthBonus ?: 0) > (b.rangedStrengthBonus ?: 0) ||
+                   (a.magicAttackBonus    ?: 0) > (b.magicAttackBonus    ?: 0) ||
+                   (a.magicDamageBonus    ?: 0) > (b.magicDamageBonus    ?: 0)
+        }
 
         private val FISH_KEYS = setOf(
             "shrimp", "sardine", "herring", "mackerel", "trout", "salmon",

--- a/app/src/test/kotlin/com/fantasyidler/ui/viewmodel/SellOldEquipmentTest.kt
+++ b/app/src/test/kotlin/com/fantasyidler/ui/viewmodel/SellOldEquipmentTest.kt
@@ -1,0 +1,164 @@
+package com.fantasyidler.ui.viewmodel
+
+import com.fantasyidler.data.json.EquipmentData
+import com.fantasyidler.data.model.EquipSlot
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Regression tests for [ShopViewModel.computeOldEquipmentToSell].
+ *
+ * Issue #821: Skill capes should NOT be included in "Sell Old Gear" because
+ * they are rare rewards awarded for reaching level 99 in a skill — not
+ * ordinary gear that gets replaced by a better upgrade.
+ */
+class SellOldEquipmentTest {
+
+    private fun cape(
+        key: String,
+        capeSkill: String?,
+        defense: Int = 5,
+        capeBonus: Float = 0.1f,
+    ) = EquipmentData(
+        name = key,
+        displayName = key.replace("_", " ").replaceFirstChar { it.uppercase() },
+        slot = EquipSlot.CAPE,
+        defenseBonus = defense,
+        capeSkill = capeSkill,
+        capeBonus = capeBonus,
+    )
+
+    private fun body(
+        key: String,
+        attack: Int = 0,
+        strength: Int = 0,
+        defense: Int = 0,
+    ) = EquipmentData(
+        name = key,
+        displayName = key.replace("_", " ").replaceFirstChar { it.uppercase() },
+        slot = EquipSlot.BODY,
+        attackBonus = attack,
+        strengthBonus = strength,
+        defenseBonus = defense,
+    )
+
+    /** A skill cape (e.g. Prayer cape) unequipped in inventory while a combat cape is equipped. */
+    @Test
+    fun `skill cape is not included in sell old gear when a better cape is equipped`() {
+        val prayerCape = cape("prayer_cape", capeSkill = "prayer")
+        val attackCape = cape("attack_cape", capeSkill = "attack", defense = 10)
+
+        val allEquip = mapOf(
+            "prayer_cape" to prayerCape,
+            "attack_cape" to attackCape,
+        )
+        val equipped = mapOf(EquipSlot.CAPE to "attack_cape")
+        val inventory = mapOf("prayer_cape" to 1)
+
+        val toSell = ShopViewModel.computeOldEquipmentToSell(equipped, inventory, allEquip)
+
+        assertFalse(
+            "Skill cape (prayer_cape) should NOT be in sell list",
+            "prayer_cape" in toSell,
+        )
+    }
+
+    /** Multiple skill capes in inventory — none should be sold. */
+    @Test
+    fun `multiple skill capes are all excluded from sell old gear`() {
+        val allEquip = mapOf(
+            "prayer_cape"   to cape("prayer_cape", capeSkill = "prayer"),
+            "mining_cape"   to cape("mining_cape", capeSkill = "mining"),
+            "attack_cape"   to cape("attack_cape", capeSkill = "attack", defense = 10),
+        )
+        val equipped = mapOf(EquipSlot.CAPE to "attack_cape")
+        val inventory = mapOf("prayer_cape" to 1, "mining_cape" to 1)
+
+        val toSell = ShopViewModel.computeOldEquipmentToSell(equipped, inventory, allEquip)
+
+        assertFalse("prayer_cape should NOT be sold", "prayer_cape" in toSell)
+        assertFalse("mining_cape should NOT be sold", "mining_cape" in toSell)
+    }
+
+    /** A skill cape in inventory with no cape equipped should still not be sold. */
+    @Test
+    fun `skill cape is not sold even when no cape is equipped`() {
+        val prayerCape = cape("prayer_cape", capeSkill = "prayer")
+
+        val allEquip = mapOf(
+            "prayer_cape" to prayerCape,
+            "bronze_platebody" to body("bronze_platebody", defense = 3),
+            "runite_platebody" to body("runite_platebody", defense = 40),
+        )
+        // No cape equipped, runite platebody equipped, bronze platebody in inventory
+        val equipped = mapOf(EquipSlot.BODY to "runite_platebody")
+        val inventory = mapOf("prayer_cape" to 1, "bronze_platebody" to 1)
+
+        val toSell = ShopViewModel.computeOldEquipmentToSell(equipped, inventory, allEquip)
+
+        assertFalse("prayer_cape should NOT be sold", "prayer_cape" in toSell)
+        assertTrue(
+            "Old non-cape gear (bronze_platebody) should still be sold when dominated",
+            "bronze_platebody" in toSell,
+        )
+    }
+
+    /** Combat capes (capeSkill set to a combat skill) should also be excluded. */
+    @Test
+    fun `combat cape is not sold even when dominated by another combat cape`() {
+        val allEquip = mapOf(
+            "attack_cape"   to cape("attack_cape", capeSkill = "attack", defense = 10),
+            "strength_cape" to cape("strength_cape", capeSkill = "strength", defense = 10),
+        )
+        val equipped = mapOf(EquipSlot.CAPE to "attack_cape")
+        val inventory = mapOf("strength_cape" to 1)
+
+        val toSell = ShopViewModel.computeOldEquipmentToSell(equipped, inventory, allEquip)
+
+        assertFalse("strength_cape should NOT be sold", "strength_cape" in toSell)
+    }
+
+    /** Non-cape equipment in the cape slot (if any) should still be sellable. */
+    @Test
+    fun `non-skill item in cape slot is still sold when dominated`() {
+        val allEquip = mapOf(
+            "regular_cape" to EquipmentData(
+                name = "regular_cape",
+                displayName = "Regular Cape",
+                slot = EquipSlot.CAPE,
+                defenseBonus = 1,
+            ),
+            "spotted_cape" to EquipmentData(
+                name = "spotted_cape",
+                displayName = "Spotted Cape",
+                slot = EquipSlot.CAPE,
+                defenseBonus = 10,
+            ),
+        )
+        val equipped = mapOf(EquipSlot.CAPE to "spotted_cape")
+        val inventory = mapOf("regular_cape" to 1)
+
+        val toSell = ShopViewModel.computeOldEquipmentToSell(equipped, inventory, allEquip)
+
+        assertTrue(
+            "Non-skill cape (regular_cape) should be sold when dominated",
+            "regular_cape" in toSell,
+        )
+    }
+
+    /** Old body armor should still be sold (regression: fix doesn't break normal behaviour). */
+    @Test
+    fun `old body armor is still sold when dominated`() {
+        val allEquip = mapOf(
+            "bronze_platebody" to body("bronze_platebody", defense = 3),
+            "runite_platebody" to body("runite_platebody", defense = 40),
+        )
+        val equipped = mapOf(EquipSlot.BODY to "runite_platebody")
+        val inventory = mapOf("bronze_platebody" to 1)
+
+        val toSell = ShopViewModel.computeOldEquipmentToSell(equipped, inventory, allEquip)
+
+        assertTrue("bronze_platebody should be sold", "bronze_platebody" in toSell)
+    }
+}


### PR DESCRIPTION
Skill capes (items with capeSkill != null) are rare level-99 rewards that should never be auto-sold by the "Sell Old Gear" feature. Previously, a skill cape in inventory could be marked as dominated by a combat cape and suggested for bulk sale.

Extracted the sell-old-gear logic from ShopViewModel.previewSellOldEquipment() into a testable companion-object function computeOldEquipmentToSell().

Added regression tests covering:
- Skill cape excluded when a better cape is equipped
- Multiple skill capes all excluded
- Skill cape excluded even with no cape equipped
- Combat capes also excluded
- Non-skill capes still sellable when dominated
- Normal body armor still sellable (no regression)

Fixes #821