### PR TITLE
Fix German translation for quest_demon_slayer_1_objective and quest_d…

### DIFF
--- a/app/src/main/res/values-de/strings_quests.xml
+++ b/app/src/main/res/values-de/strings_quests.xml
@@ -195,9 +195,9 @@
     <string name="quest_orc_slayer_2_name">Ork-Jäger II</string>
     <string name="quest_orc_slayer_2_objective">Besiegt 50 Ork-Krieger</string>
     <string name="quest_demon_slayer_1_name">Dämonen-Jäger I</string>
-    <string name="quest_demon_slayer_1_objective">Besiegt 20 Kleine Dämonen</string>
+    <string name="quest_demon_slayer_1_objective">Besiegt den Dämonenkönig</string>
     <string name="quest_demon_slayer_2_name">Dämonen-Jäger II</string>
-    <string name="quest_demon_slayer_2_objective">Besiegt 40 Kleine Dämonen</string>
+    <string name="quest_demon_slayer_2_objective">Besiegt den Dämonenkönig 5 Mal</string>
     <string name="quest_demon_slayer_3_name">Dämonen-Jäger III</string>
     <string name="quest_demon_slayer_3_objective">Besiegt den Dämonenkönig 25 Mal</string>
     <string name="quest_dragon_slayer_1_name">Drachen-Jäger I</string>


### PR DESCRIPTION
## Before submitting

- [X] I've tested any changes with appropriate tests (eg. Unit tests, validation scripts)
- [X] I've pulled and merged the latest changes from the repository

## Summary

German translation: Fixes wrong translation for `quest_demon_slayer_1_objective` and `quest_demon_slayer_2_objective`, as described in araccaine/IdleFantasy-german-i18n#7


## Related issue(s) or discussion(s)

Fixes araccaine/IdleFantasy-german-i18n#7

## Changelog

- Fixes wrong German translation for quest objectives of Demon Slayer 1 and 2 