### PR TITLE
Debug: Add screen to add items to the inventory directly

### DIFF
--- a/app/src/main/kotlin/com/fantasyidler/ui/screen/DebugModifyItemCountSheet.kt
+++ b/app/src/main/kotlin/com/fantasyidler/ui/screen/DebugModifyItemCountSheet.kt
@@ -1,0 +1,113 @@
+package com.fantasyidler.ui.screen
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.BottomSheetDefaults
+import androidx.compose.material3.Button
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.unit.dp
+
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalLayoutApi::class)
+@Composable
+fun DebugModifyItemCountSheet(
+    onAddItem: (name: String, amount: Int) -> Unit,
+    onRemoveItem: (name: String, amount: Int) -> Unit,
+    onDismiss: () -> Unit,
+) {
+    var draftID by remember { mutableStateOf("") }
+    var draftAmountText by remember { mutableStateOf("") }
+    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+
+    ModalBottomSheet(
+        onDismissRequest = onDismiss,
+        sheetState       = sheetState,
+        dragHandle       = { BottomSheetDefaults.DragHandle() },
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .verticalScroll(rememberScrollState())
+                .padding(horizontal = 16.dp)
+                .padding(bottom = 32.dp),
+            verticalArrangement = Arrangement.spacedBy(16.dp),
+        ) {
+            Text(
+                text  = "Debug: Modify Item Count",
+                style = MaterialTheme.typography.titleLarge,
+            )
+
+            OutlinedTextField(
+                value         = draftID,
+                onValueChange = { draftID = it },
+                label         = { Text("Item ID") },
+                singleLine    = true,
+                modifier      = Modifier.fillMaxWidth(),
+            )
+
+            OutlinedTextField(
+                value         = draftAmountText,
+                onValueChange = { new ->
+                    draftAmountText = new.filter { it.isDigit() }
+                },
+                label         = { Text("Item Amount") },
+                singleLine    = true,
+                modifier      = Modifier.fillMaxWidth(),
+                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+            )
+       
+
+            HorizontalDivider()
+
+            Row(
+                modifier              = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.End,
+            ) {
+                TextButton(onClick = onDismiss) {
+                    Text("Cancel")
+                }
+                Spacer(Modifier.width(8.dp))
+                Button(
+                    onClick = {
+                        onRemoveItem(draftID.trim(), draftAmountText.toInt())
+                    },
+                    enabled = draftID.isNotBlank() && draftAmountText.isNotBlank() &&
+                            draftAmountText.toInt() > 0,
+                ) {
+                    Text("Remove")
+                }
+                Button(
+                    onClick  = {
+                        onAddItem(draftID.trim(), draftAmountText.toInt())
+                    },
+                    enabled  = draftID.isNotBlank() && draftAmountText.isNotBlank() &&
+                            draftAmountText.toInt() > 0,
+                ) {
+                    Text("Add")
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/kotlin/com/fantasyidler/ui/screen/ProfileScreen.kt
+++ b/app/src/main/kotlin/com/fantasyidler/ui/screen/ProfileScreen.kt
@@ -1,7 +1,6 @@
 package com.fantasyidler.ui.screen
 
 import android.widget.Toast
-import kotlin.math.roundToInt
 import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.clickable
@@ -29,7 +28,6 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Clear
 import androidx.compose.material.icons.filled.Edit
 import androidx.compose.material.icons.filled.Person
 import androidx.compose.foundation.background
@@ -37,8 +35,6 @@ import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.WindowInsetsSides
 import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.safeDrawing
-import androidx.compose.material3.Button
-import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.FilterChip
 import androidx.compose.material3.BottomSheetDefaults
 import androidx.compose.material3.ElevatedCard
@@ -69,7 +65,6 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
 import androidx.compose.ui.geometry.Rect
 import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.graphics.ColorMatrix
@@ -85,11 +80,9 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
+import com.fantasyidler.BuildConfig
 import com.fantasyidler.R
 import com.fantasyidler.data.json.SkillingDungeonData
-import com.fantasyidler.data.json.ConstructionRecipe
-import com.fantasyidler.data.json.ThievingNpcData
-import com.fantasyidler.data.model.EquipSlot
 import com.fantasyidler.ui.theme.GoldPrimary
 import com.fantasyidler.ui.viewmodel.Achievement
 import com.fantasyidler.ui.viewmodel.AchievementsViewModel
@@ -101,12 +94,10 @@ import com.fantasyidler.ui.viewmodel.TitleCatalog
 import com.fantasyidler.util.drawableByName
 import com.fantasyidler.ui.viewmodel.InventoryViewModel
 import com.fantasyidler.ui.viewmodel.SettingsViewModel
-import com.fantasyidler.ui.viewmodel.slotDisplayName
 import com.fantasyidler.ui.viewmodel.xpProgressFraction
 import com.fantasyidler.util.GameStrings
 import com.fantasyidler.util.formatCoins
 import com.fantasyidler.util.stringByName
-import com.fantasyidler.util.toTitleCase
 
 private val SKILL_CATEGORY_GROUPS: List<Pair<Int, List<String>>> = listOf(
     R.string.label_gathering      to listOf("mining", "fishing", "woodcutting", "farming", "thieving"),
@@ -153,6 +144,7 @@ fun ProfileScreen(
     var selectedTab  by remember { mutableIntStateOf(0) }
     var showEditSheet by remember { mutableStateOf(false) }
     var showAppearanceSheet by remember { mutableStateOf(false) }
+    var showAddItemSheet by remember { mutableStateOf(false) }
 
     Scaffold(
         contentWindowInsets = WindowInsets.safeDrawing.only(WindowInsetsSides.Top),
@@ -245,7 +237,7 @@ fun ProfileScreen(
             val tabContent: @Composable (Int) -> Unit = { tab ->
                 when (tab) {
                     0    -> SkillsTab(state.skillLevels, state.skillXp, context, viewModel)
-                    1    -> InventoryTab(state.inventory, context, viewModel::categoryFor)
+                    1    -> InventoryTab(state.inventory, context, viewModel::categoryFor) { showAddItemSheet = true }
                     2    -> EquipmentTab(
                         equipped           = state.equipped,
                         context            = context,
@@ -358,6 +350,19 @@ fun ProfileScreen(
         )
     }
 
+    if (BuildConfig.DEBUG && showAddItemSheet) {
+        DebugModifyItemCountSheet(
+            onAddItem    = { itemId, amount ->
+                viewModel.debugAddItem(itemId, amount)
+                showAddItemSheet = false
+            },
+            onRemoveItem = { itemId, amount ->
+                viewModel.debugRemoveItem(itemId, amount)
+                showAddItemSheet = false
+            },
+            onDismiss    = { showAddItemSheet = false },
+        )
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -823,6 +828,7 @@ private fun InventoryTab(
     inventory: Map<String, Int>,
     context: android.content.Context,
     categoryFor: (String) -> InventoryCategory,
+    onDebugAddItem: () -> Unit,
 ) {
     var sortAlpha by remember { mutableStateOf(false) }
     var selectedCategory by remember { mutableStateOf<InventoryCategory?>(null) }
@@ -846,6 +852,11 @@ private fun InventoryTab(
     }
 
     Column(modifier = Modifier.fillMaxSize()) {
+        if (BuildConfig.DEBUG) {
+            TextButton(onClick = onDebugAddItem) {
+                Text("[Debug] Modify Item Count")
+            }
+        }
         Row(
             modifier              = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
             horizontalArrangement = Arrangement.spacedBy(8.dp),

--- a/app/src/main/kotlin/com/fantasyidler/ui/viewmodel/InventoryViewModel.kt
+++ b/app/src/main/kotlin/com/fantasyidler/ui/viewmodel/InventoryViewModel.kt
@@ -32,6 +32,8 @@ import com.fantasyidler.repository.GameDataRepository
 import com.fantasyidler.repository.PlayerRepository
 import com.fantasyidler.repository.TitleRepository
 import com.fantasyidler.util.GameStrings
+import com.fantasyidler.util.stringByName
+import com.fantasyidler.util.withAppLocale
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
@@ -429,6 +431,49 @@ class InventoryViewModel @Inject constructor(
 
     private val cropProduceKeys: Set<String> by lazy {
         gameData.crops.keys.toSet()
+    }
+
+    fun debugAddItem(itemId: String, amount: Int) {
+        viewModelScope.launch {
+            val key = itemId.trim()
+            if (key.isEmpty() || amount <= 0) return@launch
+
+            if (!isKnownItemId(key)) {
+                _extra.update { it.copy(snackbarMessage = "$key not found") }
+                return@launch
+            }
+
+            playerRepo.addItem(key, amount)
+            val name = GameStrings.itemName(context.withAppLocale(), key)
+            _extra.update { it.copy(snackbarMessage = "$amount $name added") }
+        }
+    }
+
+    fun debugRemoveItem(itemId: String, amount: Int) {
+        viewModelScope.launch {
+            val key = itemId.trim()
+            if (key.isEmpty() || amount <= 0) return@launch
+
+            if (!isKnownItemId(key)) {
+                _extra.update { it.copy(snackbarMessage = "$key not found") }
+                return@launch
+            }
+
+            if (playerRepo.sellItem(key, amount, 0)) {
+                val name = GameStrings.itemName(context.withAppLocale(), key)
+                _extra.update { it.copy(snackbarMessage = "$amount $name removed") }
+            } else {
+                val name = GameStrings.itemName(context.withAppLocale(), key)
+                _extra.update { it.copy(snackbarMessage = "Not enough $name to remove $amount items") }
+            }
+        }
+    }
+
+    private fun isKnownItemId(itemId: String): Boolean {
+        val localeCtx = context.withAppLocale()
+        return localeCtx.stringByName("item_${itemId}_name") != null ||
+            localeCtx.stringByName("crop_${itemId}_name") != null ||
+            itemId in gameData.usefulItemKeys
     }
 }
 


### PR DESCRIPTION
## Before submitting

- [x] I've tested any changes with the appropriate tests (eg. Unit tests, validation scripts)
- [x] I've pulled and merged the latest changes from the repository

## Summary

<!-- Short summary of the pull request and what it changes -->

This pull request adds a new sheet used when debugging allowing you to directly add items to the inventory. It uses the item ID to add said item

## Related issue(s) or discussion(s)

<!-- Prepend issues with "Fixes" if this should close the issue, e.g. Fixes #283, Relates to #284 -->

Used when debugging #1016

## Changelog

<!-- Concise list of changes, e.g.
- Fix time-slot bug causing XP gains to not show in notification banner
- Added ellipsis for quests XP gains exceeding screen width
-->

- New: Add debug button to inventory tab in the profile allowing direct additions to the inventory

