### PR TITLE
Add quest indicators to all skill selection sheets

### DIFF
--- a/app/src/main/kotlin/com/fantasyidler/ui/screen/CraftingScreen.kt
+++ b/app/src/main/kotlin/com/fantasyidler/ui/screen/CraftingScreen.kt
@@ -68,6 +68,8 @@ import com.fantasyidler.ui.viewmodel.CraftableRecipe
 import com.fantasyidler.ui.viewmodel.CraftingUiState
 import com.fantasyidler.ui.viewmodel.CraftingViewModel
 import com.fantasyidler.ui.viewmodel.QuestFillSuggestion
+import com.fantasyidler.ui.viewmodel.QuestCategory
+import androidx.compose.ui.draw.alpha
 import com.fantasyidler.util.GameStrings
 import com.fantasyidler.util.formatXp
 
@@ -222,6 +224,21 @@ private fun RecipeRow(
                         style    = MaterialTheme.typography.bodySmall,
                         color    = MaterialTheme.colorScheme.onSurfaceVariant,
                     )
+                }
+                val questIndicators = state.recipeQuests[recipe.outputKey] ?: emptyList()
+                if (questIndicators.isNotEmpty()) {
+                    val categories = questIndicators.groupBy { it.category }
+                    val sortedCategories = categories.entries.sortedBy { it.key }
+                    sortedCategories.forEach { (category, indicators) ->
+                        val emoji = if (category == QuestCategory.DAILY) "⏰" else "📜"
+                        val isCompletable = indicators.any { it.isCompletable }
+                        val alpha = if (isCompletable) 1.0f else 0.38f
+                        Text(
+                            text     = " $emoji",
+                            style    = MaterialTheme.typography.bodyMedium,
+                            modifier = Modifier.alpha(alpha),
+                        )
+                    }
                 }
             }
             // Materials row

--- a/app/src/main/kotlin/com/fantasyidler/ui/screen/SkillsScreen.kt
+++ b/app/src/main/kotlin/com/fantasyidler/ui/screen/SkillsScreen.kt
@@ -251,6 +251,7 @@ fun SkillActivitySheet(
                     currentXp         = state.skillXp[Skills.MINING] ?: 0L,
                     efficiency        = state.miningEfficiency,
                     xpBonusMult       = state.xpBonusMult,
+                    activeQuests      = state.activeQuests,
                     onSelect          = { oreKey -> viewModel.startMiningSession(oreKey) },
                 )
                 is SheetState.Woodcutting -> WoodcuttingSheet(
@@ -262,6 +263,7 @@ fun SkillActivitySheet(
                     currentXp         = state.skillXp[Skills.WOODCUTTING] ?: 0L,
                     efficiency        = state.woodcuttingEfficiency,
                     xpBonusMult       = state.xpBonusMult,
+                    activeQuests      = state.activeQuests,
                     onSelect          = { treeKey -> viewModel.startWoodcuttingSession(treeKey) },
                 )
                 is SheetState.Fishing -> FishingSheet(
@@ -273,6 +275,7 @@ fun SkillActivitySheet(
                     currentXp         = state.skillXp[Skills.FISHING] ?: 0L,
                     efficiency        = state.fishingEfficiency,
                     xpBonusMult       = state.xpBonusMult,
+                    activeQuests      = state.activeQuests,
                     onSelect          = { fishKey -> viewModel.startFishingSession(fishKey) },
                 )
                 is SheetState.Agility -> AgilitySheet(
@@ -283,6 +286,7 @@ fun SkillActivitySheet(
                     sessionDurationMs = state.sessionDurationMs,
                     currentXp         = state.skillXp[Skills.AGILITY] ?: 0L,
                     xpBonusMult       = state.xpBonusMult,
+                    activeQuests      = state.activeQuests,
                     onSelect          = { courseKey -> viewModel.startAgilitySession(courseKey) },
                 )
                 is SheetState.Firemaking -> FiremakingSheet(
@@ -296,6 +300,7 @@ fun SkillActivitySheet(
                     onStart           = { logKey, qty -> viewModel.startFiremakingSession(logKey, qty) },
                     context           = context,
                     questFills        = sheet.questFills,
+                    activeQuests      = state.activeQuests,
                 )
                 is SheetState.Runecrafting -> RunecraftingSheet(
                     sheet             = sheet,
@@ -307,6 +312,7 @@ fun SkillActivitySheet(
                     onStart           = { runeKey, qty, ashKey -> viewModel.startRunecraftingSession(runeKey, qty, ashKey) },
                     currentXp         = state.skillXp[Skills.RUNECRAFTING] ?: 0L,
                     questFills        = sheet.questFills,
+                    activeQuests      = state.activeQuests,
                 )
                 is SheetState.Prayer -> PrayerSheet(
                     availableBones        = sheet.availableBones,
@@ -323,6 +329,7 @@ fun SkillActivitySheet(
                         onNavigateToBoneAltar()
                     },
                     questFills            = sheet.questFills,
+                    activeQuests          = state.activeQuests,
                 )
                 is SheetState.Crafting -> {
                     val craftState by craftingViewModel.uiState.collectAsState()
@@ -349,6 +356,7 @@ fun SkillActivitySheet(
                     isQueueFull       = state.queueSize >= state.maxQueueSize,
                     sessionDurationMs = state.sessionDurationMs,
                     context           = context,
+                    activeQuests      = state.activeQuests,
                     onSelect          = { npcKey -> viewModel.startThievingSession(npcKey) },
                 )
                 SheetState.Mercantile -> MercantileSheetContent(onDismiss = viewModel::dismissSheet)

--- a/app/src/main/kotlin/com/fantasyidler/ui/screen/skills/AgilitySheet.kt
+++ b/app/src/main/kotlin/com/fantasyidler/ui/screen/skills/AgilitySheet.kt
@@ -108,6 +108,7 @@ import com.fantasyidler.util.formatXp
 import com.fantasyidler.util.toCountdown
 import java.util.Locale
 import com.fantasyidler.ui.viewmodel.QuestFillSuggestion
+import com.fantasyidler.ui.viewmodel.QuestIndicator
 
 
 @Composable
@@ -119,6 +120,7 @@ internal fun AgilitySheet(
     sessionDurationMs: Long,
     currentXp: Long = 0L,
     xpBonusMult: Float = 1f,
+    activeQuests: Map<String, List<QuestIndicator>> = emptyMap(),
     onSelect: (String) -> Unit,
 ) {
     val context = LocalContext.current
@@ -157,6 +159,7 @@ internal fun AgilitySheet(
                         isStarting       = isStarting,
                         hasActiveSession = hasActiveSession,
                         isQueueFull      = isQueueFull,
+                        questIndicators  = activeQuests[key] ?: emptyList(),
                         onClick          = { selectedKey = key },
                     )
                 }

--- a/app/src/main/kotlin/com/fantasyidler/ui/screen/skills/CraftSkillSheet.kt
+++ b/app/src/main/kotlin/com/fantasyidler/ui/screen/skills/CraftSkillSheet.kt
@@ -108,6 +108,8 @@ import com.fantasyidler.util.formatXp
 import com.fantasyidler.util.toCountdown
 import java.util.Locale
 import com.fantasyidler.ui.viewmodel.QuestFillSuggestion
+import com.fantasyidler.ui.viewmodel.QuestCategory
+import androidx.compose.ui.draw.alpha
 
 
 @Composable
@@ -285,12 +287,29 @@ private fun CraftRecipeRow(
         verticalAlignment = Alignment.CenterVertically,
     ) {
         Column(Modifier.weight(1f)) {
-            Text(
-                text       = GameStrings.itemName(context, recipe.outputKey),
-                style      = MaterialTheme.typography.bodyLarge,
-                fontWeight = FontWeight.Medium,
-                color      = if (enabled) MaterialTheme.colorScheme.onSurface else dim,
-            )
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Text(
+                    text       = GameStrings.itemName(context, recipe.outputKey),
+                    style      = MaterialTheme.typography.bodyLarge,
+                    fontWeight = FontWeight.Medium,
+                    color      = if (enabled) MaterialTheme.colorScheme.onSurface else dim,
+                )
+                val questIndicators = craftState.recipeQuests[recipe.outputKey] ?: emptyList()
+                if (questIndicators.isNotEmpty()) {
+                    val categories = questIndicators.groupBy { it.category }
+                    val sortedCategories = categories.entries.sortedBy { it.key }
+                    sortedCategories.forEach { (category, indicators) ->
+                        val emoji = if (category == QuestCategory.DAILY) "⏰" else "📜"
+                        val isCompletable = indicators.any { it.isCompletable }
+                        val alpha = if (isCompletable) 1.0f else 0.38f
+                        Text(
+                            text     = " $emoji",
+                            style    = MaterialTheme.typography.bodyMedium,
+                            modifier = Modifier.alpha(alpha),
+                        )
+                    }
+                }
+            }
             if (recipe.outputQty > 1) {
                 Text(
                     text  = context.getString(R.string.crafting_per_craft, recipe.outputQty),

--- a/app/src/main/kotlin/com/fantasyidler/ui/screen/skills/FiremakingSheet.kt
+++ b/app/src/main/kotlin/com/fantasyidler/ui/screen/skills/FiremakingSheet.kt
@@ -108,6 +108,9 @@ import com.fantasyidler.util.formatXp
 import com.fantasyidler.util.toCountdown
 import java.util.Locale
 import com.fantasyidler.ui.viewmodel.QuestFillSuggestion
+import com.fantasyidler.ui.viewmodel.QuestCategory
+import com.fantasyidler.ui.viewmodel.QuestIndicator
+import androidx.compose.ui.draw.alpha
 
 
 @Composable
@@ -123,6 +126,7 @@ internal fun FiremakingSheet(
     context: android.content.Context,
     craftLimit: Int = Int.MAX_VALUE,
     questFills: Map<String, List<QuestFillSuggestion>> = emptyMap(),
+    activeQuests: Map<String, List<QuestIndicator>> = emptyMap(),
 ) {
     var selectedKey by remember { mutableStateOf<String?>(null) }
     val selectedLog = selectedKey?.let { availableLogs[it] }
@@ -152,19 +156,37 @@ internal fun FiremakingSheet(
             } else {
                 Column(Modifier.verticalScroll(rememberScrollState())) {
                     availableLogs.entries.sortedBy { it.value.levelRequired }.forEach { (key, log) ->
-                        val ashName = GameStrings.itemName(context, when (key) {
+                        val ashKey = when (key) {
                             "oak_log" -> "oak_ashes"; "willow_log" -> "willow_ashes"
                             "maple_log" -> "maple_ashes"; "yew_log" -> "yew_ashes"
                             "magic_log" -> "magic_ashes"; "redwood_log" -> "redwood_ashes"
                             else -> "ashes"
-                        })
+                        }
+                        val ashName = GameStrings.itemName(context, ashKey)
                         Row(
                             modifier          = Modifier.fillMaxWidth().clickable { selectedKey = key }.padding(horizontal = 16.dp, vertical = 12.dp),
                             horizontalArrangement = Arrangement.SpaceBetween,
                             verticalAlignment = Alignment.CenterVertically,
                         ) {
                             Column(Modifier.weight(1f)) {
-                                Text(GameStrings.itemName(context, key), style = MaterialTheme.typography.bodyLarge)
+                                Row(verticalAlignment = Alignment.CenterVertically) {
+                                    Text(GameStrings.itemName(context, key), style = MaterialTheme.typography.bodyLarge)
+                                    val questIndicators = activeQuests[ashKey] ?: emptyList()
+                                    if (questIndicators.isNotEmpty()) {
+                                        val categories = questIndicators.groupBy { it.category }
+                                        val sortedCategories = categories.entries.sortedBy { it.key }
+                                        sortedCategories.forEach { (category, indicators) ->
+                                            val emoji = if (category == QuestCategory.DAILY) "⏰" else "📜"
+                                            val isCompletable = indicators.any { it.isCompletable }
+                                            val alpha = if (isCompletable) 1.0f else 0.38f
+                                            Text(
+                                                text     = " $emoji",
+                                                style    = MaterialTheme.typography.bodyMedium,
+                                                modifier = Modifier.alpha(alpha),
+                                            )
+                                        }
+                                    }
+                                }
                                 Text(
                                     text  = stringResource(R.string.firemaking_burns_to, ashName) + "  •  ${log.xpPerLog} XP",
                                     style = MaterialTheme.typography.bodySmall,

--- a/app/src/main/kotlin/com/fantasyidler/ui/screen/skills/GatheringSheets.kt
+++ b/app/src/main/kotlin/com/fantasyidler/ui/screen/skills/GatheringSheets.kt
@@ -108,6 +108,9 @@ import com.fantasyidler.util.formatXp
 import com.fantasyidler.util.toCountdown
 import java.util.Locale
 import com.fantasyidler.ui.viewmodel.QuestFillSuggestion
+import com.fantasyidler.ui.viewmodel.QuestCategory
+import com.fantasyidler.ui.viewmodel.QuestIndicator
+import androidx.compose.ui.draw.alpha
 
 
 @Composable
@@ -120,6 +123,7 @@ internal fun MiningSheet(
     currentXp: Long = 0L,
     efficiency: Float = 1f,
     xpBonusMult: Float = 1f,
+    activeQuests: Map<String, List<QuestIndicator>> = emptyMap(),
     onSelect: (String) -> Unit,
 ) {
     val context = LocalContext.current
@@ -163,6 +167,7 @@ internal fun MiningSheet(
                         isStarting       = isStarting,
                         hasActiveSession = hasActiveSession,
                         isQueueFull      = isQueueFull,
+                        questIndicators  = activeQuests[key] ?: emptyList(),
                         onClick          = { selectedKey = key },
                     )
                 }
@@ -192,6 +197,7 @@ internal fun WoodcuttingSheet(
     currentXp: Long = 0L,
     efficiency: Float = 1f,
     xpBonusMult: Float = 1f,
+    activeQuests: Map<String, List<QuestIndicator>> = emptyMap(),
     onSelect: (String) -> Unit,
 ) {
     val context = LocalContext.current
@@ -229,6 +235,7 @@ internal fun WoodcuttingSheet(
                         isStarting       = isStarting,
                         hasActiveSession = hasActiveSession,
                         isQueueFull      = isQueueFull,
+                        questIndicators  = activeQuests[tree.logName] ?: emptyList(),
                         onClick          = { selectedKey = key },
                     )
                 }
@@ -258,6 +265,7 @@ internal fun FishingSheet(
     currentXp: Long = 0L,
     efficiency: Float = 1f,
     xpBonusMult: Float = 1f,
+    activeQuests: Map<String, List<QuestIndicator>> = emptyMap(),
     onSelect: (String) -> Unit,
 ) {
     val context = LocalContext.current
@@ -295,6 +303,7 @@ internal fun FishingSheet(
                         isStarting       = isStarting,
                         hasActiveSession = hasActiveSession,
                         isQueueFull      = isQueueFull,
+                        questIndicators  = activeQuests[key] ?: emptyList(),
                         onClick          = { selectedKey = key },
                     )
                 }
@@ -348,6 +357,7 @@ internal fun ActivityRow(
     isStarting: Boolean,
     hasActiveSession: Boolean,
     isQueueFull: Boolean,
+    questIndicators: List<QuestIndicator> = emptyList(),
     onClick: () -> Unit,
 ) {
     val queueBlocked = hasActiveSession && isQueueFull
@@ -360,7 +370,23 @@ internal fun ActivityRow(
         verticalAlignment     = Alignment.CenterVertically,
     ) {
         Column(modifier = Modifier.weight(1f)) {
-            Text(name, style = MaterialTheme.typography.bodyLarge)
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Text(name, style = MaterialTheme.typography.bodyLarge)
+                if (questIndicators.isNotEmpty()) {
+                    val categories = questIndicators.groupBy { it.category }
+                    val sortedCategories = categories.entries.sortedBy { it.key }
+                    sortedCategories.forEach { (category, indicators) ->
+                        val emoji = if (category == QuestCategory.DAILY) "⏰" else "📜"
+                        val isCompletable = indicators.any { it.isCompletable }
+                        val alpha = if (isCompletable) 1.0f else 0.38f
+                        Text(
+                            text     = " $emoji",
+                            style    = MaterialTheme.typography.bodyMedium,
+                            modifier = Modifier.alpha(alpha),
+                        )
+                    }
+                }
+            }
             Text(
                 text  = detail,
                 style = MaterialTheme.typography.bodySmall,

--- a/app/src/main/kotlin/com/fantasyidler/ui/screen/skills/PrayerSheet.kt
+++ b/app/src/main/kotlin/com/fantasyidler/ui/screen/skills/PrayerSheet.kt
@@ -108,6 +108,9 @@ import com.fantasyidler.util.formatXp
 import com.fantasyidler.util.toCountdown
 import java.util.Locale
 import com.fantasyidler.ui.viewmodel.QuestFillSuggestion
+import com.fantasyidler.ui.viewmodel.QuestCategory
+import com.fantasyidler.ui.viewmodel.QuestIndicator
+import androidx.compose.ui.draw.alpha
 
 
 @Composable
@@ -124,6 +127,7 @@ internal fun PrayerSheet(
     onNavigateToBoneAltar: () -> Unit = {},
     tierMaxQty: Int = Int.MAX_VALUE,
     questFills: List<QuestFillSuggestion> = emptyList(),
+    activeQuests: Map<String, List<QuestIndicator>> = emptyMap(),
 ) {
     val context = LocalContext.current
     var selectedKey by remember { mutableStateOf<String?>(null) }
@@ -190,7 +194,24 @@ internal fun PrayerSheet(
                         verticalAlignment = Alignment.CenterVertically,
                     ) {
                         Column(Modifier.weight(1f)) {
-                            Text(GameStrings.itemName(context, key), style = MaterialTheme.typography.bodyLarge)
+                            Row(verticalAlignment = Alignment.CenterVertically) {
+                                Text(GameStrings.itemName(context, key), style = MaterialTheme.typography.bodyLarge)
+                                val questIndicators = activeQuests[key] ?: emptyList()
+                                if (questIndicators.isNotEmpty()) {
+                                    val categories = questIndicators.groupBy { it.category }
+                                    val sortedCategories = categories.entries.sortedBy { it.key }
+                                    sortedCategories.forEach { (category, indicators) ->
+                                        val emoji = if (category == QuestCategory.DAILY) "⏰" else "📜"
+                                        val isCompletable = indicators.any { it.isCompletable }
+                                        val alpha = if (isCompletable) 1.0f else 0.38f
+                                        Text(
+                                            text     = " $emoji",
+                                            style    = MaterialTheme.typography.bodyMedium,
+                                            modifier = Modifier.alpha(alpha),
+                                        )
+                                    }
+                                }
+                            }
                             Text(
                                 text  = stringResource(R.string.skills_bone_qty, bone.xpPerBone.toInt(), qty),
                                 style = MaterialTheme.typography.bodySmall,

--- a/app/src/main/kotlin/com/fantasyidler/ui/screen/skills/RunecraftingSheet.kt
+++ b/app/src/main/kotlin/com/fantasyidler/ui/screen/skills/RunecraftingSheet.kt
@@ -108,6 +108,9 @@ import com.fantasyidler.util.formatXp
 import com.fantasyidler.util.toCountdown
 import java.util.Locale
 import com.fantasyidler.ui.viewmodel.QuestFillSuggestion
+import com.fantasyidler.ui.viewmodel.QuestCategory
+import com.fantasyidler.ui.viewmodel.QuestIndicator
+import androidx.compose.ui.draw.alpha
 
 
 @Composable
@@ -122,6 +125,7 @@ internal fun RunecraftingSheet(
     currentXp: Long = 0L,
     tierMaxQty: Int = Int.MAX_VALUE,
     questFills: Map<String, List<QuestFillSuggestion>> = emptyMap(),
+    activeQuests: Map<String, List<QuestIndicator>> = emptyMap(),
 ) {
     val context = LocalContext.current
     var selectedKey by remember { mutableStateOf<String?>(null) }
@@ -187,7 +191,24 @@ internal fun RunecraftingSheet(
                         verticalAlignment = Alignment.CenterVertically,
                     ) {
                         Column(Modifier.weight(1f)) {
-                            Text(GameStrings.itemName(context, key), style = MaterialTheme.typography.bodyLarge)
+                            Row(verticalAlignment = Alignment.CenterVertically) {
+                                Text(GameStrings.itemName(context, key), style = MaterialTheme.typography.bodyLarge)
+                                val questIndicators = activeQuests[key] ?: emptyList()
+                                if (questIndicators.isNotEmpty()) {
+                                    val categories = questIndicators.groupBy { it.category }
+                                    val sortedCategories = categories.entries.sortedBy { it.key }
+                                    sortedCategories.forEach { (category, indicators) ->
+                                        val emoji = if (category == QuestCategory.DAILY) "⏰" else "📜"
+                                        val isCompletable = indicators.any { it.isCompletable }
+                                        val alpha = if (isCompletable) 1.0f else 0.38f
+                                        Text(
+                                            text     = " $emoji",
+                                            style    = MaterialTheme.typography.bodyMedium,
+                                            modifier = Modifier.alpha(alpha),
+                                        )
+                                    }
+                                }
+                            }
                             Text(
                                 text  = stringResource(R.string.skills_rune_desc, rune.xpPerRune.toInt(), rune.levelRequired),
                                 style = MaterialTheme.typography.bodySmall,

--- a/app/src/main/kotlin/com/fantasyidler/ui/screen/skills/ThievingSheet.kt
+++ b/app/src/main/kotlin/com/fantasyidler/ui/screen/skills/ThievingSheet.kt
@@ -108,6 +108,7 @@ import com.fantasyidler.util.formatXp
 import com.fantasyidler.util.toCountdown
 import java.util.Locale
 import com.fantasyidler.ui.viewmodel.QuestFillSuggestion
+import com.fantasyidler.ui.viewmodel.QuestIndicator
 
 
 @Composable
@@ -120,6 +121,7 @@ internal fun ThievingSheet(
     isQueueFull: Boolean,
     sessionDurationMs: Long,
     context: android.content.Context,
+    activeQuests: Map<String, List<QuestIndicator>> = emptyMap(),
     onSelect: (String) -> Unit,
 ) {
     var selectedKey by remember { mutableStateOf<String?>(null) }
@@ -163,6 +165,7 @@ internal fun ThievingSheet(
                         isStarting       = isStarting,
                         hasActiveSession = hasActiveSession,
                         isQueueFull      = isQueueFull,
+                        questIndicators  = activeQuests[npc.key] ?: emptyList(),
                         onClick          = { selectedKey = npc.key },
                     )
                 }

--- a/app/src/main/kotlin/com/fantasyidler/ui/viewmodel/CraftingViewModel.kt
+++ b/app/src/main/kotlin/com/fantasyidler/ui/viewmodel/CraftingViewModel.kt
@@ -42,6 +42,16 @@ import dagger.hilt.android.qualifiers.ApplicationContext
 
 data class QuestFillSuggestion(val label: String, val qty: Int)
 
+enum class QuestCategory {
+    DAILY,
+    MAIN
+}
+
+data class QuestIndicator(
+    val category: QuestCategory,
+    val isCompletable: Boolean
+)
+
 // ---------------------------------------------------------------------------
 // Unified recipe model (normalises all 4 recipe types for display + crafting)
 // ---------------------------------------------------------------------------
@@ -105,6 +115,7 @@ data class CraftingUiState(
     val snackbarMessage: String? = null,
     val isLoading: Boolean = true,
     val questFills: List<QuestFillSuggestion> = emptyList(),
+    val recipeQuests: Map<String, List<QuestIndicator>> = emptyMap(),
 ) {
     /** Returns how many times [recipe] can be crafted given [effectiveInventory]. */
     fun maxCraftable(recipe: CraftableRecipe): Int {
@@ -163,6 +174,7 @@ class CraftingViewModel @Inject constructor(
             val xp: Map<String, Long> = json.decodeFromString(player.skillXp)
             val inventory: Map<String, Int> = json.decodeFromString(player.inventory)
             val flags: PlayerFlags = json.decodeFromString(player.flags)
+            val effInv = computeEffectiveInventory(inventory)
             extra.copy(
                 smithingLevel      = levels[Skills.SMITHING]      ?: 1,
                 cookingLevel       = levels[Skills.COOKING]       ?: 1,
@@ -173,9 +185,10 @@ class CraftingViewModel @Inject constructor(
                 skillLevels        = levels,
                 skillXp            = xp,
                 inventory          = inventory,
-                effectiveInventory = computeEffectiveInventory(inventory),
+                effectiveInventory = effInv,
                 isLoading          = false,
                 questFills         = computeQuestFills(extra.selectedRecipe, questProgress, flags),
+                recipeQuests       = computeRecipeQuests(allRecipes, questProgress, flags, effInv),
             )
         }
     }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), CraftingUiState())
@@ -558,6 +571,137 @@ class CraftingViewModel @Inject constructor(
         }
 
         return fills.sortedBy { it.qty }
+    }
+
+    private val allRecipes: List<CraftableRecipe> by lazy {
+        smithingRecipes + cookingRecipes + fletchingRecipes + herbloreRecipes + constructionRecipes + jewelleryRecipes
+    }
+
+    private fun computeRecipeQuests(
+        allRecipes: List<CraftableRecipe>,
+        questProgress: List<QuestProgress>,
+        flags: PlayerFlags,
+        effectiveInventory: Map<String, Int>,
+    ): Map<String, List<QuestIndicator>> {
+        val result = mutableMapOf<String, MutableList<QuestIndicator>>()
+        val progressById = questProgress.associateBy { it.questId }
+
+        val activeDailies = dailyQuestRepo.getActiveDailyQuests(flags).filter { !it.claimed }
+        val activeWeeklies = weeklyQuestRepo.getActiveWeeklyQuests(flags).filter { !it.claimed }
+        val guildPool = gameData.guildDailyPool.associateBy { it.id }
+        val activeGuildDailyIds = flags.guildDailyIds.filter { it !in flags.guildDailyClaimed }
+        val completedIds = progressById.entries.filter { it.value.completed }.map { it.key }.toSet()
+
+        for (recipe in allRecipes) {
+            val key = recipe.outputKey
+            val skill = recipe.skillName
+
+            val max = if (recipe.materials.isEmpty()) 0
+                      else recipe.materials.minOf { (item, needed) ->
+                          (effectiveInventory[item] ?: 0) / needed
+                      }
+
+            val indicators = mutableListOf<QuestIndicator>()
+
+            // 1. Regular Quests
+            for ((id, quest) in gameData.quests) {
+                if (quest.type != "craft" && quest.type != "craft_any") continue
+                val prog = progressById[id]
+                if (prog?.completed == true) continue
+                val progress = prog?.progress ?: 0
+                val remaining = quest.amount - progress
+                if (remaining <= 0) continue
+
+                val matches = when (quest.type) {
+                    "craft"     -> quest.target == key
+                    "craft_any" -> quest.skill == skill && craftAnyTargetMatches(quest.target, recipe)
+                    else        -> false
+                }
+                if (matches) {
+                    val prereqDone = quest.requiresPrevious == null ||
+                            progressById[quest.requiresPrevious]?.completed == true
+                    if (prereqDone) {
+                        val neededCrafts = ceilDiv(remaining, recipe.outputQty)
+                        indicators.add(QuestIndicator(QuestCategory.MAIN, max >= neededCrafts))
+                    }
+                }
+            }
+
+            // 2. Guild Progression Quests
+            for ((id, quest) in gameData.guildQuests) {
+                if (quest.type != "craft" && quest.type != "craft_any") continue
+                val prog = progressById[id]
+                if (prog?.completed == true) continue
+                val rep = flags.guildReputation[quest.guild] ?: 0L
+                if (guildRepo.guildLevel(quest.guild, rep, completedIds) < quest.guildLevelRequired) continue
+                val progress = prog?.progress ?: 0
+                val effectiveAmount = guildRepo.effectiveQuestAmountFromFlags(quest, flags)
+                val remaining = effectiveAmount - progress
+                if (remaining <= 0) continue
+
+                val matches = when (quest.type) {
+                    "craft"     -> quest.target == key
+                    "craft_any" -> quest.guild  == skill
+                    else        -> false
+                }
+                if (matches) {
+                    val neededCrafts = ceilDiv(remaining, recipe.outputQty)
+                    indicators.add(QuestIndicator(QuestCategory.MAIN, max >= neededCrafts))
+                }
+            }
+
+            // 3. Daily Quests
+            for (daily in activeDailies) {
+                val remaining = daily.template.amount - daily.progress
+                if (remaining <= 0) continue
+                val matches = when (daily.template.type) {
+                    "craft"     -> daily.template.target == key
+                    "craft_any" -> daily.template.skill  == skill
+                    else        -> false
+                }
+                if (matches) {
+                    val neededCrafts = ceilDiv(remaining, recipe.outputQty)
+                    indicators.add(QuestIndicator(QuestCategory.DAILY, max >= neededCrafts))
+                }
+            }
+
+            // 4. Weekly Quests
+            for (weekly in activeWeeklies) {
+                val remaining = weekly.template.amount - weekly.progress
+                if (remaining <= 0) continue
+                val matches = when (weekly.template.type) {
+                    "craft"     -> weekly.template.target == key
+                    "craft_any" -> weekly.template.skill  == skill
+                    else        -> false
+                }
+                if (matches) {
+                    val neededCrafts = ceilDiv(remaining, recipe.outputQty)
+                    indicators.add(QuestIndicator(QuestCategory.DAILY, max >= neededCrafts))
+                }
+            }
+
+            // 5. Guild Daily Quests
+            for (id in activeGuildDailyIds) {
+                val template = guildPool[id] ?: continue
+                val progress = flags.guildDailyProgress[id] ?: 0
+                val remaining = template.amount - progress
+                if (remaining <= 0) continue
+                val matches = when (template.type) {
+                    "craft"     -> template.target == key
+                    "craft_any" -> template.guild  == skill
+                    else        -> false
+                }
+                if (matches) {
+                    val neededCrafts = ceilDiv(remaining, recipe.outputQty)
+                    indicators.add(QuestIndicator(QuestCategory.DAILY, max >= neededCrafts))
+                }
+            }
+
+            if (indicators.isNotEmpty()) {
+                result[key] = indicators
+            }
+        }
+        return result
     }
 
     private fun craftAnyTargetMatches(target: String, recipe: CraftableRecipe): Boolean = when (target) {

--- a/app/src/main/kotlin/com/fantasyidler/ui/viewmodel/SkillsViewModel.kt
+++ b/app/src/main/kotlin/com/fantasyidler/ui/viewmodel/SkillsViewModel.kt
@@ -50,6 +50,8 @@ import dagger.hilt.android.qualifiers.ApplicationContext
 // UI State
 // ---------------------------------------------------------------------------
 
+
+
 data class SessionResult(
     val skillName: String,
     val xpGained: Long,
@@ -90,6 +92,7 @@ data class SkillsUiState(
     val skillPrestige: Map<String, Int> = emptyMap(),
     val inventory: Map<String, Int> = emptyMap(),
     val petBoostBySkill: Map<String, Int> = emptyMap(),
+    val activeQuests: Map<String, List<QuestIndicator>> = emptyMap(),
 )
 
 sealed class SheetState {
@@ -145,8 +148,8 @@ class SkillsViewModel @Inject constructor(
         sessionRepo.activeSessionFlow,
         _uiState,
         farmingRepo.observePatches(),
-    ) { player, session, extra, patches ->
-        // Combat sessions are managed by CombatViewModel; hide them here.
+        questRepo.observeProgress(),
+    ) { player, session, extra, patches, questProgress ->
         val nonCombatSession = session?.takeIf { it.skillName != "combat" }
         val now = System.currentTimeMillis()
         val cropsReady = patches.count { it.remainingMs(gameData.crops, now) <= 0 }
@@ -182,6 +185,7 @@ class SkillsViewModel @Inject constructor(
                 petBoostBySkill       = (Skills.GATHERING + Skills.CRAFTING_SKILLS + Skills.SUPPORT + listOf(Skills.AGILITY, Skills.SLAYER))
                     .associateWith { key -> petBoostFor(player.pets, key) }
                     .filterValues { it > 0 },
+                activeQuests          = computeActiveQuests(questProgress, flags, inv),
             )
         }
     }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), SkillsUiState())
@@ -1107,6 +1111,158 @@ class SkillsViewModel @Inject constructor(
         }
 
         return fills.sortedBy { it.qty }
+    }
+
+    private fun computeActiveQuests(
+        questProgress: List<com.fantasyidler.data.model.QuestProgress>,
+        flags: PlayerFlags,
+        inventory: Map<String, Int>,
+    ): Map<String, List<QuestIndicator>> {
+        val result = mutableMapOf<String, MutableList<QuestIndicator>>()
+        val progressById = questProgress.associateBy { it.questId }
+
+        val activeDailies = dailyQuestRepo.getActiveDailyQuests(flags).filter { !it.claimed }
+        val activeWeeklies = weeklyQuestRepo.getActiveWeeklyQuests(flags).filter { !it.claimed }
+        val guildPool = gameData.guildDailyPool.associateBy { it.id }
+        val activeGuildDailyIds = flags.guildDailyIds.filter { it !in flags.guildDailyClaimed }
+        val completedIds = progressById.entries.filter { it.value.completed }.map { it.key }.toSet()
+
+        fun addIndicator(key: String, skill: String, category: QuestCategory, remaining: Int) {
+            val isCompletable = when (skill) {
+                Skills.RUNECRAFTING -> {
+                    val rune = gameData.runes[key]
+                    val cost = rune?.essenceCost ?: 1
+                    val essence = inventory["rune_essence"] ?: 0
+                    (essence / cost) >= remaining
+                }
+                Skills.FIREMAKING -> {
+                    val logKey = when (key) {
+                        "ashes" -> "log"
+                        "oak_ashes" -> "oak_log"
+                        "willow_ashes" -> "willow_log"
+                        "maple_ashes" -> "maple_log"
+                        "yew_ashes" -> "yew_log"
+                        "magic_ashes" -> "magic_log"
+                        "redwood_ashes" -> "redwood_log"
+                        else -> key
+                    }
+                    val logs = inventory[logKey] ?: 0
+                    logs >= remaining
+                }
+                Skills.PRAYER -> {
+                    val bones = inventory[key] ?: 0
+                    bones >= remaining
+                }
+                else -> true
+            }
+            result.getOrPut(key) { mutableListOf() }.add(QuestIndicator(category, isCompletable))
+        }
+
+        fun checkAndAdd(questType: String, questSkill: String, questTarget: String, questAmount: Int, questProgressVal: Int, category: QuestCategory) {
+            val remaining = questAmount - questProgressVal
+            if (remaining <= 0) return
+
+            when (questType) {
+                "gather" -> {
+                    addIndicator(questTarget, questSkill, category, remaining)
+                }
+                "gather_any" -> {
+                    when (questSkill) {
+                        Skills.MINING -> gameData.ores.keys.forEach { addIndicator(it, questSkill, category, remaining) }
+                        Skills.WOODCUTTING -> gameData.trees.keys.forEach { addIndicator(it, questSkill, category, remaining) }
+                        Skills.FISHING -> gameData.fish.keys.forEach { addIndicator(it, questSkill, category, remaining) }
+                    }
+                }
+                "pickpocket" -> {
+                    addIndicator(questTarget, questSkill, category, remaining)
+                }
+                "pickpocket_any" -> {
+                    gameData.thievingNpcs.keys.forEach { addIndicator(it, questSkill, category, remaining) }
+                }
+                "sessions" -> {
+                    if (questSkill == Skills.AGILITY) {
+                        addIndicator(questTarget, questSkill, category, remaining)
+                    }
+                }
+                "burn" -> {
+                    val logToAsh = mapOf(
+                        "log" to "ashes", "oak_log" to "oak_ashes", "willow_log" to "willow_ashes",
+                        "maple_log" to "maple_ashes", "yew_log" to "yew_ashes",
+                        "magic_log" to "magic_ashes", "redwood_log" to "redwood_ashes"
+                    )
+                    val ashKey = logToAsh[questTarget] ?: questTarget
+                    addIndicator(ashKey, questSkill, category, remaining)
+                }
+                "burn_any" -> {
+                    if (questSkill == Skills.FIREMAKING) {
+                        gameData.logs.keys.forEach { logKey ->
+                            val logToAsh = mapOf(
+                                "log" to "ashes", "oak_log" to "oak_ashes", "willow_log" to "willow_ashes",
+                                "maple_log" to "maple_ashes", "yew_log" to "yew_ashes",
+                                "magic_log" to "magic_ashes", "redwood_log" to "redwood_ashes"
+                            )
+                            val ashKey = logToAsh[logKey] ?: logKey
+                            addIndicator(ashKey, questSkill, category, remaining)
+                        }
+                    }
+                }
+                "craft" -> {
+                    if (questSkill == Skills.RUNECRAFTING) {
+                        addIndicator(questTarget, questSkill, category, remaining)
+                    }
+                }
+                "craft_any" -> {
+                    if (questSkill == Skills.RUNECRAFTING) {
+                        gameData.runes.keys.forEach { addIndicator(it, questSkill, category, remaining) }
+                    }
+                }
+                "prayer" -> {
+                    if (questSkill == Skills.PRAYER) {
+                        if (questTarget.isNotEmpty()) {
+                            addIndicator(questTarget, questSkill, category, remaining)
+                        } else {
+                            gameData.bones.keys.forEach { addIndicator(it, questSkill, category, remaining) }
+                        }
+                    }
+                }
+            }
+        }
+
+        for ((id, quest) in gameData.quests) {
+            val prog = progressById[id]
+            if (prog?.completed == true) continue
+            val prereqDone = quest.requiresPrevious == null ||
+                    progressById[quest.requiresPrevious]?.completed == true
+            if (!prereqDone) continue
+
+            checkAndAdd(quest.type, quest.skill, quest.target, quest.amount, prog?.progress ?: 0, QuestCategory.MAIN)
+        }
+
+        for ((id, quest) in gameData.guildQuests) {
+            val prog = progressById[id]
+            if (prog?.completed == true) continue
+            val rep = flags.guildReputation[quest.guild] ?: 0L
+            if (guildRepo.guildLevel(quest.guild, rep, completedIds) < quest.guildLevelRequired) continue
+
+            val effectiveAmount = guildRepo.effectiveQuestAmountFromFlags(quest, flags)
+            checkAndAdd(quest.type, quest.guild, quest.target, effectiveAmount, prog?.progress ?: 0, QuestCategory.MAIN)
+        }
+
+        for (daily in activeDailies) {
+            checkAndAdd(daily.template.type, daily.template.skill, daily.template.target, daily.template.amount, daily.progress, QuestCategory.DAILY)
+        }
+
+        for (weekly in activeWeeklies) {
+            checkAndAdd(weekly.template.type, weekly.template.skill, weekly.template.target, weekly.template.amount, weekly.progress, QuestCategory.DAILY)
+        }
+
+        for (id in activeGuildDailyIds) {
+            val template = guildPool[id] ?: continue
+            val progress = flags.guildDailyProgress[id] ?: 0
+            checkAndAdd(template.type, template.guild, template.target, template.amount, progress, QuestCategory.DAILY)
+        }
+
+        return result
     }
 
     private fun petBoostFor(petsJson: String, skillKey: String): Int {


### PR DESCRIPTION
This PR adds visual indicators next to items in skill selection views to show when there are active quests for them.

Details:
- Shows ⏰ for daily/weekly/guild-daily quests, and 📜 for main/guild progression quests.
- The emojis are faded (38% opacity) if the player does not have enough raw materials in their inventory to complete the quest.