### PR TITLE
Add option to show/hide Stats Card on Home screen

### DIFF
--- a/app/src/main/kotlin/com/fantasyidler/data/model/PlayerModels.kt
+++ b/app/src/main/kotlin/com/fantasyidler/data/model/PlayerModels.kt
@@ -118,6 +118,8 @@ data class PlayerFlags(
     @SerialName("show_seasonal_events") val showSeasonalEvents: Boolean = true,
     /** Whether to show the character sprite viewer on the home screen. */
     @SerialName("show_character_viewer") val showCharacterViewer: Boolean = true,
+    /** Whether to show the player stats card (combat level, total level, coins) on the home screen. */
+    @SerialName("show_stats_card") val showStatsCard: Boolean = true,
     /** Whether the Town grid (Shop, Inn, Guild, etc.) on the home screen is shown as a collapsible card. */
     @SerialName("collapsible_town_grid") val collapsibleTownGrid: Boolean = true,
     /** Persisted expand/collapse state of the Town grid card, when collapsibleTownGrid is on. */

--- a/app/src/main/kotlin/com/fantasyidler/ui/screen/HomeScreen.kt
+++ b/app/src/main/kotlin/com/fantasyidler/ui/screen/HomeScreen.kt
@@ -84,6 +84,10 @@ import com.fantasyidler.data.model.HiredWorker
 import com.fantasyidler.data.model.QueuedAction
 import com.fantasyidler.data.model.SkillSession
 import com.fantasyidler.data.model.WorkerTier
+import com.fantasyidler.data.json.BlessingType
+import com.fantasyidler.repository.ChurchRepository
+import com.fantasyidler.ui.viewmodel.combatLevelFrom
+import com.fantasyidler.ui.viewmodel.totalLevelFrom
 import com.fantasyidler.ui.theme.GoldPrimary
 import com.fantasyidler.ui.viewmodel.HomeViewModel
 import com.fantasyidler.ui.viewmodel.SessionSummary
@@ -585,6 +589,101 @@ fun HomeScreen(
                 }
             }
 
+            if (state.showStatsCard) {
+                Spacer(Modifier.height(8.dp))
+                // ── Stats card ──────────────────────────────────────────────
+                Surface(
+                    shape  = RoundedCornerShape(16.dp),
+                    color  = MaterialTheme.colorScheme.surfaceVariant,
+                    modifier = Modifier.fillMaxWidth(),
+                ) {
+                    Column(Modifier.padding(16.dp)) {
+                        Text(
+                            text  = stringResource(R.string.label_player_stats),
+                            style = MaterialTheme.typography.labelMedium,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                        Spacer(Modifier.height(8.dp))
+
+                        Row(
+                            modifier              = Modifier.fillMaxWidth(),
+                            horizontalArrangement = Arrangement.SpaceBetween,
+                        ) {
+                            StatItem(
+                                label = stringResource(R.string.label_combat_level),
+                                value = combatLevelFrom(state.skillLevels).toString(),
+                            )
+                            StatItem(
+                                label = stringResource(R.string.label_total_level),
+                                value = totalLevelFrom(state.skillLevels).toString(),
+                            )
+                            StatItem(
+                                label = stringResource(R.string.label_coins),
+                                value = state.coins.formatCoins(),
+                                valueColor = GoldPrimary,
+                            )
+                        }
+
+                        val blessingActive = state.activeBlessingKey.isNotEmpty() && state.activeBlessingRemainingMs > 0
+                        if (blessingActive) {
+                            val context = LocalContext.current
+                            val nameResId = context.resources.getIdentifier(
+                                "blessing_${state.activeBlessingKey}_name", "string", context.packageName,
+                            )
+                            val blessingName = if (nameResId != 0) stringResource(nameResId) else state.activeBlessingKey
+                            val blessingData = ChurchRepository.ALL_BLESSINGS.firstOrNull { it.key == state.activeBlessingKey }
+                            val boostDesc = blessingData?.let { b ->
+                                when (b.type) {
+                                    BlessingType.XP      -> "${b.magnitude}x XP"
+                                    BlessingType.DEFENSE -> "+${b.magnitude.toInt()} DEF"
+                                    BlessingType.COINS   -> "+${(b.magnitude * 100).toInt()}% coins"
+                                }
+                            }
+                            val timeLeft = state.activeBlessingRemainingMs.formatDurationMs()
+                            val blessingText = if (boostDesc != null) "$blessingName ($boostDesc) - $timeLeft"
+                                              else "$blessingName - $timeLeft"
+                            Spacer(Modifier.height(8.dp))
+                            HorizontalDivider()
+                            Spacer(Modifier.height(8.dp))
+                            Row(verticalAlignment = Alignment.CenterVertically) {
+                                Icon(
+                                    imageVector        = Icons.Filled.Star,
+                                    contentDescription = null,
+                                    tint               = GoldPrimary,
+                                    modifier           = Modifier.size(14.dp),
+                                )
+                                Spacer(Modifier.width(4.dp))
+                                Text(
+                                    text  = blessingText,
+                                    style = MaterialTheme.typography.labelSmall,
+                                    color = GoldPrimary,
+                                )
+                            }
+                        }
+
+                        if (state.xpBoostRemainingMs > 0) {
+                            Spacer(Modifier.height(8.dp))
+                            HorizontalDivider()
+                            Spacer(Modifier.height(8.dp))
+                            Row(verticalAlignment = Alignment.CenterVertically) {
+                                Icon(
+                                    imageVector        = Icons.Filled.Star,
+                                    contentDescription = null,
+                                    tint               = MaterialTheme.colorScheme.tertiary,
+                                    modifier           = Modifier.size(14.dp),
+                                )
+                                Spacer(Modifier.width(4.dp))
+                                Text(
+                                    text  = stringResource(R.string.home_xp_boost_active, state.xpBoostRemainingMs.formatDurationMs()),
+                                    style = MaterialTheme.typography.labelSmall,
+                                    color = MaterialTheme.colorScheme.tertiary,
+                                )
+                            }
+                        }
+                    }
+                }
+            }
+
             // ── Town grid ───────────────────────────────────────────────
             val churchTint = if (state.activeBlessingKey.isNotEmpty() && state.activeBlessingRemainingMs > 0)
                 GoldPrimary else MaterialTheme.colorScheme.onSurfaceVariant
@@ -854,3 +953,25 @@ private fun TownGridCard(
         }
     }
 }
+
+@Composable
+private fun StatItem(
+    label: String,
+    value: String,
+    valueColor: androidx.compose.ui.graphics.Color = MaterialTheme.colorScheme.onSurface,
+) {
+    Column(horizontalAlignment = Alignment.CenterHorizontally) {
+        Text(
+            text  = value,
+            style = MaterialTheme.typography.titleLarge,
+            fontWeight = FontWeight.Bold,
+            color = valueColor,
+        )
+        Text(
+            text  = label,
+            style = MaterialTheme.typography.labelSmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+    }
+}
+

--- a/app/src/main/kotlin/com/fantasyidler/ui/screen/SettingsScreen.kt
+++ b/app/src/main/kotlin/com/fantasyidler/ui/screen/SettingsScreen.kt
@@ -86,6 +86,7 @@ fun SettingsScreen(
     val showSeasonalEvents     by viewModel.showSeasonalEvents.collectAsState()
     val collapsibleTownGrid    by viewModel.collapsibleTownGrid.collectAsState()
     val showCharacterViewer    by viewModel.showCharacterViewer.collectAsState()
+    val showStatsCard          by viewModel.showStatsCard.collectAsState()
     val profileLayout          by viewModel.profileLayout.collectAsState()
     val backupFolderUri  by viewModel.backupFolderUri.collectAsState()
     val backupFrequency  by viewModel.backupFrequency.collectAsState()
@@ -371,6 +372,16 @@ fun SettingsScreen(
                     Switch(
                         checked         = showCharacterViewer,
                         onCheckedChange = { viewModel.setShowCharacterViewer(it) },
+                    )
+                }
+            )
+            SettingsRow(
+                title    = stringResource(R.string.settings_show_stats_card),
+                subtitle = stringResource(R.string.settings_show_stats_card_desc),
+                trailing = {
+                    Switch(
+                        checked         = showStatsCard,
+                        onCheckedChange = { viewModel.setShowStatsCard(it) },
                     )
                 }
             )

--- a/app/src/main/kotlin/com/fantasyidler/ui/viewmodel/HomeViewModel.kt
+++ b/app/src/main/kotlin/com/fantasyidler/ui/viewmodel/HomeViewModel.kt
@@ -125,6 +125,7 @@ data class HomeUiState(
     val characterBeardStyle: Int = 0,
     val characterBeardColor: String = "a",
     val showCharacterViewer: Boolean = true,
+    val showStatsCard: Boolean = true,
     val equippedTitle: String? = null,
     /** Resolved, localized title name (e.g. "Master Smith"), or null if none equipped. */
     val titleName: String? = null,
@@ -307,6 +308,7 @@ class HomeViewModel @Inject constructor(
                 characterBeardStyle = flags.characterBeardStyle,
                 characterBeardColor = flags.characterBeardColor,
                 showCharacterViewer = flags.showCharacterViewer,
+                showStatsCard       = flags.showStatsCard,
                 equippedTitle       = flags.equippedTitle,
                 titleName           = titleRepo.displayName(context, flags.equippedTitle, flags),
                 sessionQueue        = flags.sessionQueue,

--- a/app/src/main/kotlin/com/fantasyidler/ui/viewmodel/SettingsViewModel.kt
+++ b/app/src/main/kotlin/com/fantasyidler/ui/viewmodel/SettingsViewModel.kt
@@ -112,6 +112,14 @@ class SettingsViewModel @Inject constructor(
         }
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), true)
 
+    val showStatsCard: StateFlow<Boolean> = playerRepo.playerFlow
+        .map { player ->
+            if (player == null) return@map true
+            try { json.decodeFromString<PlayerFlags>(player.flags).showStatsCard }
+            catch (_: Exception) { true }
+        }
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), true)
+
     val profileLayout: StateFlow<String> = playerRepo.playerFlow
         .map { player ->
             if (player == null) return@map "rail"
@@ -159,6 +167,13 @@ class SettingsViewModel @Inject constructor(
         viewModelScope.launch {
             val flags = playerRepo.getFlags()
             playerRepo.updateFlags(flags.copy(showCharacterViewer = enabled))
+        }
+    }
+
+    fun setShowStatsCard(enabled: Boolean) {
+        viewModelScope.launch {
+            val flags = playerRepo.getFlags()
+            playerRepo.updateFlags(flags.copy(showStatsCard = enabled))
         }
     }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -285,6 +285,8 @@
     <string name="settings_collapsible_town_grid_desc">Show the Town section (Shop, Inn, Guild, etc.) as a card you can collapse on the home screen</string>
     <string name="settings_character_viewer">Character Viewer</string>
     <string name="settings_character_viewer_desc">Show your character sprite on the home screen</string>
+    <string name="settings_show_stats_card">Stats Card</string>
+    <string name="settings_show_stats_card_desc">Show the player stats card (Combat Level, Total Level, Coins) on the home screen</string>
     <string name="label_no_sessions_yet">No sessions completed yet.</string>
 
     <!-- ===== CombatScreen ===== -->


### PR DESCRIPTION
References discussion #979. This PR adds a toggle option in Settings to show or hide the Player Stats Card (Combat Level, Total Level, Coins, and active Church Blessing) on the Home screen. This restores the stats view for players who preferred it while keeping the screen clean for others, defaulting to enabled.