### PR TITLE
Replace modifier.clickable with onClick property to respect internal modifiers

### DIFF
--- a/app/src/main/kotlin/com/fantasyidler/ui/screen/HomeScreen.kt
+++ b/app/src/main/kotlin/com/fantasyidler/ui/screen/HomeScreen.kt
@@ -870,7 +870,10 @@ private fun TownGridCard(
     iconTint: Color = MaterialTheme.colorScheme.onSurfaceVariant,
     badgeCount: Int = 0,
 ) {
-    ElevatedCard(modifier = modifier, onClick = onClick) {
+    ElevatedCard(
+        modifier = modifier,
+        onClick = onClick
+    ) {
         Column(
             modifier            = Modifier.fillMaxWidth().padding(vertical = 12.dp, horizontal = 4.dp),
             horizontalAlignment = Alignment.CenterHorizontally,

--- a/app/src/main/kotlin/com/fantasyidler/ui/screen/HomeScreen.kt
+++ b/app/src/main/kotlin/com/fantasyidler/ui/screen/HomeScreen.kt
@@ -694,7 +694,8 @@ fun HomeScreen(
                     shape    = RoundedCornerShape(16.dp),
                     color    = MaterialTheme.colorScheme.surfaceVariant,
                     modifier = if (eventComplete) Modifier.fillMaxWidth()
-                               else Modifier.fillMaxWidth().clickable { onNavigateToSeasonalEvent() },
+                               else Modifier.fillMaxWidth(),
+                    onClick = onNavigateToSeasonalEvent,
                 ) {
                     Row(
                         modifier = Modifier.padding(12.dp),
@@ -869,7 +870,7 @@ private fun TownGridCard(
     iconTint: Color = MaterialTheme.colorScheme.onSurfaceVariant,
     badgeCount: Int = 0,
 ) {
-    ElevatedCard(modifier = modifier.clickable { onClick() }) {
+    ElevatedCard(modifier = modifier, onClick = onClick) {
         Column(
             modifier            = Modifier.fillMaxWidth().padding(vertical = 12.dp, horizontal = 4.dp),
             horizontalAlignment = Alignment.CenterHorizontally,

--- a/app/src/main/kotlin/com/fantasyidler/ui/screen/ProfileScreen.kt
+++ b/app/src/main/kotlin/com/fantasyidler/ui/screen/ProfileScreen.kt
@@ -557,9 +557,12 @@ private fun SkillGridCard(
     modifier: Modifier = Modifier,
 ) {
     val progress = xpProgressFraction(xp)
-    ElevatedCard(modifier = modifier.clickable { onClick() }) {
+    ElevatedCard(
+        modifier = modifier,
+        onClick = onClick
+    ) {
         Column(
-            modifier            = Modifier.fillMaxWidth().padding(8.dp),
+            modifier = Modifier.fillMaxWidth().padding(8.dp),
             horizontalAlignment = Alignment.CenterHorizontally,
         ) {
             val iconRes = GameStrings.skillIconRes(skillKey)


### PR DESCRIPTION
Click handling was being done via Modifier.clickable, causing the touch effect to  ignore the card's internal modifiers (such as its rounded shape). This change replaces it with the onClick handler so the component can manage its own interactions and correctly apply the touch effect within its shape.