### PR TITLE
Fix #941: Add Stone to marketplace buy category

### DIFF
--- a/app/src/main/assets/data/marketplace.json
+++ b/app/src/main/assets/data/marketplace.json
@@ -15,6 +15,12 @@
         "price": 5,
         "stock": "unlimited"
       },
+      "stone": {
+        "display_name": "Stone",
+        "description": "A block of stone. Used for construction.",
+        "price": 8,
+        "stock": "unlimited"
+      },
       "rune_essence": {
         "display_name": "Rune Essence",
         "description": "Raw magical essence used to craft runes.",


### PR DESCRIPTION
Resolves #941. Adds Stone to the buy section of the Marketplace under the Ores & Materials category (unlimited stock, base price of 8 coins) so players can purchase it instead of only being able to mine it.