### PR TITLE
Debugging: Add debug button that resets guild daily quests

### DIFF
--- a/app/src/main/kotlin/com/fantasyidler/repository/GuildRepository.kt
+++ b/app/src/main/kotlin/com/fantasyidler/repository/GuildRepository.kt
@@ -13,6 +13,8 @@ import javax.inject.Singleton
 import kotlin.random.Random
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.sync.withLock
+import kotlin.random.nextInt
+import kotlin.random.nextLong
 
 data class GuildQuestWithProgress(
     val quest: GuildQuestData,
@@ -501,11 +503,12 @@ class GuildRepository @Inject constructor(
 
     /** Selects up to 4 daily templates per guild for today, filtered by current guild level.
      *  Uses a date-seeded RNG so the same dailies are shown all day. */
-    fun buildRefreshedGuildDailyFlags(flags: PlayerFlags, completedQuestIds: Set<String>, skillLevels: Map<String, Int> = emptyMap()): PlayerFlags {
+    fun buildRefreshedGuildDailyFlags(flags: PlayerFlags, completedQuestIds: Set<String>, skillLevels: Map<String, Int> = emptyMap(), randomSeed: Boolean = false): PlayerFlags {
         val today = Calendar.getInstance().let {
             it.get(Calendar.YEAR) * 10000 + it.get(Calendar.MONTH) * 100 + it.get(Calendar.DAY_OF_MONTH)
         }
-        val rng = Random(today.toLong())
+        val rng = if (randomSeed) Random(Random.nextLong()) else Random(today.toLong())
+   
         val selectedIds = mutableListOf<String>()
 
         for (guild in ALL_GUILDS) {
@@ -529,6 +532,18 @@ class GuildRepository @Inject constructor(
 
     /** Refreshes guild dailies if needed, then retroactively resets any quest progress that pre-accumulated above the current tier. */
     suspend fun ensureGuildDailiesRefreshed(): PlayerFlags = playerRepo.playerMutex.withLock { ensureGuildDailiesRefreshedUnlocked() }
+
+    /**
+     * Debug helper: force-regenerates today's guild dailies and clears progress/claimed state,
+     * as if the 6am daily reset had just fired.
+     */
+    suspend fun debugResetGuildDailies() = playerRepo.playerMutex.withLock {
+        val flags = playerRepo.getFlags()
+        val completedQuestIds = loadCompletedQuestIds()
+        val skillLevels = try { playerRepo.getSkillLevels() } catch (_: Exception) { emptyMap() }
+        val refreshed = buildRefreshedGuildDailyFlags(flags, completedQuestIds, skillLevels, true)
+        playerRepo.updateFlagsUnlocked(refreshed)
+    }
 
     internal suspend fun ensureGuildDailiesRefreshedUnlocked(): PlayerFlags {
         var flags = getRefreshedGuildDailyFlags()

--- a/app/src/main/kotlin/com/fantasyidler/ui/screen/GuildHallScreen.kt
+++ b/app/src/main/kotlin/com/fantasyidler/ui/screen/GuildHallScreen.kt
@@ -33,6 +33,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
@@ -44,6 +45,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
+import com.fantasyidler.BuildConfig
 import com.fantasyidler.R
 import com.fantasyidler.ui.theme.GoldPrimary
 import com.fantasyidler.ui.viewmodel.GuildHallViewModel
@@ -138,6 +140,11 @@ fun GuildHallScreen(
                     color    = MaterialTheme.colorScheme.onSurfaceVariant,
                     modifier = Modifier.padding(horizontal = 16.dp, vertical = 12.dp),
                 )
+                if (BuildConfig.DEBUG) {
+                    TextButton(onClick  = { viewModel.debugResetGuildDailies() }) {
+                        Text("[Debug] Reset dailies")
+                    }
+                }
             }
             for (group in GUILD_GROUPS) {
                 item(key = "header_${group.headerRes}") {

--- a/app/src/main/kotlin/com/fantasyidler/ui/viewmodel/GuildHallViewModel.kt
+++ b/app/src/main/kotlin/com/fantasyidler/ui/viewmodel/GuildHallViewModel.kt
@@ -95,4 +95,10 @@ class GuildHallViewModel @Inject constructor(
 
         GuildHallUiState(isLoading = false, guilds = summaries)
     }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), GuildHallUiState())
+
+    fun debugResetGuildDailies() {
+        viewModelScope.launch {
+            guildRepo.debugResetGuildDailies()
+        }
+    }
 }


### PR DESCRIPTION
## Before submitting

- [x] I've tested any changes with the appropriate tests (eg. Unit tests, validation scripts)
- [x] I've pulled and merged the latest changes from the repository

## Summary

<!-- Short summary of the pull request and what it changes -->

Adds a debug button to the guild hall to reset daily quests. This was used when debugging the issues in #1076.

## Related issue(s) or discussion(s)

<!-- Prepend issues with "Fixes" if this should close the issue, e.g. Fixes #283, Relates to #284 -->

Relates to #1076

## Changelog

<!-- Concise list of changes, e.g.
- Fix time-slot bug causing XP gains to not show in notification banner
- Added ellipsis for quests XP gains exceeding screen width
-->

- Adds a debug button to the guild hall
- Adds a new parameter to GuildRepository::buildRefreshedGuildDailyFlags that allows forcing a random seed instead of relying on the current date - keeps normal gameplay the same

## Anything else?

Only issue I can see with this is the minor modification to GuildRepository::buildRefreshedGuildDailyFlags but otherwise could be helpful