### PR TITLE
Highlight rare drops on session collection screens

### DIFF
--- a/app/src/main/kotlin/com/fantasyidler/ui/screen/CombatResultSheet.kt
+++ b/app/src/main/kotlin/com/fantasyidler/ui/screen/CombatResultSheet.kt
@@ -226,18 +226,23 @@ internal fun CombatResultSheet(
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
             )
             for ((item, qty) in result.itemsGained) {
+                val isRare = item in result.rareItems
                 Row(
                     modifier = Modifier.fillMaxWidth().padding(vertical = 2.dp),
                     horizontalArrangement = Arrangement.SpaceBetween,
                 ) {
+                    val displayName = GameStrings.itemName(context, item)
                     Text(
-                        text  = GameStrings.itemName(context, item),
+                        text  = if (isRare) "🌟 $displayName" else displayName,
                         style = MaterialTheme.typography.bodyMedium,
+                        fontWeight = if (isRare) FontWeight.Bold else FontWeight.Normal,
+                        color = if (isRare) GoldPrimary else MaterialTheme.colorScheme.onSurface,
                     )
                     Text(
                         text  = "×$qty",
                         style = MaterialTheme.typography.bodyMedium,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        color = if (isRare) GoldPrimary else MaterialTheme.colorScheme.onSurfaceVariant,
+                        fontWeight = if (isRare) FontWeight.Bold else FontWeight.Normal,
                     )
                 }
             }

--- a/app/src/main/kotlin/com/fantasyidler/ui/screen/HomeCards.kt
+++ b/app/src/main/kotlin/com/fantasyidler/ui/screen/HomeCards.kt
@@ -592,16 +592,23 @@ internal fun SummarySection(title: String) {
 }
 
 @Composable
-internal fun SummaryRow(label: String, value: String) {
+internal fun SummaryRow(
+    label: String,
+    value: String,
+    labelColor: androidx.compose.ui.graphics.Color = MaterialTheme.colorScheme.onSurface,
+    valueColor: androidx.compose.ui.graphics.Color = MaterialTheme.colorScheme.onSurfaceVariant,
+    fontWeight: FontWeight = FontWeight.Normal,
+) {
     Row(
         modifier              = Modifier.fillMaxWidth(),
         horizontalArrangement = Arrangement.SpaceBetween,
     ) {
-        Text(label, style = MaterialTheme.typography.bodyMedium, modifier = Modifier.weight(1f))
+        Text(label, style = MaterialTheme.typography.bodyMedium, color = labelColor, fontWeight = fontWeight, modifier = Modifier.weight(1f))
         Text(
             text       = value,
             style      = MaterialTheme.typography.bodyMedium,
-            fontWeight = FontWeight.SemiBold,
+            fontWeight = if (fontWeight == FontWeight.Bold) FontWeight.Bold else FontWeight.SemiBold,
+            color      = valueColor,
         )
     }
 }

--- a/app/src/main/kotlin/com/fantasyidler/ui/screen/HomeScreen.kt
+++ b/app/src/main/kotlin/com/fantasyidler/ui/screen/HomeScreen.kt
@@ -228,7 +228,16 @@ fun HomeScreen(
                     if (summary.itemLines.isNotEmpty()) {
                         Spacer(Modifier.height(4.dp))
                         SummarySection(stringResource(R.string.home_loot))
-                        summary.itemLines.forEach { (item, qty) -> SummaryRow(item, qty) }
+                        summary.itemLines.forEach { (item, qty) ->
+                            val isRare = item in summary.rareItems
+                            SummaryRow(
+                                label = if (isRare) "🌟 $item" else item,
+                                value = qty,
+                                labelColor = if (isRare) GoldPrimary else MaterialTheme.colorScheme.onSurface,
+                                valueColor = if (isRare) GoldPrimary else MaterialTheme.colorScheme.onSurfaceVariant,
+                                fontWeight = if (isRare) FontWeight.Bold else FontWeight.Normal,
+                            )
+                        }
                     }
                     if (summary.coinsGained > 0) {
                         SummaryRow(stringResource(R.string.label_coins), "+${summary.coinsGained.formatCoins()}")
@@ -375,7 +384,16 @@ fun HomeScreen(
                     if (summary.itemLines.isNotEmpty()) {
                         Spacer(Modifier.height(4.dp))
                         SummarySection(stringResource(R.string.home_loot))
-                        summary.itemLines.forEach { (item, qty) -> SummaryRow(item, qty) }
+                        summary.itemLines.forEach { (item, qty) ->
+                            val isRare = item in summary.rareItems
+                            SummaryRow(
+                                label = if (isRare) "🌟 $item" else item,
+                                value = qty,
+                                labelColor = if (isRare) GoldPrimary else MaterialTheme.colorScheme.onSurface,
+                                valueColor = if (isRare) GoldPrimary else MaterialTheme.colorScheme.onSurfaceVariant,
+                                fontWeight = if (isRare) FontWeight.Bold else FontWeight.Normal,
+                            )
+                        }
                     }
                     if (summary.coinsGained > 0) {
                         SummaryRow(stringResource(R.string.label_coins), "+${summary.coinsGained.formatCoins()}")

--- a/app/src/main/kotlin/com/fantasyidler/ui/viewmodel/CombatViewModel.kt
+++ b/app/src/main/kotlin/com/fantasyidler/ui/viewmodel/CombatViewModel.kt
@@ -65,6 +65,7 @@ data class CombatSessionResult(
     val xpBlessingBonusBySkill: Map<String, Long> = emptyMap(),
     val coinBlessingBonus: Long = 0L,
     val boostWasActive: Boolean = false,
+    val rareItems: Set<String> = emptySet(),
 )
 
 data class CombatUiState(
@@ -796,6 +797,9 @@ class CombatViewModel @Inject constructor(
         }.filter { (_, bonus) -> bonus > 0 }
         val coinBlessingBonus = (coinsGained.toDouble() * (blessingCoinMult - 1)).toLong()
         val itemsDisplay = last.items.toMutableMap().also { it.remove("coins") }
+        val bossRareKeys = boss?.rareDrops?.map { it.item }?.toSet() ?: emptySet()
+        val bossPetKey = boss?.pet?.id
+        val rareItems = itemsDisplay.keys.filter { it in bossRareKeys || it == bossPetKey }.toSet()
         sessionRepo.deleteSession(session.sessionId)
         val bossRecentFlags = playerRepo.getFlags()
         playerRepo.updateFlags(bossRecentFlags.copy(
@@ -821,6 +825,7 @@ class CombatViewModel @Inject constructor(
                     xpBlessingBonusBySkill = xpBlessingBonusBySkill,
                     coinBlessingBonus      = coinBlessingBonus,
                     boostWasActive         = boostActive,
+                    rareItems              = rareItems,
                 ),
                 snackbarMessage = buildCapeMessage(capes),
                 petFoundName    = petFoundName,
@@ -909,6 +914,16 @@ class CombatViewModel @Inject constructor(
             ((boosted.toDouble() * blessingXpMult).toLong() - boosted).coerceAtLeast(0L)
         }.filter { (_, bonus) -> bonus > 0 }
         val coinBlessingBonus = (coinsGained.toDouble() * (blessingCoinMult - 1)).toLong()
+        val dungeonRareKeys = mutableSetOf<String>()
+        dungeon?.rareDrops?.forEach { dungeonRareKeys.add(it.item) }
+        dungeon?.enemySpawns?.forEach { spawn ->
+            gameData.enemies[spawn.enemy]?.dropTable?.forEach { entry ->
+                if (entry.chance <= 0.005) {
+                    dungeonRareKeys.add(entry.item)
+                }
+            }
+        }
+        val rareItems = allItems.keys.filter { it in dungeonRareKeys }.toSet()
         sessionRepo.deleteSession(session.sessionId)
         val dungeonRecentFlags = playerRepo.getFlags()
         val runStats = DungeonRunStats(
@@ -942,6 +957,7 @@ class CombatViewModel @Inject constructor(
                     xpBlessingBonusBySkill = xpBlessingBonusBySkill,
                     coinBlessingBonus      = coinBlessingBonus,
                     boostWasActive         = boostActive,
+                    rareItems              = rareItems,
                 ),
                 snackbarMessage = buildCapeMessage(capes),
             )

--- a/app/src/main/kotlin/com/fantasyidler/ui/viewmodel/HomeViewModel.kt
+++ b/app/src/main/kotlin/com/fantasyidler/ui/viewmodel/HomeViewModel.kt
@@ -100,6 +100,7 @@ data class SessionSummary(
     val noteLines: List<String> = emptyList(),
     /** Expedition: set when this collect triggered a new combat dungeon unlock. */
     val unlockMessage: String? = null,
+    val rareItems: Set<String> = emptySet(),
 )
 
 data class HomeUiState(
@@ -732,6 +733,32 @@ class HomeViewModel @Inject constructor(
             for (session in sessions) sessionRepo.deleteSession(session.sessionId)
             if (dailyKills.isNotEmpty()) playerRepo.recordDailyKills(dailyKills)
 
+            val rareItemsDisplayNames = mutableSetOf<String>()
+            for (session in sessions) {
+                if (session.skillName == "boss") {
+                    val boss = gameData.bosses[session.activityKey]
+                    val bossRareKeys = boss?.rareDrops?.map { it.item }?.toSet() ?: emptySet()
+                    val bossPetKey = boss?.pet?.id
+                    val combinedBossRareKeys = bossRareKeys + listOfNotNull(bossPetKey)
+                    combinedBossRareKeys.forEach { key ->
+                        rareItemsDisplayNames.add(gameData.itemDisplayName(key))
+                    }
+                }
+                if (session.skillName == "combat") {
+                    val dungeon = gameData.dungeons[session.activityKey]
+                    dungeon?.rareDrops?.forEach {
+                        rareItemsDisplayNames.add(gameData.itemDisplayName(it.item))
+                    }
+                    dungeon?.enemySpawns?.forEach { spawn ->
+                        gameData.enemies[spawn.enemy]?.dropTable?.forEach { entry ->
+                            if (entry.chance <= 0.005) {
+                                rareItemsDisplayNames.add(gameData.itemDisplayName(entry.item))
+                            }
+                        }
+                    }
+                }
+            }
+
             // ── Recent sessions log ───────────────────────────────────────
             val newEntries = sessions.map { s ->
                 val activityDisplay = when (s.skillName) {
@@ -825,6 +852,7 @@ class HomeViewModel @Inject constructor(
                 coinBlessingBonus = coinBlessingBonus,
                 noteLines        = expeditionNoteLines,
                 unlockMessage    = expeditionUnlockMessage,
+                rareItems        = rareItemsDisplayNames,
             )
 
             val capeMessage = if (awardedCapes.isNotEmpty()) {


### PR DESCRIPTION
Highlights rare combat and boss drops on session collection screens (Combat sheet & Home screen collection dialogs) using a gold color and a 🌟 prefix.

It matches:
- Bosses: Boss rare drops + pets
- Dungeons: Dungeon completion rares + enemy drops with a chance <= 0.5% (like shadow_signet or ring_of_dragons_might, while avoiding gem/common item clutter)

Regular skilling is excluded to prevent visual spam.