### PR TITLE
Fix #942: Mercantile and Thieving XP displays on home tab queue

### DIFF
--- a/app/src/main/kotlin/com/fantasyidler/ui/viewmodel/MercantileViewModel.kt
+++ b/app/src/main/kotlin/com/fantasyidler/ui/viewmodel/MercantileViewModel.kt
@@ -3,16 +3,19 @@ package com.fantasyidler.ui.viewmodel
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.fantasyidler.data.json.TradeRouteData
+import com.fantasyidler.data.json.XpRange
 import com.fantasyidler.data.model.PlayerFlags
 import com.fantasyidler.data.model.QueuedAction
 import com.fantasyidler.data.model.SessionFrame
 import com.fantasyidler.data.model.Skills
+import com.fantasyidler.repository.ChurchRepository
 import com.fantasyidler.repository.GameDataRepository
 import com.fantasyidler.repository.PlayerRepository
 import com.fantasyidler.repository.QueuedSessionStarter
 import com.fantasyidler.repository.SessionRepository
 import com.fantasyidler.simulator.MercantileSimulator
 import com.fantasyidler.simulator.SkillSimulator
+import com.fantasyidler.simulator.XpTable
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
@@ -99,11 +102,24 @@ class MercantileViewModel @Inject constructor(
                     _extra.update { it.copy(snackbarMessage = context.getString(R.string.mercantile_not_enough_coins, route.coinCost.toString())) }
                     return@launch
                 }
+                val startXp = xp[Skills.MERCANTILE] ?: 0L
+                val currentLevel = XpTable.levelForXp(startXp)
+                val sortedKeys = route.xpRanges.keys.mapNotNull { it.toIntOrNull() }.sorted()
+                val matchedKey = sortedKeys.lastOrNull { it <= currentLevel } ?: sortedKeys.firstOrNull()
+                val xpRange = matchedKey?.let { route.xpRanges[it.toString()] } ?: XpRange(1, 1)
+
+                val expectedRawXp = (xpRange.min + xpRange.max) * 30L
+                val xpQueueMult = (if (mercFlags.xpBoostExpiresAt > System.currentTimeMillis()) 2.0 else 1.0) * ChurchRepository.xpMultiplier(mercFlags)
+                val prestigeLevel = mercFlags.skillPrestige[Skills.MERCANTILE] ?: 0
+                val prestigeMult = 1.0 + prestigeLevel * 0.10
+                val estimatedXpGain = (expectedRawXp * xpQueueMult * prestigeMult).toLong()
+
                 val enqueued = playerRepo.enqueueAction(
                     QueuedAction(
                         skillName           = Skills.MERCANTILE,
                         activityKey         = routeId,
                         skillDisplayName    = "Mercantile",
+                        estimatedXpGain     = estimatedXpGain,
                         estimatedDurationMs = SkillSimulator.sessionDurationMs(agilityLevel, mercFlags.skillPrestige[Skills.AGILITY] ?: 0),
                         coinRefund          = route.coinCost.toLong(),
                     )

--- a/app/src/main/kotlin/com/fantasyidler/ui/viewmodel/SkillsViewModel.kt
+++ b/app/src/main/kotlin/com/fantasyidler/ui/viewmodel/SkillsViewModel.kt
@@ -661,11 +661,23 @@ class SkillsViewModel @Inject constructor(
                 val player = playerRepo.getOrCreatePlayer()
                 val agility = (json.decodeFromString<Map<String, Int>>(player.skillLevels))[Skills.AGILITY] ?: 1
                 val thievingFlags = try { json.decodeFromString<PlayerFlags>(player.flags) } catch (_: Exception) { PlayerFlags() }
+                val levels = json.decodeFromString<Map<String, Int>>(player.skillLevels)
+                val thievingLevel = levels[Skills.THIEVING] ?: 1
+                val successChance = (0.40 + (thievingLevel - npc.levelRequired) * 0.02).coerceIn(0.10, 0.95)
+                val petBoostPct = petBoostFor(player.pets, Skills.THIEVING)
+                val petBoostedXp = if (petBoostPct > 0) (npc.baseXp * (1.0 + petBoostPct / 100.0)).toInt() else npc.baseXp
+                val expectedXp = 60.0 * (successChance / (2.0 - successChance)) * petBoostedXp
+                val xpQueueMult = (if (thievingFlags.xpBoostExpiresAt > System.currentTimeMillis()) 2.0 else 1.0) * ChurchRepository.xpMultiplier(thievingFlags)
+                val prestigeLevel = thievingFlags.skillPrestige[Skills.THIEVING] ?: 0
+                val prestigeMult = 1.0 + prestigeLevel * 0.10
+                val estimatedXpGain = (expectedXp * xpQueueMult * prestigeMult).toLong()
+
                 val enqueued = playerRepo.enqueueAction(
                     QueuedAction(
                         skillName           = Skills.THIEVING,
                         activityKey         = npcKey,
                         skillDisplayName    = "Thieving",
+                        estimatedXpGain     = estimatedXpGain,
                         estimatedDurationMs = SkillSimulator.sessionDurationMs(agility, thievingFlags.skillPrestige[Skills.AGILITY] ?: 0),
                     )
                 )


### PR DESCRIPTION
Resolves #942. Calculates and populates estimated XP gains for enqueued Mercantile and Thieving sessions so they display correctly on the Home tab's queue list.