### PR TITLE
Fix #946: Label seasonal event combat section as Dungeon instead of Expedition

### DIFF
--- a/app/src/main/kotlin/com/fantasyidler/ui/screen/SeasonalEventScreen.kt
+++ b/app/src/main/kotlin/com/fantasyidler/ui/screen/SeasonalEventScreen.kt
@@ -166,7 +166,7 @@ fun SeasonalEventScreen(
             }
 
             if ("expedition" in event.pillars && event.expeditionDungeonKey != null) {
-                SectionCard(title = stringResource(R.string.seasonal_expedition_title)) {
+                SectionCard(title = stringResource(R.string.label_dungeon)) {
                     Text(viewModel.dungeonDisplayName(event.expeditionDungeonKey), style = MaterialTheme.typography.bodyLarge)
                     Spacer(Modifier.height(8.dp))
                     Button(onClick = { onNavigateToExpedition(event.expeditionDungeonKey) }, modifier = Modifier.fillMaxWidth()) {


### PR DESCRIPTION
Resolves #946. Replaces the hardcoded seasonal_expedition_title with label_dungeon in SeasonalEventScreen.kt so that combat sections (like Sunspire) are correctly labeled as Dungeons instead of Expeditions.