### PR TITLE
Debug: Add instant harvest/climb options for farming

### DIFF
--- a/app/src/main/kotlin/com/fantasyidler/ui/screen/FarmingScreen.kt
+++ b/app/src/main/kotlin/com/fantasyidler/ui/screen/FarmingScreen.kt
@@ -64,6 +64,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
+import com.fantasyidler.BuildConfig
 import com.fantasyidler.R
 import com.fantasyidler.data.json.CropData
 import com.fantasyidler.data.model.FarmingPatch
@@ -381,7 +382,7 @@ private fun PatchCard(
 
     val isEmpty   = patch == null || patch.cropType == null
     val cropData  = patch?.cropType?.let { crops[it] }
-    val remaining = if (isEmpty) Long.MAX_VALUE else patch!!.remainingMs(crops, now)
+    val remaining = if (isEmpty) Long.MAX_VALUE else patch.remainingMs(crops, now)
     val isReady   = !isEmpty && remaining <= 0
     val isGrowing = !isEmpty && !isReady
 
@@ -418,7 +419,7 @@ private fun PatchCard(
                     val elapsed   = growthMs - remaining
                     val progress  = (elapsed.toFloat() / growthMs).coerceIn(0f, 1f)
 
-                    if (patch?.cropType == "magic_bean") {
+                    if (patch.cropType == "magic_bean") {
                         // Magic bean — show cryptic progress note, no crop name or time
                         val note = when {
                             progress < 0.12f -> stringResource(R.string.farming_bean_note_1)
@@ -441,6 +442,11 @@ private fun PatchCard(
                             modifier = Modifier.fillMaxWidth().height(6.dp).clip(RoundedCornerShape(3.dp)),
                             color    = GoldPrimary,
                         )
+                        if (BuildConfig.DEBUG) {
+                            TextButton(onClick = onClimb) {
+                                Text("[Debug] Instant Climb")
+                            }
+                        }
                     } else {
                         // Normal crop
                         Text(
@@ -468,6 +474,11 @@ private fun PatchCard(
                             style = MaterialTheme.typography.bodySmall,
                             color = MaterialTheme.colorScheme.onSurfaceVariant,
                         )
+                        if (BuildConfig.DEBUG) {
+                            TextButton(onClick = onHarvest) {
+                                Text("[Debug] Instant Harvest")
+                            }
+                        }
                     }
                     Spacer(Modifier.height(8.dp))
                     OutlinedButton(
@@ -480,7 +491,7 @@ private fun PatchCard(
                 }
 
                 isReady -> {
-                    if (patch?.cropType == "magic_bean") {
+                    if (patch.cropType == "magic_bean") {
                         // Magic bean ready — show Climb button
                         Text(
                             text  = stringResource(R.string.farming_bean_ready),


### PR DESCRIPTION
## Before submitting

- [x] I've tested any changes with the appropriate tests (eg. Unit tests, validation scripts)
- [x] I've pulled and merged the latest changes from the repository

## Summary

<!-- Short summary of the pull request and what it changes -->

Simple feature that adds an instant harvest/climb for debug builds

## Related issue(s) or discussion(s)

<!-- Prepend issues with "Fixes" if this should close the issue, e.g. Fixes #283, Relates to #284 -->

Used while debugging #1016

## Changelog

<!-- Concise list of changes, e.g.
- Fix time-slot bug causing XP gains to not show in notification banner
- Added ellipsis for quests XP gains exceeding screen width
-->

- Adds a text button which instantly harvests patches and also allows for climbing magic beans