### PR TITLE
Fix inconsistency in Japanese translation

### DIFF
--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -1083,20 +1083,20 @@
     <string name="crafting_tier_adamantite">アダマンタイト</string>
     <string name="crafting_tier_arrow">矢</string>
     <string name="crafting_tier_bronze">ブロンズ</string>
-    <string name="crafting_tier_gold">ゴールド</string>
-    <string name="crafting_tier_iron">アイアン</string>
-    <string name="crafting_tier_magic">マジック</string>
-    <string name="crafting_tier_maple">メイプル</string>
+    <string name="crafting_tier_gold">金</string>
+    <string name="crafting_tier_iron">鉄</string>
+    <string name="crafting_tier_magic">魔法</string>
+    <string name="crafting_tier_maple">メープル</string>
     <string name="crafting_tier_mithril">ミスリル</string>
     <string name="crafting_tier_oak">オーク</string>
     <string name="crafting_tier_platinum">プラチナ</string>
-    <string name="crafting_tier_runite">ルーナイト</string>
+    <string name="crafting_tier_runite">ルナイト</string>
     <string name="crafting_tier_shortbow">ショートボウ</string>
-    <string name="crafting_tier_silver">シルバー</string>
+    <string name="crafting_tier_silver">銀</string>
     <string name="crafting_tier_staff">スタッフ</string>
-    <string name="crafting_tier_steel">スチール</string>
-    <string name="crafting_tier_willow">ウィロー</string>
-    <string name="crafting_tier_yew">ユー</string>
+    <string name="crafting_tier_steel">鋼鉄</string>
+    <string name="crafting_tier_willow">ヤナギ</string>
+    <string name="crafting_tier_yew">イチイ</string>
 
     <!-- Bone Altar -->
     <string name="bone_altar_title">骨の祭壇</string>
@@ -1149,12 +1149,12 @@
     <!-- Construction item names (planks, nails, stone) -->
     <string name="item_plank_name">木板</string>
     <string name="item_oak_plank_name">オークの木板</string>
-    <string name="item_willow_plank_name">ウィローの木板</string>
-    <string name="item_maple_plank_name">メイプルの木板</string>
-    <string name="item_yew_plank_name">ユーの木板</string>
-    <string name="item_magic_plank_name">マジックの木板</string>
+    <string name="item_willow_plank_name">ヤナギの木板</string>
+    <string name="item_maple_plank_name">メープルの木板</string>
+    <string name="item_yew_plank_name">イチイの木板</string>
+    <string name="item_magic_plank_name">魔法の木板</string>
     <string name="item_iron_nail_name">鉄の釘</string>
-    <string name="item_steel_nail_name">スチールの釘</string>
+    <string name="item_steel_nail_name">鋼鉄の釘</string>
     <string name="item_mithril_nail_name">ミスリルの釘</string>
     <string name="item_stone_name">石材</string>
     <string name="item_carved_stone_name">彫刻された石材</string>
@@ -1165,9 +1165,9 @@
     <string name="item_wooden_shelf_name">木製のシェルフ</string>
     <string name="item_oak_table_name">オークのテーブル</string>
     <string name="item_oak_bookshelf_name">オークの本棚</string>
-    <string name="item_willow_cabinet_name">ウィローのキャビネット</string>
-    <string name="item_maple_dresser_name">メイプルのタンス</string>
-    <string name="item_yew_wardrobe_name">ユーのクローゼット</string>
+    <string name="item_willow_cabinet_name">ヤナギのキャビネット</string>
+    <string name="item_maple_dresser_name">メープルのタンス</string>
+    <string name="item_yew_wardrobe_name">イチイのクローゼット</string>
     <string name="item_magic_throne_name">魔法の玉座</string>
 
     <!-- Town building upgrade UI -->
@@ -1537,7 +1537,7 @@
     <string name="seasonal_bounty_sunspire_firewood_name">篝火用の薪を調達する</string>
     <string name="seasonal_bounty_sunspire_firewood_hint">オークの原木を伐採 — 伐採スキル</string>
     <string name="seasonal_bounty_sunspire_kindling_name">篝火用の付け木を調達する</string>
-    <string name="seasonal_bounty_sunspire_kindling_hint">ウィローの原木を伐採 — 伐採スキル</string>
+    <string name="seasonal_bounty_sunspire_kindling_hint">ヤナギの原木を伐採 — 伐採スキル</string>
     <string name="seasonal_bounty_sunspire_sunore_name">太陽の尖塔を装飾する金を採掘する</string>
     <string name="seasonal_bounty_sunspire_sunore_hint">金の鉱石を採掘 — 採掘スキル</string>
     <string name="seasonal_bounty_sunspire_draughts_name">筋力ポーションを調合する</string>

--- a/app/src/main/res/values-ja/strings_items.xml
+++ b/app/src/main/res/values-ja/strings_items.xml
@@ -37,8 +37,8 @@
     <string name="item_mithril_bar_desc">軽量で魔力を秘めた金属インゴット。</string>
     <string name="item_adamantite_bar_name">アダマンタイトのインゴット</string>
     <string name="item_adamantite_bar_desc">並外れて硬い金属インゴット。</string>
-    <string name="item_platinum_bar_name">白金のインゴット</string>
-    <string name="item_platinum_bar_desc">高ランクの宝飾品に使用される、希少で光沢のある白金のインゴット。</string>
+    <string name="item_platinum_bar_name">プラチナのインゴット</string>
+    <string name="item_platinum_bar_desc">高ランクの宝飾品に使用される、希少で光沢のあるプラチナのインゴット。</string>
     <string name="item_runite_bar_name">ルナイトのインゴット</string>
     <string name="item_runite_bar_desc">製錬可能な最強の金属インゴット。</string>
 
@@ -57,8 +57,8 @@
     <string name="item_log_desc">普通の木から採れた基本的な原木。火起こしや矢作りに使用される。</string>
     <string name="item_oak_log_name">オークの原木</string>
     <string name="item_oak_log_desc">オークの木から採れた原木。</string>
-    <string name="item_willow_log_name">ウィローの原木</string>
-    <string name="item_willow_log_desc">ウィローの木から採れた軽量な原木。</string>
+    <string name="item_willow_log_name">ヤナギの原木</string>
+    <string name="item_willow_log_desc">ヤナギの木から採れた軽量な原木。</string>
     <string name="item_maple_log_name">メープルの原木</string>
     <string name="item_maple_log_desc">メープルの木から採れた密度の高い原木。</string>
     <string name="item_yew_log_name">イチイの原木</string>
@@ -391,10 +391,10 @@
     <string name="item_gold_ring_desc">シンプルな金の指輪。</string>
     <string name="item_gold_necklace_name">金のネックレス</string>
     <string name="item_gold_necklace_desc">シンプルな金のネックレス。</string>
-    <string name="item_platinum_ring_name">白金の指輪</string>
-    <string name="item_platinum_ring_desc">シンプルな白金の指輪。</string>
-    <string name="item_platinum_necklace_name">白金のネックレス</string>
-    <string name="item_platinum_necklace_desc">シンプルな白金のネックレス。</string>
+    <string name="item_platinum_ring_name">プラチナの指輪</string>
+    <string name="item_platinum_ring_desc">シンプルなプラチナの指輪。</string>
+    <string name="item_platinum_necklace_name">プラチナのネックレス</string>
+    <string name="item_platinum_necklace_desc">シンプルなプラチナのネックレス。</string>
 
     <!-- Jewellery — sapphire -->
     <string name="item_silver_sapphire_ring_name">銀のサファイアの指輪</string>
@@ -405,48 +405,48 @@
     <string name="item_gold_sapphire_ring_desc">サファイアがはめ込まれた金の指輪。</string>
     <string name="item_gold_sapphire_necklace_name">金のサファイアのネックレス</string>
     <string name="item_gold_sapphire_necklace_desc">サファイアがはめ込まれた金のネックレス。</string>
-    <string name="item_platinum_sapphire_ring_name">白金のサファイアの指輪</string>
-    <string name="item_platinum_sapphire_ring_desc">サファイアがはめ込まれた白金の指輪。</string>
-    <string name="item_platinum_sapphire_necklace_name">白金のサファイアのネックレス</string>
-    <string name="item_platinum_sapphire_necklace_desc">サファイアがはめ込まれた白金のネックレス。</string>
+    <string name="item_platinum_sapphire_ring_name">プラチナのサファイアの指輪</string>
+    <string name="item_platinum_sapphire_ring_desc">サファイアがはめ込まれたプラチナの指輪。</string>
+    <string name="item_platinum_sapphire_necklace_name">プラチナのサファイアのネックレス</string>
+    <string name="item_platinum_sapphire_necklace_desc">サファイアがはめ込まれたプラチナのネックレス。</string>
 
     <!-- Jewellery — emerald -->
     <string name="item_gold_emerald_ring_name">金のエメラルドの指輪</string>
     <string name="item_gold_emerald_ring_desc">エメラルドがはめ込まれた金の指輪。</string>
     <string name="item_gold_emerald_necklace_name">金のエメラルドのネックレス</string>
     <string name="item_gold_emerald_necklace_desc">エメラルドがはめ込まれた金のネックレス。</string>
-    <string name="item_platinum_emerald_ring_name">白金のエメラルドの指輪</string>
-    <string name="item_platinum_emerald_ring_desc">エメラルドがはめ込まれた白金の指輪。</string>
-    <string name="item_platinum_emerald_necklace_name">白金のエメラルドのネックレス</string>
-    <string name="item_platinum_emerald_necklace_desc">エメラルドがはめ込まれた白金のネックレス。</string>
+    <string name="item_platinum_emerald_ring_name">プラチナのエメラルドの指輪</string>
+    <string name="item_platinum_emerald_ring_desc">エメラルドがはめ込まれたプラチナの指輪。</string>
+    <string name="item_platinum_emerald_necklace_name">プラチナのエメラルドのネックレス</string>
+    <string name="item_platinum_emerald_necklace_desc">エメラルドがはめ込まれたプラチナのネックレス。</string>
 
     <!-- Jewellery — ruby -->
     <string name="item_gold_ruby_ring_name">金のルビーの指輪</string>
     <string name="item_gold_ruby_ring_desc">ルビーがはめ込まれた金の指輪。</string>
     <string name="item_gold_ruby_necklace_name">金のルビーのネックレス</string>
     <string name="item_gold_ruby_necklace_desc">ルビーがはめ込まれた金のネックレス。</string>
-    <string name="item_platinum_ruby_ring_name">白金のルビーの指輪</string>
-    <string name="item_platinum_ruby_ring_desc">ルビーがはめ込まれた白金の指輪。</string>
-    <string name="item_platinum_ruby_necklace_name">白金のルビーのネックレス</string>
-    <string name="item_platinum_ruby_necklace_desc">ルビーがはめ込まれた白金のネックレス。</string>
+    <string name="item_platinum_ruby_ring_name">プラチナのルビーの指輪</string>
+    <string name="item_platinum_ruby_ring_desc">ルビーがはめ込まれたプラチナの指輪。</string>
+    <string name="item_platinum_ruby_necklace_name">プラチナのルビーのネックレス</string>
+    <string name="item_platinum_ruby_necklace_desc">ルビーがはめ込まれたプラチナのネックレス。</string>
 
     <!-- Jewellery — diamond -->
     <string name="item_gold_diamond_ring_name">金のダイヤモンドの指輪</string>
     <string name="item_gold_diamond_ring_desc">ダイヤモンドがはめ込まれた金の指輪。</string>
     <string name="item_gold_diamond_necklace_name">金のダイヤモンドのネックレス</string>
     <string name="item_gold_diamond_necklace_desc">ダイヤモンドがはめ込まれた金のネックレス。</string>
-    <string name="item_platinum_diamond_ring_name">白金のダイヤモンドの指輪</string>
-    <string name="item_platinum_diamond_ring_desc">ダイヤモンドがはめ込まれた白金の指輪。</string>
-    <string name="item_platinum_diamond_necklace_name">白金のダイヤモンドのネックレス</string>
-    <string name="item_platinum_diamond_necklace_desc">ダイヤモンドがはめ込まれた白金のネックレス。</string>
+    <string name="item_platinum_diamond_ring_name">プラチナのダイヤモンドの指輪</string>
+    <string name="item_platinum_diamond_ring_desc">ダイヤモンドがはめ込まれたプラチナの指輪。</string>
+    <string name="item_platinum_diamond_necklace_name">プラチナのダイヤモンドのネックレス</string>
+    <string name="item_platinum_diamond_necklace_desc">ダイヤモンドがはめ込まれたプラチナのネックレス。</string>
 
     <!-- ===== Miscellaneous drops ===== -->
     <string name="item_ashes_name">灰</string>
     <string name="item_ashes_desc">普通の原木が燃えた残りかす。祈りスキルで撒くとボーナス祈り経験値（XP）を獲得できる。</string>
     <string name="item_oak_ashes_name">オークの灰</string>
     <string name="item_oak_ashes_desc">オークの原木が燃えた残りかす。撒くと普通の灰よりも多くの祈り経験値（XP）を獲得できる。</string>
-    <string name="item_willow_ashes_name">ウィローの灰</string>
-    <string name="item_willow_ashes_desc">ウィローの原木が燃えた残りかす。撒くと祈り経験値（XP）を獲得できる。</string>
+    <string name="item_willow_ashes_name">ヤナギの灰</string>
+    <string name="item_willow_ashes_desc">ヤナギの原木が燃えた残りかす。撒くと祈り経験値（XP）を獲得できる。</string>
     <string name="item_maple_ashes_name">メープルの灰</string>
     <string name="item_maple_ashes_desc">メープルの原木が燃えた残りかす。撒くと祈り経験値（XP）を獲得できる。</string>
     <string name="item_yew_ashes_name">イチイの灰</string>
@@ -786,7 +786,7 @@
     <string name="item_mutton_name" translatable="false">マトン肉</string>
     <string name="item_necklace_of_anguish_name" translatable="false">苦悶のネックレス</string>
     <string name="item_oak_shortbow_name" translatable="false">オークのショートボウ</string>
-    <string name="item_platinum_ore_name" translatable="false">白金の鉱石</string>
+    <string name="item_platinum_ore_name" translatable="false">プラチナの鉱石</string>
     <string name="item_prayer_cape_name" translatable="false">祈りのマント</string>
     <string name="item_prayer_guild_cape_name" translatable="false">祈りギルドのマント</string>
     <string name="item_ranged_cape_name" translatable="false">遠距離のマント</string>
@@ -845,7 +845,7 @@
     <string name="item_water_bolt_name" translatable="false">ウォーターボルト</string>
     <string name="item_water_strike_name" translatable="false">ウォーターストライク</string>
     <string name="item_water_wave_name" translatable="false">ウォーターウェーブ</string>
-    <string name="item_willow_shortbow_name" translatable="false">ウィローのショートボウ</string>
+    <string name="item_willow_shortbow_name" translatable="false">ヤナギのショートボウ</string>
     <string name="item_wind_blast_name" translatable="false">ウィンドブラスト</string>
     <string name="item_wind_bolt_name" translatable="false">ウィンドボルト</string>
     <string name="item_wind_strike_name" translatable="false">ウィンドストライク</string>

--- a/app/src/main/res/values-ja/strings_quests.xml
+++ b/app/src/main/res/values-ja/strings_quests.xml
@@ -23,7 +23,7 @@
     <string name="quest_woodcutting_2_name">伐採 II</string>
     <string name="quest_woodcutting_2_objective">オークの原木を750本伐採する</string>
     <string name="quest_woodcutting_3_name">伐採 III</string>
-    <string name="quest_woodcutting_3_objective">ウィローの原木を1100本伐採する</string>
+    <string name="quest_woodcutting_3_objective">ヤナギの原木を1100本伐採する</string>
     <string name="quest_woodcutting_4_name">伐採 IV</string>
     <string name="quest_woodcutting_4_objective">メープルの原木を1650本伐採する</string>
     <string name="quest_woodcutting_5_name">伐採 V</string>
@@ -165,13 +165,13 @@
     <string name="quest_crafting_2_name">製作 II</string>
     <string name="quest_crafting_2_objective">金の指輪を250個製作する</string>
     <string name="quest_crafting_3_name">製作 III</string>
-    <string name="quest_crafting_3_objective">白金の指輪を500個製作する</string>
+    <string name="quest_crafting_3_objective">プラチナの指輪を500個製作する</string>
     <string name="quest_crafting_4_name">製作 IV</string>
     <string name="quest_crafting_4_objective">銀のサファイアの指輪を750個製作する</string>
     <string name="quest_crafting_5_name">製作 V</string>
     <string name="quest_crafting_5_objective">金のサファイアの指輪を1000個製作する</string>
     <string name="quest_crafting_6_name">製作 VI</string>
-    <string name="quest_crafting_6_objective">白金のダイヤモンドの指輪を1500個製作する</string>
+    <string name="quest_crafting_6_objective">プラチナのダイヤモンドの指輪を1500個製作する</string>
 
     <!-- Monster slayer chains -->
     <string name="quest_goblin_slayer_1_name">ゴブリンスレイヤー I</string>
@@ -251,7 +251,7 @@
     <string name="quest_firemaking_2_name">火起こし II</string>
     <string name="quest_firemaking_2_objective">オークの原木を750本燃やす</string>
     <string name="quest_firemaking_3_name">火起こし III</string>
-    <string name="quest_firemaking_3_objective">ウィローの原木を1100本燃やす</string>
+    <string name="quest_firemaking_3_objective">ヤナギの原木を1100本燃やす</string>
     <string name="quest_firemaking_4_name">火起こし IV</string>
     <string name="quest_firemaking_4_objective">メープルの原木を1650本燃やす</string>
     <string name="quest_firemaking_5_name">火起こし V</string>
@@ -404,7 +404,7 @@
     <string name="quest_daily_fish_swordfish_name">メカジキハンター</string>
     <string name="quest_daily_fish_shark_name">サメ使い</string>
     <string name="quest_daily_wc_oak_name">オークの木こり</string>
-    <string name="quest_daily_wc_willow_name">ウィローの細工師</string>
+    <string name="quest_daily_wc_willow_name">ヤナギの細工師</string>
     <string name="quest_daily_wc_yew_name">イチイの木こり</string>
     <string name="quest_daily_wc_magic_name">魔法の木こり</string>
     <string name="quest_daily_smith_iron_name">鉄の鍛冶職人</string>


### PR DESCRIPTION
## Before submitting

- [x] I've tested any changes with appropriate tests (eg. Unit tests, validation scripts)
- [x] I've pulled and merged the latest changes from the repository

## Summary
This pull request improves the quality of the Japanese translation by resolving term inconsistencies and updating specific names to fit the game's context better. 

- Fixed inconsistent terms for the filter chips in `strings.xml`.
- Updated Platinum from "白金" to "プラチナ" and Willow from "ウィロー" to "ヤナギ" for better localization styling.

## Related issue(s) or discussion(s)

<!-- None -->

## Changelog

- Fixed inconsistencies in the translation of filter chips in strings.xml.
- Changed the translation of Platinum from "白金" to "プラチナ."
- Changed the translation of Willow from "ウィロー" to "ヤナギ."

## Anything else?

I reviewed the strings after the initial merge and verified that these changes provide a more natural and consistent experience for Japanese players.