### PR TITLE
issue_templates: close an unclosed parenthese

### DIFF
--- a/.github/ISSUE_TEMPLATE/wiki_error.yml
+++ b/.github/ISSUE_TEMPLATE/wiki_error.yml
@@ -11,7 +11,7 @@ body:
           required: true
         - label: This relates to the latest version of the game
           required: true
-        - label: _(Optional)_ I would like to fix this myself (Thanks! See [how to get started](https://idlefantasy.tristinbaker.xyz/getting_started_wiki.html)
+        - label: _(Optional)_ I would like to fix this myself (Thanks! See [how to get started](https://idlefantasy.tristinbaker.xyz/getting_started_wiki.html))
           required: false
 
   - type: input


### PR DESCRIPTION
## Before submitting

- [x] I've tested any changes with appropriate tests (eg. Unit tests, validation scripts)
- [x] I've pulled and merged the latest changes from the repository

## Summary

A parenthesis was not closed in the wiki issue template. This close it.



## Related issue(s) or discussion(s)

N/A



## Changelog

No changelog for wiki fixes I think?