### PR TITLE
Fix #872: Clarify seasonal fletching task requires Mithril arrows

### DIFF
--- a/app/src/main/assets/data/seasonal_events.json
+++ b/app/src/main/assets/data/seasonal_events.json
@@ -57,7 +57,7 @@
         "type": "craft",
         "target": "mithril_arrow",
         "amount": 50,
-        "display_name": "Fletch arrows to hold back the wisps",
+        "display_name": "Fletch Mithril arrows to hold back the wisps",
         "hint": "Fletching",
         "skill": "fletching"
       },


### PR DESCRIPTION
Fixes #872. Updates the display name for the seasonal fletching task to explicitly state Mithril arrows.