### PR TITLE
Increase emphasis on implicit next steps after climbing the beanstalk

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1376,7 +1376,7 @@
     <string name="farming_bean_note_8">Almost there. The air grows thin. You can nearly see the top.</string>
     <string name="farming_bean_ready">The beanstalk reaches beyond the clouds. Ready to climb?</string>
     <string name="farming_bean_climb">Climb</string>
-    <string name="farming_bean_climbed">You have climbed the beanstalk. Something awaits…</string>
+    <string name="farming_bean_climbed">You have climbed the beanstalk. A serpent\'s hiss catches your attention…</string>
     <string name="farming_bean_picker_stats">\?\?\?  •  \?\?\?  •  \?\?\?</string>
     <string name="farming_magic_bean_one_plot">Magic Beans can only be planted in one plot</string>
 


### PR DESCRIPTION
## Before submitting

- [x] I've tested any changes with the appropriate tests (eg. Unit tests, validation scripts)
- [x] I've pulled and merged the latest changes from the repository

## Summary

<!-- Short summary of the pull request and what it changes -->

This attempts to make the notification a bit more suggestive, encouraging players to check out the dungeons whilst still attempting to retain the general whimsical writing style.

## Related issue(s) or discussion(s)

<!-- Prepend issues with "Fixes" if this should close the issue, e.g. Fixes #283, Relates to #284 -->

Relates to feature request #1117

## Changelog

<!-- Concise list of changes, e.g.
- Fix time-slot bug causing XP gains to not show in notification banner
- Added ellipsis for quests XP gains exceeding screen width
-->

- Fix: Emphasised the implicit next steps after climbing the beanstalk

## Anything else?

I'm unaware if there's a way to mark strings as stale - eg. How to effectively show that the e.g. German translation needs updating