### PR TITLE
Bugfix: Fixed the source for the juggling imp

### DIFF
--- a/app/src/main/assets/data/pets.json
+++ b/app/src/main/assets/data/pets.json
@@ -194,7 +194,7 @@
     "display_name": "Juggling Imp",
     "emoji": "\ud83e\udd39",
     "description": "A mischievous imp that juggles your worries away. Boosts all skill XP by 3%.",
-    "source": "Carnival prize shop (2,000 tickets)",
+    "source": "Carnival prize shop (4,000 tickets)",
     "effect_type": "xp_boost",
     "boosted_skill": "all",
     "boost_percent": 3


### PR DESCRIPTION
## Before submitting

- [x] I've tested any changes with appropriate tests (eg. Unit tests, validation scripts)
- [x] I've pulled and merged the latest changes from the repository

## Summary

<!-- Short summary of the pull request and what it changes -->

This pull request fixes the source for the juggling imp that is referred to in the wiki

## Related issue(s) or discussion(s)

<!-- Prepend issues with "Fixes" if this should close the issue, e.g. Fixes #283, Relates to #284 -->

Fixes #1050

## Changelog

<!-- Concise list of changes, e.g.
- Fix time-slot bug causing XP gains to not show in notification banner
- Added ellipsis for quests XP gains exceeding screen width
-->

- Fix: Source for juggling imp now uses correct 4,000 ticket amount
