### PR TITLE
Bugfix: Fix king black dragons counting toward green dragon quest

### DIFF
--- a/app/src/main/assets/data/enemies.json
+++ b/app/src/main/assets/data/enemies.json
@@ -725,6 +725,7 @@
   "dragon": {
     "name": "dragon",
     "display_name": "Green Dragon",
+    "tags": ["green_dragon"],
     "hp": 150,
     "combat_stats": {
       "attack_level": 28,

--- a/app/src/main/assets/data/quests.json
+++ b/app/src/main/assets/data/quests.json
@@ -1400,7 +1400,7 @@
     "tier": 9,
     "requires_previous": null,
     "type": "kill_enemy",
-    "target": "dragon",
+    "target": "green_dragon",
     "amount": 10,
     "description": "Defeat 10 Green Dragons",
     "rewards": {
@@ -1416,7 +1416,7 @@
     "tier": 10,
     "requires_previous": "dragon_slayer_1",
     "type": "kill_enemy",
-    "target": "dragon",
+    "target": "green_dragon",
     "amount": 25,
     "description": "Defeat 25 Green Dragons",
     "rewards": {

--- a/app/src/main/kotlin/com/fantasyidler/repository/QuestRepository.kt
+++ b/app/src/main/kotlin/com/fantasyidler/repository/QuestRepository.kt
@@ -239,6 +239,34 @@ class QuestRepository @Inject constructor(
     /** Adds [delta] to the stored progress for [questId], creating a row if absent. Skips already-completed quests. */
     suspend fun resetAllProgress() = questProgressDao.deleteAll()
 
+    /**
+     * Debug helper: clears progress/completion for [questId] and every quest that
+     * transitively lists it (or one of its dependents) as [QuestData.requiresPrevious].
+     * Does not claw back rewards already granted.
+     */
+    suspend fun resetQuestAndDependents(questId: String) {
+        // Return if quest is unknown
+        if (questId !in gameData.quests) return
+        // Map prerequisites -> dependents
+        val dependentsByPrereq = mutableMapOf<String, MutableList<String>>()
+        for ((id, quest) in gameData.quests) {
+            val prereq = quest.requiresPrevious ?: continue
+            dependentsByPrereq.getOrPut(prereq) { mutableListOf() }.add(id)
+        }
+        // Find all affected quests (questId and dependents)
+        val toReset = linkedSetOf<String>()
+        val queue = ArrayDeque<String>().apply { add(questId) }
+        while (queue.isNotEmpty()) {
+            val current = queue.removeFirst()
+            if (!toReset.add(current)) continue
+            dependentsByPrereq[current]?.forEach { queue.add(it) }
+        }
+        // Reset progress
+        for (id in toReset) {
+            questProgressDao.upsert(QuestProgress(questId = id))
+        }
+    }
+
     private suspend fun addProgress(questId: String, requiredAmount: Int, delta: Int, requiresPrevious: String?) {
         val current = questProgressDao.getQuestProgress(questId) ?: QuestProgress(questId)
         if (current.completed) return

--- a/app/src/main/kotlin/com/fantasyidler/ui/screen/QuestsScreen.kt
+++ b/app/src/main/kotlin/com/fantasyidler/ui/screen/QuestsScreen.kt
@@ -29,7 +29,9 @@ import androidx.compose.material3.Tab
 import androidx.compose.material3.TabRow
 import androidx.compose.material3.ScrollableTabRow
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar
+import com.fantasyidler.BuildConfig
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
@@ -200,6 +202,7 @@ fun QuestsScreen(
                                 QuestRow(
                                     questWithProgress = questWithProgress,
                                     onClaimReward     = { viewModel.claimReward(questWithProgress.quest.id) },
+                                    onDebugReset      = { viewModel.debugResetQuest(questWithProgress.quest.id) },
                                 )
                                 HorizontalDivider(modifier = Modifier.padding(horizontal = 16.dp))
                             }
@@ -542,6 +545,7 @@ private fun DailyQuestCard(
 private fun QuestRow(
     questWithProgress: QuestWithProgress,
     onClaimReward: () -> Unit,
+    onDebugReset: () -> Unit,
 ) {
     val context = LocalContext.current
     val quest   = questWithProgress.quest
@@ -564,7 +568,6 @@ private fun QuestRow(
             fontWeight = FontWeight.Bold,
             color      = titleColor,
         )
-
         // Description / objective
         val objective = GameStrings.questObjective(context, quest.id).takeIf { it.isNotBlank() }
             ?: buildQuestObjective(context, quest)
@@ -613,6 +616,12 @@ private fun QuestRow(
                     color = Color(0xFF4CAF50),
                     fontWeight = FontWeight.SemiBold,
                 )
+            }
+        }
+
+        if (BuildConfig.DEBUG && (questWithProgress.completed || questWithProgress.progress > 0)) {
+            TextButton(onDebugReset) {
+                Text("Reset")
             }
         }
 

--- a/app/src/main/kotlin/com/fantasyidler/ui/viewmodel/QuestsViewModel.kt
+++ b/app/src/main/kotlin/com/fantasyidler/ui/viewmodel/QuestsViewModel.kt
@@ -169,6 +169,12 @@ class QuestsViewModel @Inject constructor(
         }
     }
 
+    fun debugResetQuest(questId: String) {
+        viewModelScope.launch {
+            questRepo.resetQuestAndDependents(questId)
+        }
+    }
+
     private suspend fun applyClaimSuccess(questId: String, rewards: QuestRewards) {
         val quest = gameData.quests[questId] ?: return
 


### PR DESCRIPTION
## Before submitting

- [x] I've tested any changes with appropriate tests (eg. Unit tests, validation scripts)
- [x] I've pulled and merged the latest changes from the repository

## Summary

<!-- Short summary of the pull request and what it changes -->

This pull request makes it so only the green dragon counts towards the green dragon quest whereas previously, the king black dragon also counted. It adds a tag to the green dragon and changes the target. It also adds a debug button to reset quest progress

## Related issue(s) or discussion(s)

<!-- Prepend issues with "Fixes" if this should close the issue, e.g. Fixes #283, Relates to #284 -->

Fixes #1051

## Changelog

<!-- Concise list of changes, e.g.
- Fix time-slot bug causing XP gains to not show in notification banner
- Added ellipsis for quests XP gains exceeding screen width
-->

- Fix: Ensure only the green dragon counts towards the green dragon quest
- New: Add debug button to reset quest progress on debug builds