### PR TITLE
Bugfix: Fix small error in wiki

### DIFF
--- a/wiki/src/pages.py
+++ b/wiki/src/pages.py
@@ -830,8 +830,8 @@ def _trade_route_rows(ranges: list[tuple[int, dict]]):
     rows = []
     for i, (start_level, tr_range) in enumerate(ranges):
         mercantile_level = f"{start_level}-{ranges[i + 1][0]}" if i < len(ranges) - 1 else f">{start_level}"
-        average_return = int((tr_range["max"] + tr_range["min"]) / 2)
-        rows.append([mercantile_level, f"{tr_range["min"]}-{tr_range["max"]}", str(average_return)])
+        average_return = int((tr_range["max"] + tr_range["min"]) * 60 / 2)
+        rows.append([mercantile_level, f"{tr_range["min"] * 60:,}-{tr_range["max"] * 60:,}", f"{average_return:,}"])
     return rows
 
 
@@ -849,7 +849,7 @@ def gen_trade_route(trade_route: dict) -> str:
     return get_template("skills/support/trade_route").format(
         title=trade_route["display_name"],
         min_level=trade_route["level_required"],
-        cost=trade_route["coin_cost"],
+        cost=f"{trade_route["coin_cost"]:,}",
         description=trade_route["description"],
         xp_ranges_table=table(["Mercantile Level", "XP range", "Average xp"], _trade_route_rows(xp_ranges)),
         coin_ranges_table=table(["Mercantile Level", "Coin range", "Average coins"], _trade_route_rows(coin_ranges)),


### PR DESCRIPTION
## Before submitting

- [x] I've tested any changes with the appropriate tests (eg. Unit tests, validation scripts)
- [x] I've pulled and merged the latest changes from the repository

## Summary

<!-- Short summary of the pull request and what it changes -->

Just realised when I was typing up a discussion topic that I made a small mistake as the trade routes showed the per-minute coin amounts instead of the full route amounts as they should have. This pull request fixes that

## Related issue(s) or discussion(s)

<!-- Prepend issues with "Fixes" if this should close the issue, e.g. Fixes #283, Relates to #284 -->

Relates to #1089

## Changelog

<!-- Concise list of changes, e.g.
- Fix time-slot bug causing XP gains to not show in notification banner
- Added ellipsis for quests XP gains exceeding screen width
-->

- Fix coin and xp ranges in wiki to show full amounts after completion not per-minute