### PR TITLE
Increase emphasis on implicit next steps after climbing the beanstalk

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1376,7 +1376,7 @@
     <string name="farming_bean_note_8">Almost there. The air grows thin. You can nearly see the top.</string>
     <string name="farming_bean_ready">The beanstalk reaches beyond the clouds. Ready to climb?</string>
     <string name="farming_bean_climb">Climb</string>
-    <string name="farming_bean_climbed">You have climbed the beanstalk. Something awaits…</string>
+    <string name="farming_bean_climbed">You have climbed the beanstalk. A serpent\'s hiss catches your attention…</string>
     <string name="farming_bean_picker_stats">\?\?\?  •  \?\?\?  •  \?\?\?</string>
     <string name="farming_magic_bean_one_plot">Magic Beans can only be planted in one plot</string>
 


### PR DESCRIPTION
Resolves the merge conflict blocking #1118 (rebased onto current main, keeping the `translatable="false"` attribute added since that branch diverged).

Closes #1118

🤖 Generated with [Claude Code](https://claude.com/claude-code)