### PR TITLE
Fix #944: Change potion sequence row chunk size to 4 to prevent squeezing

### DIFF
--- a/app/src/main/kotlin/com/fantasyidler/ui/screen/CarnivalScreen.kt
+++ b/app/src/main/kotlin/com/fantasyidler/ui/screen/CarnivalScreen.kt
@@ -569,10 +569,11 @@ private fun PotionSequenceCard(gameState: ActiveGameState, difficulty: Difficult
                     verticalArrangement = Arrangement.spacedBy(8.dp),
                 ) {
                     Text(stringResource(R.string.carnival_sequence_watch), style = MaterialTheme.typography.bodyMedium, fontWeight = FontWeight.SemiBold)
-                    seq.chunked(6).forEachIndexed { rowIdx, chunk ->
+                    val chunkSize = 4
+                    seq.chunked(chunkSize).forEachIndexed { rowIdx, chunk ->
                         Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
                             chunk.forEachIndexed { localIdx, colorIdx ->
-                                val i = rowIdx * 6 + localIdx
+                                val i = rowIdx * chunkSize + localIdx
                                 Box(
                                     modifier = Modifier
                                         .size(48.dp)


### PR DESCRIPTION
Resolves #944. Replaces the hardcoded row chunk size of 6 with 4 when displaying the active potion sequence, reducing row width from 328dp to 216dp so they fit comfortably on narrower screens without squeezing the last potion.