### PR TITLE
Add pull request templates and fix wiki_error label

### DIFF
--- a/.github/ISSUE_TEMPLATE/wiki_error.yml
+++ b/.github/ISSUE_TEMPLATE/wiki_error.yml
@@ -1,6 +1,6 @@
 name: Wiki Error
 description: Something in the wiki is incorrect/needs expanding
-labels: ["wiki"]
+labels: ["documentation"]
 body:
   - type: checkboxes
     id: preflight

--- a/.github/PULL_REQUEST_TEMPLATE/bug_fix.md
+++ b/.github/PULL_REQUEST_TEMPLATE/bug_fix.md
@@ -1,0 +1,33 @@
+## Before submitting
+
+- [ ] I've tested the final changes (with unit tests) to ensure the bug is fixed
+- [ ] I have pulled and merged the latest changes from the repository
+
+## Related issue(s)
+
+<!-- Prepend with "Fixes" if this should close the issue, e.g. Fixes #283, Relates to #284 -->
+
+
+
+## Summary
+
+<!-- Short summary of the pull request and what it changes, e.g. Ensures that the XP gains for quests are correctly displayed -->
+
+
+
+## Changelog
+
+<!-- Concise list of changes, e.g.
+- Fix time-slot bug causing XP gains to not show in notification banner
+- Added ellipsis for quests XP gains exceeding screen width
+-->
+
+-
+
+## Additional work
+
+<!-- Any follow-up still needed (aim to minimise) -->
+
+
+
+## Anything else?

--- a/.github/PULL_REQUEST_TEMPLATE/new_feature.md
+++ b/.github/PULL_REQUEST_TEMPLATE/new_feature.md
@@ -1,0 +1,33 @@
+## Before submitting
+
+- [ ] I've tested the final changes (with unit tests) to ensure the feature works
+- [ ] I have pulled and merged the latest changes from the repository
+
+## Related discussion/issue(s)
+
+<!-- e.g. Implements some features described in #294 -->
+
+
+
+## Summary
+
+<!-- Short summary of the pull request and what it changes, e.g. Adds a new quest indicator to all skills -->
+
+
+
+## Changelog
+
+<!-- Concise list of changes, e.g.
+- Added quest indicators to all individual skills
+- Adjusted the QuestRepository class to...
+-->
+
+-
+
+## Additional work
+
+<!-- Any follow-up still needed (aim to minimise) -->
+
+
+
+## Anything else?

--- a/.github/PULL_REQUEST_TEMPLATE/translations.md
+++ b/.github/PULL_REQUEST_TEMPLATE/translations.md
@@ -1,0 +1,23 @@
+## Before submitting
+
+- [ ] I have pulled and merged the latest changes from the repository
+
+## Language(s)
+
+<!-- Which language(s) this PR adds translations for, e.g. German -->
+
+
+
+## Summary
+
+<!-- Short summary of the translations that were added, e.g. Translated strings relating to the guild hall -->
+
+
+
+## Detailed changes
+
+<!-- Optional: more detail on the changes made -->
+
+
+
+## Anything else?

--- a/.github/PULL_REQUEST_TEMPLATE/wiki_update.md
+++ b/.github/PULL_REQUEST_TEMPLATE/wiki_update.md
@@ -1,0 +1,40 @@
+## Before submitting
+
+- [ ] I have pulled and merged the latest changes from the repository
+
+## Related issue/discussion(s)
+
+<!-- Prepend issues with "Fixes" if this should close them, e.g. Relates to #304, Fixes #305 -->
+
+
+
+## Summary
+
+<!-- Short summary of the pull request and what it changes, e.g. Adds new boss pages to the wiki and missing boss pages to the first page -->
+
+
+
+## Affected pages
+
+<!-- Links to changed pages. Dynamically-generated pages don't need every URL listed, e.g.
+- https://idlefantasy.tristinbaker.xyz/...
+-->
+
+-
+
+## Changelog
+
+<!-- Concise list of changes, e.g.
+- Added dynamically-generated boss pages
+- Linked bosses to associated pages in the combat page
+-->
+
+-
+
+## Additional work
+
+<!-- Any follow-up still needed (aim to minimise) -->
+
+
+
+## Anything else?

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,29 @@
+## Before submitting
+
+- [ ] I've tested any changes with appropriate tests (eg. Unit tests, validation scripts)
+- [ ] I've pulled and merged the latest changes from the repository
+
+## Summary
+
+<!-- Short summary of the pull request and what it changes -->
+
+
+
+## Related issue(s) or discussion(s)
+
+<!-- Prepend issues with "Fixes" if this should close the issue, e.g. Fixes #283, Relates to #284 -->
+
+
+
+## Changelog
+
+<!-- Concise list of changes, e.g.
+- Fix time-slot bug causing XP gains to not show in notification banner
+- Added ellipsis for quests XP gains exceeding screen width
+-->
+
+-
+
+
+## Anything else?
+


### PR DESCRIPTION
## Before submitting

- [x] I've tested any changes with appropriate tests (eg. Unit tests, validation scripts)
- [x] I've pulled and merged the latest changes from the repository

## Summary

<!-- Short summary of the pull request and what it changes -->

This pull request adds a new default pull request template and also some specialised templates. The main goal being to streamline pull requests and save having to type out any headings, etc.

I originally created some pull request YAML forms similar to the issue forms on the assumption that GitHub would have these with the goal of streamlining pull requests like they do for issues but it seemed GitHub only supports using markdown templates which are not as good unfortunately and only supports use of a single generic template when creating pull requests without a special URL parameter.

## Related issue(s) or discussion(s)

<!-- Prepend issues with "Fixes" if this should close the issue, e.g. Fixes #283, Relates to #284 -->

Relates to the additional work described in #920.

## Changelog

<!-- Concise list of changes, e.g.
- Fix time-slot bug causing XP gains to not show in notification banner
- Added ellipsis for quests XP gains exceeding screen width
-->

- Adds a default `pull_request_template.md` used by default when creating a pull request
- Add custom pull request templates for individual situations like bug fixes, translations, etc, although these require use of a `template=<template_name>` URL parameter so they may not be used often
- Change "wiki" label to "documentation" for the wiki issue form aligning with existing labels


## Anything else

Btw, this pull request uses the default template so you can see what it looks like and see if there's any changes that should be made/if it's desired.