### PR TITLE
Adds a new combat wiki page and adds some minor fixes

### DIFF
--- a/.github/ISSUE_TEMPLATE/wiki_error.yml
+++ b/.github/ISSUE_TEMPLATE/wiki_error.yml
@@ -26,7 +26,7 @@ body:
     id: page_url
     attributes:
       label: Page URL
-      description: Which page is having issues? Leave as N/A for missing pages. If there are multiple affected pages, list each of them here or in the description
+      description: Which page is having issues? If there are multiple affected pages, list each of them here or in the description
       placeholder: "https://idlefantasy.tristinbaker.xyz/..."
     validations:
       required: true
@@ -59,5 +59,5 @@ body:
     id: additional
     attributes:
       label: Anything else?
-      description: Screenshots of the game or information about your game state could be helpful
+      description: Screenshots of the game or information about your game state could be helpful if relevant
 

--- a/.github/ISSUE_TEMPLATE/wiki_error.yml
+++ b/.github/ISSUE_TEMPLATE/wiki_error.yml
@@ -11,7 +11,7 @@ body:
           required: true
         - label: This relates to the latest version of the game
           required: true
-        - label: _(Optional)_ I would like to fix this myself (Thanks! See [how to get started](https://idlefantasy.tristinbaker.xyz/getting_started_wiki.html)
+        - label: _(Optional)_ I would like to fix this myself (Thanks! See [how to get started](https://idlefantasy.tristinbaker.xyz/getting_started_wiki.html))
           required: false
 
   - type: input

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,6 +1,6 @@
 ## Before submitting
 
-- [ ] I've tested any changes with appropriate tests (eg. Unit tests, validation scripts)
+- [ ] I've tested any changes with the appropriate tests (eg. Unit tests, validation scripts)
 - [ ] I've pulled and merged the latest changes from the repository
 
 ## Summary

--- a/app/src/main/kotlin/com/fantasyidler/simulator/CombatSimulator.kt
+++ b/app/src/main/kotlin/com/fantasyidler/simulator/CombatSimulator.kt
@@ -152,8 +152,8 @@ object CombatSimulator {
 
             repeat(ticksPerFrame) {
                 // Player attacks (ranged is capped by arrow supply)
-                val pDmg = when {
-                    combatStyle == "ranged" -> {
+                val pDmg = when (combatStyle) {
+                    "ranged" -> {
                         while (arrowsLeft == 0 && arrowTierIdx + 1 < arrowTiers.size) {
                             arrowTierIdx++
                             arrowsLeft = arrowTiers[arrowTierIdx].second
@@ -166,7 +166,7 @@ object CombatSimulator {
                             if (rnd.nextDouble() < playerHitChance) rnd.nextInt(0, playerMaxHit + 1) else 0
                         } else 0
                     }
-                    combatStyle == "magic" -> {
+                    "magic" -> {
                         val canCast = runeKey == null || runesLeft >= runeCostPerAttack
                         if (canCast) {
                             if (runeKey != null) { runesLeft -= runeCostPerAttack; frameRunesUsed++ }
@@ -209,7 +209,7 @@ object CombatSimulator {
                 currentHp      -= eDmg
 
                 // Always eat the best-tier food still in stock first; only fall back to a
-                // weaker tier once the best one runs out, up to 200 items total.
+                // weaker tier once the best one runs out, up to 300 items total.
                 var ate = true
                 while (ate && totalFoodEaten < 300) {
                     ate = false
@@ -409,8 +409,8 @@ object CombatSimulator {
             var frameRunesUsed = 0
 
             for (tick in 0 until ticksPerFrame) {
-                val pDmg = when {
-                    combatStyle == "ranged" -> {
+                val pDmg = when (combatStyle) {
+                    "ranged" -> {
                         while (arrowsLeft == 0 && arrowTierIdx + 1 < arrowTiers.size) {
                             arrowTierIdx++
                             arrowsLeft = arrowTiers[arrowTierIdx].second
@@ -423,7 +423,7 @@ object CombatSimulator {
                             if (rnd.nextDouble() < playerHitChance) rnd.nextInt(0, playerMax + 1) else 0
                         } else 0
                     }
-                    combatStyle == "magic" -> {
+                    "magic" -> {
                         val canCast = runeKey == null || runesLeft >= runeCostPerAttack
                         if (canCast) {
                             if (runeKey != null) { runesLeft -= runeCostPerAttack; frameRunesUsed++ }
@@ -460,7 +460,7 @@ object CombatSimulator {
                 eHits.add(bDmg)
 
                 // Always eat the best-tier food still in stock first; only fall back to a
-                // weaker tier once the best one runs out, up to 200 items total.
+                // weaker tier once the best one runs out, up to 300 items total.
                 var ate = true
                 while (ate && totalFoodEaten < 300) {
                     ate = false

--- a/wiki/requirements.txt
+++ b/wiki/requirements.txt
@@ -1,2 +1,3 @@
 jinja2>=3.1
 markdown>=3.5
+markdown-katex-rs>=0.1.0

--- a/wiki/src/pages.py
+++ b/wiki/src/pages.py
@@ -83,6 +83,7 @@ def add_static_pages():
             ("equipment", PageInfo("Equipment", "Equipment.md", gen_equipment)),
         ]],
         ["Combat", False, [
+            ("combat", PageInfo("Combat", "Combat.md", gen_combat_page)),
             ("bosses", PageInfo("Bosses", "Bosses.md", gen_bosses)),
             ("dungeons", PageInfo("Dungeons", "Dungeons.md", gen_dungeons)),
             ("enemies", PageInfo("Enemies", "Enemies.md", gen_enemies)),
@@ -408,24 +409,26 @@ def gen_table_of_contents(page_content: str, max_level: int = 4, min_level: int 
     return "\n".join(lines)
 
 
-def gen_getting_started_game() -> str:
-    page = get_template("contributing/getting_started_game").format(
-        wiki_contribution_link=link("getting_started_wiki", "Contributing to the wiki")
-    )
-    return page.format(table_of_contents=f"## Table of contents\n\n{gen_table_of_contents(page)}")
+def make_latex_safe(content: str, escape_levels: int = 1) -> str:
+    """Escape braces inside inline LaTeX (``$...$``) so ``str.format`` leaves them intact.
 
+    Expressions such as ``$\\dfrac{a}{b}$`` contain braces that ``str.format`` would
+    otherwise treat as replacement fields. Braces are doubled once per escape level
+    (level 1 → ``{{`` / ``}}``, level 2 → ``{{{{`` / ``}}}}``, and so on).
 
-def gen_getting_started_wiki() -> str:
-    page = get_template("contributing/getting_started_wiki").format(
-        page_types_link=link("wiki_page_types"),
-        game_contribution_link=link("getting_started_game", "how to contribute to the game")
-    )
-    return page.format(table_of_contents=f"## Table of contents\n\n{gen_table_of_contents(page)}")
+    :param content: Text that may contain inline LaTeX maths.
+    :param escape_levels: Number of ``.format`` passes the content will go through.
+    :return: Content with LaTeX braces escaped for the given format depth.
+    """
+    open_brace = "{" * (2 ** escape_levels)
+    close_brace = "}" * (2 ** escape_levels)
 
+    def _escape_math(match: re.Match[str]) -> str:
+        body = match.group(1).replace("{", open_brace).replace("}", close_brace)
+        return f"${body}$"
 
-def gen_wiki_page_types() -> str:
-    page = get_template("contributing/wiki_page_types")
-    return page.format(table_of_contents=f"## Table of contents\n\n{gen_table_of_contents(page)}")
+    return re.sub(r"\$([^$]+)\$", _escape_math, content)
+
 
 
 # ---------------------------------------------------------------------------
@@ -451,6 +454,26 @@ def gen_home() -> str:
 
 def gen_sidebar() -> str:
     return _gen_page_listing(PAGE_HIERARCHY)
+
+
+def gen_getting_started_game() -> str:
+    page = get_template("contributing/getting_started_game").format(
+        wiki_contribution_link=link("getting_started_wiki", "Contributing to the wiki")
+    )
+    return page.format(table_of_contents=f"## Table of contents\n\n{gen_table_of_contents(page)}")
+
+
+def gen_getting_started_wiki() -> str:
+    page = get_template("contributing/getting_started_wiki").format(
+        page_types_link=link("wiki_page_types"),
+        game_contribution_link=link("getting_started_game", "how to contribute to the game")
+    )
+    return page.format(table_of_contents=f"## Table of contents\n\n{gen_table_of_contents(page)}")
+
+
+def gen_wiki_page_types() -> str:
+    page = get_template("contributing/wiki_page_types")
+    return page.format(table_of_contents=f"## Table of contents\n\n{gen_table_of_contents(page)}")
 
 
 def gen_skills() -> str:
@@ -1273,8 +1296,7 @@ def gen_guilds() -> str:
                 reward_parts.append(f"{r['xp']:,} XP")
             if r.get("reputation"):
                 reward_parts.append(f"{r['reputation']:,} rep")
-            for item, qty in r.get("items", {}).items():
-                reward_parts.append(f"{qty}x {title(item)}")
+            reward_parts.append(fmt_materials(r.get("items", {})))
             rows.append([
                 q["name"],
                 q["guild_level_required"],
@@ -1433,6 +1455,16 @@ def gen_titles() -> str:
         guild_table=guild_table,
         other_table=other_table,
     )
+
+
+def gen_combat_page() -> str:
+    page = make_latex_safe(get_template("combat/combat"), 2).format(
+        bosses_link=link("bosses"),
+        dungeons_link=link("dungeons"),
+        wiki_contribution_link=link("getting_started_wiki", "Contributing to the wiki"),
+        combat_footer=gen_combat_footer()
+    )
+    return page.format(table_of_contents=f"## Table of contents\n\n{gen_table_of_contents(page)}")
 
 
 def gen_boss(boss: dict) -> str:

--- a/wiki/src/site.py
+++ b/wiki/src/site.py
@@ -68,8 +68,8 @@ def _add_row_ids(html: str) -> str:
 
 
 def _md_to_html(text: str) -> str:
-    # Todo: Improve fenced code blocks, maybe SuperFenced extension?
-    html = md_lib.markdown(text, extensions=["tables", "toc", "fenced_code"])
+    # Todo: Improve fenced code blocks by improving the style.css, etc
+    html = md_lib.markdown(text, extensions=["tables", "toc", "fenced_code", "markdown_katex_rs"])
     html = _fix_page_links(html)
     return _add_row_ids(html)
 

--- a/wiki/templates/combat/combat.md
+++ b/wiki/templates/combat/combat.md
@@ -1,0 +1,159 @@
+# Combat
+
+_Note: The explanations on this page are valid as of v1.12.3 and could be subject to changes in future versions of the game, although we'll do our best to keep this page up-to-date._
+
+Combat is a core mechanic of the game allowing you to fight monsters for loot and receive special items only available through combat.
+
+Dungeons and bosses have various different bonuses and features however do simulate quite similarly.
+
+## Combat Level
+
+Combat level acts as an overarching level indicating your combat ability. Accessing dungeons and bosses requires having at least a minimum combat level in order to enter.
+
+Combat level is calculated using the below formula with a minimum level of at least 1:
+
+$`Combat\ Level = \dfrac{3\times (attackLvl + strengthLvl)}{8} + \dfrac{defenceLvl + hitpointsLvl}{4}`$
+
+## Dungeons
+
+Dungeons provide one of the key sources of combat in Idle Fantasy allowing you to encounter many enemies over a set period of time and receive drops specific to the enemies.
+
+More information on specific dungeons is available in {dungeons_link}.
+
+Explanation of how dungeons are simulated in the game is available in [Dungeon Simulation](#dungeon-simulation).
+
+## Bosses
+
+Unlike dungeons where you face multiple enemies, bosses allow you to face a single boss and receive special loot only available for bosses such as unique weapons and pets.
+
+Additionally, unlike dungeons, sessions for bosses only last until either you die or you defeat the boss up to the maximum time limit which depends on the boss. Also, bosses have fixed drops which do not depend on the combat style.
+
+More information about specific bosses is available in {bosses_link}.
+
+Information about how bosses are simulated in the game is available in [Boss Fight Simulations](#boss-fight-simulations).
+
+## Combat stats
+
+The various stats for the player are often boosted by many different things such as capes, etc. The terminology below is used throughout this documentation and explains how these values are calculated.
+
+| Stat               | Calculation                                                                                                          |
+|--------------------|----------------------------------------------------------------------------------------------------------------------|
+| $`playerAttack`$   | $`(attackLvl \times capeMult) + 5\times attackPrestigeLvl + potionAtkBonus`$                                         |
+| $`playerStrength`$ | $`(strengthLvl \times capeMult) + 5\times strengthPrestigeLvl + potionStrBonus`$                                     |
+| $`playerDefence`$  | $`(defenceLvl \times capeMult) + 5\times defencePrestigeLvl + potionDefBonus + armourDefBonuses + blessingDefBonus`$ |
+| $`playerMagic`$    | $`(magicLvl \times capeMult) + 5\times magicPrestigeLvl + potionMagBonus`$                                           |
+| $`playerRanged`$   | $`(rangedLvl \times capeMult) + 5\times rangedPrestigeLvl + potionRanBonus`$                                         |
+
+## Dungeon Simulation
+
+When you start a combat session, like all general skill simulations, the game simulates a total of 60 frames of combat. Additionally, each frame is again split into a set number of ticks where the actual combat takes place.
+
+Each frame works by spawning an enemy type and then running a tick-by-tick combat loop.
+
+### Enemy Spawning
+
+During the enemy spawning phase, the enemies are spawned from a spawn pool specific to that dungeon. The spawn pool is generated from a weighted list of potential enemies and is chosen randomly.
+
+During a single frame, only one enemy type is encountered, and if an enemy is killed during the tick-by-tick combat loop, then the same enemy is respawned repeatedly until the next frame.
+
+If no enemies were killed in a frame then the enemy currently being attacked is carried over to the new frame where combat continues. However, if at least one kill has occurred, any progress towards killing the last enemy is lost once the frame ends.
+
+### Tick-by-tick combat loop
+
+The tick-by-tick combat loop runs a number of ticks in which the player and enemy take turns attacking.
+
+The tick-by-tick combat loop goes through 4 distinct phases:
+1. Player attack
+2. Enemy respawning/rewards
+3. Enemy attack
+4. Healing the player
+
+#### Tick speed
+
+The enemy always attacks every "2.4s" or in other words will make $`\frac{60}{2.4} = 25\ hits`$ per frame.
+
+The player on the other hand has their attack speed moderated by the weapon they're holding with the fastest possible speed being 1.2s (50 hits) and the slowest being 2.4s (25 hits).
+
+#### Phase 1: Player attack
+
+During this part of the tick, the player attempts to attack the enemy. There is an initial check during which the simulator checks whether the player makes a hit and if they do, calculates the damage done to the enemy.
+
+The chance of hitting the enemy at all depends on the player's attack and the enemy's defence stat and is calculated using the formulas below:
+
+| Stat Comparison                      | Formula                                                               |
+|--------------------------------------|-----------------------------------------------------------------------|
+| $`effectiveAttack \gt enemyDefence`$ | $`attackChance = 1 - \dfrac{enemyDefence}{2 \times effectiveAttack}`$ |
+| $`effectiveAttack \le enemyDefence`$ | $`attackChance = \dfrac{effectiveAttack}{2\times enemyDefence}`$      |
+
+Where:
+
+$`effectiveAttack = playerAttack/playerMagic/playerRanged + weaponAttackBonus`$
+
+(whichever attack stat matches the combat style in use)
+
+This formula produces a chance between 0 and 1, which is then clamped in practice to 15%–95% for the player in dungeons (10%–95% for enemies, and for the player in boss fights). It works on a fractional scale so if your attack equals the enemy's defence, then your chance of making a hit is 50%. If attack is half the defence, then chance is 25% and so on.
+
+The $`enemyDefence`$ stat is calculated using the defensive stat of the enemy relevant to the specific combat style (e.g. strength defence is used for strength combat styles, magic for magic, etc).
+
+Assuming the player succeeds in hitting the enemy, the damage is a random number up to the maximum possible hit which depends on the attacking style as described below:
+
+| Combat Style | Maximum Damage                                                                                              |
+|--------------|-------------------------------------------------------------------------------------------------------------|
+| Melee        | $`maximumDamage = 1 + (playerStrength + weaponStrengthBonus) \times \dfrac{weaponStrengthBonus + 64}{640}`$ |
+| Ranged       | $`maximumDamage = 1 + (playerRanged + arrowStrengthBonus) \times \dfrac{arrowStrengthBonus + 64}{640}`$     |
+| Magic        | $`maximumDamage = spellMaxHit`$                                                                             |
+
+#### Phase 2: Enemy respawning / rewards
+
+If, during phase 1, the player dealt enough damage to kill an enemy, then all drops associated with that enemy will be given out.
+
+The XP dropped by enemies will be distributed providing 15% towards defence, 15% towards hitpoints with all remaining XP going to the relevant skill depending on combat style (i.e. Strength if using the strength combat style).
+
+Additionally, the enemy of the same type that was killed will be respawned. I.e. After killing a goblin, another goblin will spawn.
+
+More information about spawning is discussed in [Enemy Spawning](#enemy-spawning).
+
+#### Phase 3: Enemy attack
+
+During phase 3, the enemy will attempt to do damage to the player. Unlike the player however, the enemy has a fixed attack speed of 2.4s. This means that in some ticks, the enemy may not have an opportunity to do damage if the player's attack speed is faster than 2.4s.
+
+If the enemy does get the opportunity to attack, then its method of doing damage is similar to the player. The chance of an enemy hitting is described using the formulas below (described [earlier](#phase-1-player-attack)).
+
+| Stat Comparison                   | Formula                                                            |
+|-----------------------------------|--------------------------------------------------------------------|
+| $`enemyAttack \gt playerDefence`$ | $`attackChance = 1 - \dfrac{playerDefence}{2 \times enemyAttack}`$ |
+| $`enemyAttack \le playerDefence`$ | $`attackChance = \dfrac{enemyAttack}{2\times playerDefence}`$      |
+
+$`enemyAttack`$ is calculated as the attack level plus the attack bonus for the enemy and is otherwise known as the $`effectiveAttack`$.
+
+#### Phase 4: Healing the player
+
+Finally, once both the enemy and the player have had the chance to make hits, the player will heal themselves repeatedly by eating equipped food until the maximum allowed food has been eaten (300) or until there is less missing HP than the food would heal (e.g. the player will stop eating if they have 90/100 HP and the food has > 10 healing power). Additionally, if the enemy can kill the player in a single hit or the current HP is less than half the maximum, the player will also continue to eat.
+
+Up to a maximum of 300 food can be consumed within a dungeon and the best equipped food (by healing) will be consumed first before lower tier food.
+
+## Boss Fight Simulations
+
+While similar to dungeons, bosses are simulated somewhat differently.
+
+The most notable differences include the following:
+
+- Boss fights conclude as soon as a boss or the player is defeated.
+- Bosses return fixed rewards upon their death and do not distribute XP except using their flat rewards (these can be viewed in the bestiary or in {bosses_link}).
+- Boss fights use a maximum number of frames which can be larger or smaller than the default 60.
+
+Boss fights work by simulating a tick-by-tick combat loop followed by calculating the rewards.
+
+### Tick-by-tick combat loop
+
+The tick-by-tick combat loop functions identically to the dungeon simulation except that if the boss or player dies, the simulation immediately ends moving to the rewards phase. To see how this is simulated, check out the [explanation for dungeons](#tick-by-tick-combat-loop).
+
+### Rewards phase
+
+Rewards are received regardless of whether you defeat the boss. If you win, you'll receive all drops associated with the boss, however if you lose, you'll only receive 10% of all XP drops.
+
+Generally, bosses are a good way to receive weapons that are better than what is typically available through smithing as well as unique pets.
+
+If the boss was not defeated by the end of the maximum time, then it can still count as a win. This works by calculating your damage per second (DPS) along with your maximum HP and comparing whether you would outlive the boss given the boss's max HP. This does not factor in healing potential and so generally, if you don't defeat the boss by the end frame, this would typically result in a loss.
+
+{combat_footer}

--- a/wiki/templates/contributing/getting_started_game.md
+++ b/wiki/templates/contributing/getting_started_game.md
@@ -12,27 +12,27 @@ Want a simpler task? {wiki_contribution_link} is also a great way to learn your 
 
 As the game develops, bugs are bound to pop up and starting here is a great place to get familiar with the codebase as you'll slowly learn how everything works. Generally, the process you should follow is:
 
-1. Find a bug that you want to fix. This involves going into the [issues](https://github.com/tristinbaker/IdleFantasy/issues) and finding an issue that you think you might be able to work on. Generally starting small is a good idea
-2. Assign yourself to the issue or comment saying that you'd like to fix this. This is an important step to avoid having multiple people work on the same issue at the same time. Also, if you have an idea, it's a good idea to specify how long you think you'll take. This helps others get an idea as to when it should roughly be finished and also when they should potentially look at doing it themselves if you have issues for example.
-3. Once the issue is fixed, make sure to sync the fork with the upstream branch - resolving any merge conflicts. You should aim to ensure that your code minimises any changes to new code so as to prevent these issues cropping up again
+1. Find a bug that you want to fix. This involves going into the [issues](https://github.com/tristinbaker/IdleFantasy/issues) and finding an issue that you think you might be able to work on. Generally starting small is a good idea.
+2. Assign yourself to the issue or comment saying that you'd like to fix this. This is an important step to avoid having multiple people work on the same issue at the same time. Also, if you have an idea, it's a good idea to specify how long you think you'll take. This helps others get an idea as to when it should roughly be finished and also when they should potentially look at doing it themselves if you have issues, for example.
+3. Once the issue is fixed, make sure to sync the fork with the upstream branch - resolving any merge conflicts. You should aim to keep your changes as small as possible to fix the bug so as to prevent any other bugs from appearing.
 4. Test the code with Android Studio or similar to make sure the issue is fixed; go back to step 3 especially if syncing the fork caused any issues to try and figure out what went wrong.
-5. Once your fork is fixed, and you've tested to make sure the code works, create a pull request and explain what you've changed, referencing the issue that you're solving. Sometimes you might find some changes need to be made in which case you can make the changes and redo any checks/syncs.
+5. Once your fork is fixed, and you've tested to make sure the code works, create a pull request and explain what you've changed, referencing the issue that you're solving. Sometimes you might find some changes need to be made, in which case you can make the changes and redo any checks/syncs.
 
 If you find that a bug is much harder to solve than you expected, that's normal and not a problem. Simply mention on the issue that you're having issues and people can help out - if you need, you can also pass it on to another community member.
 
-Also, it's important to remain close to the [KISS principle](https://en.wikipedia.org/wiki/KISS_principle). Changes should ideally be as minimal as possible to fix the bug to avoid inadvertently adding new bugs. To do this, you'll probably need to really looking into what's causing the bug and make sure you properly know the cause. Using AI is not discouraged, but it's worthwhile noting that AI systems often ignore this principle and make substantial changes to fix bugs which could be solved by changing a few lines. As such, you should make sure you understand what it's changing and try to minimise any extraneous changes.
+Also, it's important to remain close to the [KISS principle](https://en.wikipedia.org/wiki/KISS_principle). Changes while fixing a bug should ideally be as minimal as possible to avoid inadvertently adding new bugs. To do this, you'll likely need to spend most of your time analysing what's causing the bug to ensure you understand the cause. Using AI is not discouraged, but it's worthwhile noting that AI systems sometimes ignore this principle and make substantial changes to fix bugs which could be solved by changing a few lines. As such, you should ensure you understand what's being changes and try to minimise any extraneous modifications.
 
 ### Developing new features
 
-Developing new features is a fun way to add to the game and see your changes more clearly. However, it's important to follow the process as you don't want to spend several days coding up a great new feature only to find that there's some changes to be made or that it might not match the direction of the game.
+Developing new features is a fun way to add to the game and see the changes you've made as you play. However, following the process is highly recommended to avoid spending several days coding up a great new feature only to find that there are some fundamental changes necessary or that it may not match the intended direction of the game.
 
 If you want to develop a new feature you should follow the below steps:
 
-1. Create a new discussion topic in [discussions](https://github.com/tristinbaker/IdleFantasy/discussions). This is an important step to make sure that the community is able to chip in and provide feedback before you work on any major development. If this is a significant new feature, you could consider adding some example designs of what you're thinking to help provide more clarity
-2. Create a new fork and start working on the project. If this is a large feature, consider updating the discussion with how you're progressing although we don't necessarily need a day-by-day update
-3. Just like with squashing bugs, once you've finished working on your feature, you should sync your fork with the upstream branches and resolve any potential merge conflicts
-4. Then, once all the merge conflicts have been sorted, you can test to ensure the feature still works properly
-5. Finally, once you've tested and synced your fork, you can create a pull request, explaining what you've added and provide a reference to the relevant discussion
+1. Create a new discussion topic in [discussions](https://github.com/tristinbaker/IdleFantasy/discussions). This ensures that the community is able to chip in and provide feedback before you start development. If this is a significant new feature, you could consider adding some example designs of what you're thinking to help provide more clarity.
+2. Create a new fork and start working on the project. If this is a large feature, consider updating the discussion with how you're progressing although we don't necessarily need a day-by-day update.
+3. Just like with squashing bugs, once you've finished working on your feature, you should sync your fork with the upstream branches and resolve any potential merge conflicts.
+4. Then, once all the merge conflicts have been sorted, you can test to ensure the feature still works properly.
+5. Finally, once you've tested and synced your fork, you can create a pull request, explaining what you've added and provide a reference to the relevant discussion.
 
 It's quite common while developing an idea that you come up with lots of additional changes and revisions. If these are large, you should consider updating the discussion topic so it properly reflects the idea in full.
 

--- a/wiki/templates/contributing/getting_started_wiki.md
+++ b/wiki/templates/contributing/getting_started_wiki.md
@@ -1,6 +1,6 @@
 # Getting started - Wiki contributions
 
-Great! You want to know how you can contribute to the wiki and make it better over time. While this wiki functions a little differently from most you may have worked on in the past, if you have a little bit of programming knowledge you'll find it easy to work with, and even if you don't have programming knowledge there's still some ways you can help out.
+Great! You want to know how you can contribute to the wiki and make it better over time. While this wiki functions a little differently from most you may have worked on in the past, if you have a little bit of programming knowledge you'll find it easy to work with, and even if you don't have programming knowledge there are still some ways you can help out.
 
 If you want to make changes to the game itself, check out {game_contribution_link}.
 
@@ -12,13 +12,15 @@ Unlike most wikis which have a collection of pages that require constant mainten
 
 It uses Markdown to define templates with Python being responsible for the compilation and generation of dynamic content.
 
+Some content still requires manual maintenance such as strategy guides and some text content however a number of changes in the game is reflected in the wiki.
+
 ## Core terminology
 
-To best understand how you can work with things (and also understand the jargon in the docs), it's helpful to go over a few core terminology:
+To best understand how you can work with the wiki codebase (and also understand the jargon in the docs), it's helpful to go over some core terminology:
 
 ### Page Directory
 
-The page directory is responsible for holding information about all the pages used within the wiki. It gets populated with information about all pages before the actual generation of any content and allows you to refer to other pages when defining page content through the use of a page ID (Eg. For links).
+The page directory is responsible for holding information about all the pages used within the wiki. It gets populated with information about all pages before the actual generation of any content and allows you to refer to other pages when defining page content through the use of a page ID (e.g. for links).
 
 Pages are added to the page directory in `pages.py` under the `Page Listings` section.
 
@@ -40,13 +42,13 @@ Templates provide the base formatting for pages within the wiki. Whenever they r
 
 ### Static/Dynamically-generated pages
 
-Whenever we refer to static vs dynamically-generated pages this refers not to the content within pages but how the pages are defined. If pages are "hardcoded" in the `add_static_pages` function, these are static, whereas generated pages, will produce an unknown amount of pages like with each individual boss page.
+Whenever we refer to static vs dynamically-generated pages this refers not to the content within pages but how the pages are defined. If pages are "hardcoded" in the `add_static_pages` function, these are static, whereas generated pages will produce an unknown amount of pages like with each individual boss page.
 
 For more information, see {page_types_link}.
 
 ## Building/Compiling the Wiki
 
-To build the wiki, you'll need to set up an appropriate Python environment which you can use to run the wiki compilation. For information about setting up virtual environments, see [this tutorial](https://www.geeksforgeeks.org/python/create-virtual-environment-using-venv-python/) (make sure to call it .venv to have it be git ignored).
+To build the wiki, you'll need to set up an appropriate Python environment which you can use to run the wiki compilation. For information about setting up virtual environments, see [this tutorial](https://www.geeksforgeeks.org/python/create-virtual-environment-using-venv-python/) (make sure to call it .venv to have it be gitignored).
 
 From there, you can run the following command to see what you can do (from the project folder):
 
@@ -63,14 +65,14 @@ python -m src -h
 
 The following code files are used as follows in the wiki:
 
-- `__main__.py` - The main entry point to the wiki program responsible for parsing arguments and top-level management
-- `page_hierarchy.py` - A simple file defining the page hierarchy structure
-- `pages.py` - The primary code responsible for generating all the Markdown pages. This also contains a number of helper functions which you should use where relevant such as `link()`, etc
-- `site.py` - The code responsible for generating the Idle Wiki website based upon the generated Markdown files
+- `__main__.py` - The main entry point to the wiki program responsible for parsing arguments and top-level management.
+- `page_hierarchy.py` - A simple file defining the page hierarchy structure.
+- `pages.py` - The primary code responsible for generating all the Markdown pages. This also contains a number of helper functions which you should use where relevant such as `link()`, etc.
+- `site.py` - The code responsible for generating the Idle Fantasy wiki website based upon the generated Markdown files.
 
 ## Contributing process
 
-For small contributions (eg. Fixing small mistakes, etc), you can simply fork the repository, make the relevant change and then create a pull request.
+For small contributions (e.g. fixing small mistakes, etc), you can simply fork the repository, make the relevant change and then create a pull request.
 
 If you notice larger issues/inaccuracies that might take some time to fix, you should create an issue beforehand and mention that you're planning on making the changes. This makes sure that there aren't multiple people working on the same issue (without knowing) and also means that the issue can be referenced/tracked.
 

--- a/wiki/templates/contributing/wiki_page_types.md
+++ b/wiki/templates/contributing/wiki_page_types.md
@@ -1,84 +1,62 @@
 # Wiki Page Types
 
-In the wiki, there's two main types of pages - static wiki pages and dynamic wiki pages, each with their own use cases.
+In the wiki, there are two main types of pages - static wiki pages and dynamic wiki pages, each with their own use cases.
 
 {table_of_contents}
 
 ## Static wiki pages
 
-Static wiki pages, despite the name, may still have content that is dynamically generated. The key feature however, is
-that these pages are defined individually in the code and often contain their own independent templates.
+Static wiki pages, despite the name, may still have content that is dynamically generated. The key feature, however, is that these pages are defined individually in the code and often contain their own independent templates.
 
-This page for example, is a static page as the number of pages does not change depending on the content. These differ
-from dynamic pages which are explained in [dynamically-generated wiki pages](#dynamically-generated-wiki-pages).
+This page, for example, is a static page as the number of pages do not change depending on the content. These differ from dynamic pages which are explained in [dynamically-generated wiki pages](#dynamically-generated-wiki-pages).
 
-Generally, you should choose static pages for any game content for which the number of pages would not change depending
-on the addition of new content (Eg. `Ashes` could be a static page, but the page for each specific ash type should be
-dynamically generated).
+Generally, you should choose static pages for any game content for which the number of pages would not change depending on the addition of new content (e.g. `Ashes` could be a static page, but the page for each specific ash type should be dynamically generated).
 
 ### How static pages are organised in the codebase
 
-Static pages like all pages typically feature a generator functions and get added to the page directory and hierarchy in
-the dedicated `add_static_pages()` function in `pages.py`. Most static pages should be both in the page hierarchy and
-the directory, however some, like the sidebar, are only in the page directory.
+Static pages, like all pages, typically feature a generator function and get added to the page directory and hierarchy in the dedicated `add_static_pages()` function in `pages.py`. Most static pages should be both in the page hierarchy and the directory, however some, like the sidebar, are only in the page directory.
 
 ### Updating & adding static pages
 
-If you wish to update an existing static page, this is usually pretty simple. Generally, I'd recommend exploring the
-`add_static_pages()` function to find the relevant page and then navigate to the generator function to see how it is
-generated, along with the associated template. Here, you can make edits as necessary
+If you wish to update an existing static page, this is usually pretty simple. Generally, I'd recommend exploring the `add_static_pages()` function to find the relevant page and then navigate to the generator function to see how it is generated, along with the associated template. Here, you can make edits as necessary.
 
-If you wish to add a new static page, you'll need to define your own generator function in `pages.py`,
-create a template file (if necessary), and then define the page in the directory and/or hierarchy in `add_static_pages()`
+If you wish to add a new static page, you'll need to define your own generator function in `pages.py`, create a template file (if necessary), and then define the page in the directory and/or hierarchy in `add_static_pages()`.
 
 As a guide, you can follow the below checklist when adding new static pages:
-1. Define a suitable Markdown template
-2. Define a generator function
-3. Add the page to the directory/hierarchy in `add_static_pages()`
-4. Test it to make sure it shows up correctly
+1. Define a suitable Markdown template.
+2. Define a generator function.
+3. Add the page to the directory/hierarchy in `add_static_pages()`.
+4. Test it to make sure it shows up correctly.
 
 ## Dynamically-generated wiki pages
 
-Unlike static pages, dynamically-generated wiki pages are typically defined and added to the page directory at wiki runtime.
-They typically use one template to generate a number of pages with related, but different content.
+Unlike static pages, dynamically-generated wiki pages are typically defined and added to the page directory at wiki runtime. They typically use one template to generate a number of pages with related, but different content.
 
-For example, the individual boss pages (eg. King Black Dragon, Demon Lord) are a good example of dynamically-generated pages as while there is a common template,
-the number of pages differs depending on how many bosses are in the game at any one time.
+For example, the individual boss pages (e.g. King Black Dragon, Demon Lord) are a good example of dynamically-generated pages as while there is a common template, the number of pages differs depending on how many bosses are in the game at any one time.
 
 ### How dynamic pages are organised in the codebase
 
-Dynamically-generated pages have a few differences compared to static pages being primarily that all generated pages
-relating to a certain topic will usually share both a template and a parameterised generator function.
+Dynamically-generated pages have a few differences compared to static pages, primarily being that all generated pages relating to a certain topic will usually share both a template and a parameterised generator function.
 
-Unlike static pages, there is no specific defined function where dynamically-generated pages are defined in the directory
-and hierarchy as they will use their own function that adds them to the hierarchy.
+Unlike static pages, there is no specific defined function where dynamically-generated pages are defined in the directory and hierarchy as they will use their own function that adds them to the hierarchy.
 
-Using the boss pages as an example, you'll notice that the template `boss.md` uses a common, highly parameterised template
-that all boss pages use. The function `gen_boss` generates content for each individual boss page. Notice how it has a `boss`
-parameter which uses the dictionary passed in to generate the page. Finally, the `add_boss_pages()` function which defines
-all the pages and adds them to the directory (and potentially hierarchy) - this function is called at the bottom of `pages.py`
-in order to actually add them to the directory/hierarchy.
+Using the boss pages as an example, you'll notice that the template `boss.md` uses a common, highly parameterised template that all boss pages use. The function `gen_boss` generates content for each individual boss page. Notice how it has a `boss` parameter which uses the dictionary passed in to generate the page. Finally, the `add_boss_pages()` function defines all the pages and adds them to the directory (and potentially hierarchy) - this function is called at the bottom of `pages.py` in order to actually add them to the directory/hierarchy.
 
 ### Adding new dynamically-generated pages
 
-If you're developing dynamically-generated pages, generally I'd recommend to first create an appropriate template file
-(Eg. `boss.md`). Then you can define a generator function which generates the content itself (Eg. `gen_boss`) and finally create the appropriate function to define these pages and add them to the
-directory/hierarchy (Eg. `add_boss_pages()`). Make sure to add a call to this final function at the bottom of `pages.py`.
+If you're developing dynamically-generated pages, generally I'd recommend to first create an appropriate template file (e.g. `boss.md`). Then you can define a generator function which generates the content itself (e.g. `gen_boss`) and finally create the appropriate function to define these pages and add them to the directory/hierarchy (e.g. `add_boss_pages()`). Make sure to add a call to this final function at the bottom of `pages.py`.
 
 When adding these pages to the hierarchy, using a collapsible hierarchy ensures it doesn't result in a messy navigation bar.
 
-Additionally, if the page is a dedicated page for an item, etc, you should keep the same name as used in the json files
-for the page ID so that they can be easily referenced by other pages.
+Additionally, if the page is a dedicated page for an item, etc, you should keep the same name as used in the json files for the page ID so that they can be easily referenced by other pages.
 
 As a guide, you can use the following checklist when adding new dynamically-generated pages:
-1. Define a suitable shared Markdown template
-2. Define a parameterised generator function which has any relevant data passed in (loading can still be done in the function but it could be more performant to delegate to the caller)
-3. Create a function that defines these pages and adds them to the directory/hierarchy
-4. Add a statement to call the function at the bottom of `pages.py`
-5. Test and ensure all the pages come up properly
+1. Define a suitable shared Markdown template.
+2. Define a parameterised generator function which has any relevant data passed in (loading can still be done in the function but it could be more performant to delegate to the caller).
+3. Create a function that defines these pages and adds them to the directory/hierarchy.
+4. Add a statement to call the function at the bottom of `pages.py`.
+5. Test and ensure all the pages come up properly.
 
 #### Tip: Footer tables
 
-If you have a specific section of the game which has a lot of dynamically generated links (eg. Combat which encompasses
-bosses, enemies, & dungeons), it's often worthwhile to create a set of footer links which you can see an example of with
-`gen_combat_footer()` - Note this generator function does not have a dedicated page as it is a component of other pages.
+If you have a specific section of the game which has a lot of dynamically generated links (e.g. Combat which encompasses bosses, enemies, & dungeons), it's often worthwhile to create a set of footer links which you can see an example of with `gen_combat_footer()` - Note this generator function does not have a dedicated page as it is a component of other pages.


### PR DESCRIPTION

## Before submitting

- [x] I've tested any changes with appropriate tests (eg. Unit tests, validation scripts)
- [x] I've pulled and merged the latest changes from the repository

## Summary

<!-- Short summary of the pull request and what it changes -->

This pull request primarily adds a new combat page as discussed in #988 and also in #502. It also has some minor refactors to various other bits of the codebase

## Related issue(s) or discussion(s)

<!-- Prepend issues with "Fixes" if this should close the issue, e.g. Fixes #283, Relates to #284 -->

Closes #988, Relates to #502, Relates to discussion in #1053.

## Changelog

<!-- Concise list of changes, e.g.
- Fix time-slot bug causing XP gains to not show in notification banner
- Added ellipsis for quests XP gains exceeding screen width
-->

- Adds a new combat page detailing how combat works in the game
- Fixes incorrect comments in CombatSimulator and minor refactoring
- Fix minor typos in the pull request template and wiki_error issue form
- Fixes confusing description in the wiki error template

## Additional work

Given it's been a bit and it's a big page, I thought I'd get out what is currently there and make some further improvements later

- Explain how the combat likeliness to die/simulator works and the different levels - I noticed that the estimateSurvival function is unused, is there a particular reason to keep it?