### PR TITLE
Add missing tool translations and map their armory slot labels

### DIFF
--- a/app/src/main/kotlin/com/fantasyidler/ui/screen/ArmoryTab.kt
+++ b/app/src/main/kotlin/com/fantasyidler/ui/screen/ArmoryTab.kt
@@ -379,6 +379,10 @@ private fun slotLabel(slot: String): String = when (slot) {
     "axe"         -> stringResource(R.string.equip_slot_axe)
     "fishing_rod" -> stringResource(R.string.equip_slot_fishing_rod)
     "hoe"         -> stringResource(R.string.equip_slot_hoe)
+    "frying_pan"  -> stringResource(R.string.equip_slot_frying_pan)
+    "grappling_hook" -> stringResource(R.string.equip_slot_grappling_hook)
+    "hammer"      -> stringResource(R.string.equip_slot_hammer)
+    "tinderbox"   -> stringResource(R.string.equip_slot_tinderbox)
     else          -> slot.replaceFirstChar { it.uppercase() }
 }
 

--- a/app/src/main/res/values-de/strings_game.xml
+++ b/app/src/main/res/values-de/strings_game.xml
@@ -106,4 +106,8 @@
     <string name="equip_slot_axe">Axt</string>
     <string name="equip_slot_fishing_rod">Angelrute</string>
     <string name="equip_slot_hoe">Hoe</string>
+    <string name="equip_slot_frying_pan">Bratpfanne</string>
+    <string name="equip_slot_grappling_hook">Greifhaken</string>
+    <string name="equip_slot_hammer">Hammer</string>
+    <string name="equip_slot_tinderbox">Zunderbüchse</string>
 </resources>

--- a/app/src/main/res/values-es/strings_game.xml
+++ b/app/src/main/res/values-es/strings_game.xml
@@ -106,4 +106,8 @@
     <string name="equip_slot_axe">Hacha</string>
     <string name="equip_slot_fishing_rod">Caña de pescar</string>
     <string name="equip_slot_hoe">Hoe</string>
+    <string name="equip_slot_frying_pan">Sartén</string>
+    <string name="equip_slot_grappling_hook">Garfio de escalada</string>
+    <string name="equip_slot_hammer">Martillo</string>
+    <string name="equip_slot_tinderbox">Yesquero</string>
 </resources>

--- a/app/src/main/res/values-fr/strings_game.xml
+++ b/app/src/main/res/values-fr/strings_game.xml
@@ -107,4 +107,8 @@
     <string name="equip_slot_axe">Hache</string>
     <string name="equip_slot_fishing_rod">Canne à pêche</string>
     <string name="equip_slot_hoe">Houe</string>
+    <string name="equip_slot_frying_pan">Poêle à frire</string>
+    <string name="equip_slot_grappling_hook">Grappin</string>
+    <string name="equip_slot_hammer">Marteau</string>
+    <string name="equip_slot_tinderbox">Briquet à amadou</string>
 </resources>

--- a/app/src/main/res/values-in/strings_game.xml
+++ b/app/src/main/res/values-in/strings_game.xml
@@ -106,4 +106,8 @@
     <string name="equip_slot_axe">Kapak</string>
     <string name="equip_slot_fishing_rod">Joran Pancing</string>
     <string name="equip_slot_hoe">Cangkul</string>
+    <string name="equip_slot_frying_pan">Wajan</string>
+    <string name="equip_slot_grappling_hook">Kait bergulat</string>
+    <string name="equip_slot_hammer">Palu</string>
+    <string name="equip_slot_tinderbox">Kotak api</string>
 </resources>

--- a/app/src/main/res/values-it/strings_game.xml
+++ b/app/src/main/res/values-it/strings_game.xml
@@ -106,4 +106,8 @@
     <string name="equip_slot_axe">Ascia</string>
     <string name="equip_slot_fishing_rod">Canna da pesca</string>
     <string name="equip_slot_hoe">Zappa</string>
+    <string name="equip_slot_frying_pan">Padella</string>
+    <string name="equip_slot_grappling_hook">Rampino</string>
+    <string name="equip_slot_hammer">Martello</string>
+    <string name="equip_slot_tinderbox">Scatola per l\'esca</string>
 </resources>

--- a/app/src/main/res/values-nl/strings_game.xml
+++ b/app/src/main/res/values-nl/strings_game.xml
@@ -106,4 +106,8 @@
     <string name="equip_slot_axe">Bijl</string>
     <string name="equip_slot_fishing_rod">Hengel</string>
     <string name="equip_slot_hoe">Schoffel</string>
+    <string name="equip_slot_frying_pan">Koekenpan</string>
+    <string name="equip_slot_grappling_hook">Grijphaak</string>
+    <string name="equip_slot_hammer">Hamer</string>
+    <string name="equip_slot_tinderbox">Tondeldoos</string>
 </resources>

--- a/app/src/main/res/values-pl/strings_game.xml
+++ b/app/src/main/res/values-pl/strings_game.xml
@@ -106,4 +106,8 @@
     <string name="equip_slot_axe">Siekiera</string>
     <string name="equip_slot_fishing_rod">Wędka</string>
     <string name="equip_slot_hoe">Motyka</string>
+    <string name="equip_slot_frying_pan">Patelnia</string>
+    <string name="equip_slot_grappling_hook">Hak wspinaczkowy</string>
+    <string name="equip_slot_hammer">Młot</string>
+    <string name="equip_slot_tinderbox">Krzesiwo</string>
 </resources>

--- a/app/src/main/res/values-pt-rBR/strings_game.xml
+++ b/app/src/main/res/values-pt-rBR/strings_game.xml
@@ -106,4 +106,8 @@
     <string name="equip_slot_axe">Machado</string>
     <string name="equip_slot_fishing_rod">Vara de Pesca</string>
     <string name="equip_slot_hoe">Enxada</string>
+    <string name="equip_slot_frying_pan">Frigideira</string>
+    <string name="equip_slot_grappling_hook">Gancho de escalada</string>
+    <string name="equip_slot_hammer">Martelo</string>
+    <string name="equip_slot_tinderbox">Caixa de isca</string>
 </resources>

--- a/app/src/main/res/values-ru/strings_game.xml
+++ b/app/src/main/res/values-ru/strings_game.xml
@@ -106,4 +106,8 @@
     <string name="equip_slot_axe">Топор</string>
     <string name="equip_slot_fishing_rod">Удочка</string>
     <string name="equip_slot_hoe">Мотыга</string>
+    <string name="equip_slot_frying_pan">Сковорода</string>
+    <string name="equip_slot_grappling_hook">Крюк-кошка</string>
+    <string name="equip_slot_hammer">Молот</string>
+    <string name="equip_slot_tinderbox">Огниво</string>
 </resources>

--- a/app/src/main/res/values-tr/strings_game.xml
+++ b/app/src/main/res/values-tr/strings_game.xml
@@ -106,4 +106,8 @@
     <string name="equip_slot_axe">Balta</string>
     <string name="equip_slot_fishing_rod">Olta</string>
     <string name="equip_slot_hoe">Hoe</string>
+    <string name="equip_slot_frying_pan">Tava</string>
+    <string name="equip_slot_grappling_hook">Kanca</string>
+    <string name="equip_slot_hammer">Çekiç</string>
+    <string name="equip_slot_tinderbox">Çakmaktaşı</string>
 </resources>

--- a/app/src/main/res/values/strings_game.xml
+++ b/app/src/main/res/values/strings_game.xml
@@ -106,4 +106,8 @@
     <string name="equip_slot_axe">Axe</string>
     <string name="equip_slot_fishing_rod">Fishing Rod</string>
     <string name="equip_slot_hoe">Hoe</string>
+    <string name="equip_slot_frying_pan">Frying Pan</string>
+    <string name="equip_slot_grappling_hook">Grappling Hook</string>
+    <string name="equip_slot_hammer">Hammer</string>
+    <string name="equip_slot_tinderbox">Tinderbox</string>
 </resources>


### PR DESCRIPTION
- Adds the missing translations for the new tool equipment slots

Note: it seems the Gear tab and the Armory tab use different fallbacks for their slot names, maybe something that needs to be addressed in a separate PR? 

I am also unsure how to handle adding new translation keys, are we supposed to wait for a native speaker to add the missing translations? Or is it okay to use a translation tool to fill the values and wait for a native speaker to correct those if need be?