### PR TITLE
Fix: Ensure only non-guild quests are included in the quest champion achievement

### DIFF
--- a/app/src/main/kotlin/com/fantasyidler/ui/viewmodel/AchievementsViewModel.kt
+++ b/app/src/main/kotlin/com/fantasyidler/ui/viewmodel/AchievementsViewModel.kt
@@ -54,7 +54,7 @@ class AchievementsViewModel @Inject constructor(
             json.decodeFromString(player.pets)
         } catch (_: Exception) { emptyList() }
         val flags: PlayerFlags = try { json.decodeFromString(player.flags) } catch (_: Exception) { PlayerFlags() }
-        val completedQuests = questProgress.count { it.completed }
+        val completedQuests = questProgress.count { it.completed && gameData.quests.keys.contains(it.questId)  }
         val totalLevel  = levels.values.sum()
         val combatLevel = combatLevelFrom(levels)
         val prestigeMap = flags.skillPrestige


### PR DESCRIPTION
Fixes #845 by ensuring that only non-guild quests are included in the quest champion achievement. If guild quests should be included, then an alternative fix is needed by making sure that completedQuests > gameData.quests.size + guild quests.

# Changelog
- Only includes quests that are in gameData.quests when counting the completed quests in the achievements screen