### PR TITLE
Fix: Modify translations on bonuses page to include percentage

### DIFF
--- a/app/src/main/kotlin/com/fantasyidler/ui/screen/BonusesTab.kt
+++ b/app/src/main/kotlin/com/fantasyidler/ui/screen/BonusesTab.kt
@@ -198,7 +198,7 @@ internal fun BonusesTab(
                     val xpDetail = entry.xpSources.joinToString(" • ") { (label, pct) -> "$label +$pct%" }
                     BonusRow(
                         name   = entry.skillName,
-                        pct    = "+${entry.xpPct}% XP",
+                        pct    = stringResource(R.string.bonus_xp, entry.xpPct),
                         scope  = "",
                         detail = xpDetail.ifEmpty { null },
                     )
@@ -206,7 +206,7 @@ internal fun BonusesTab(
                 if (entry.yieldPct > 0) {
                     BonusRow(
                         name   = entry.skillName,
-                        pct    = "+${entry.yieldPct}% ${stringResource(R.string.bonus_yield)}",
+                        pct    = stringResource(R.string.bonus_yield, entry.yieldPct),
                         scope  = "",
                         detail = entry.yieldSource,
                     )
@@ -238,7 +238,7 @@ internal fun BonusesTab(
                 item {
                     BonusRow(
                         name  = GameStrings.skillName(context, Skills.MERCANTILE),
-                        pct   = "+${mercantilePrestige * 10}% ${stringResource(R.string.bonus_coin_return)}",
+                        pct   = stringResource(R.string.bonus_coin_return, mercantilePrestige * 10),
                         scope = "",
                     )
                 }

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -1333,9 +1333,9 @@
     <string name="bonus_section_skills">Fähigkeits-Bonus</string>
     <string name="bonus_combat_stat_boost">Verstärkt Kampffähigkeiten</string>
     <string name="bonus_combined_xp">EP gesamt</string>
-    <string name="bonus_yield">Ausbeute</string>
+    <string name="bonus_yield">+%1$d%% Ausbeute</string>
     <string name="bonus_session_shorter">%1$d Min. kürzere Sitzungen</string>
-    <string name="bonus_coin_return">Münzrückgabe</string>
+    <string name="bonus_coin_return">+%1$d%% Münzrückgabe</string>
     <string name="snackbar_added_to_queue">Zur Warteschlange hinzugefügt: %1$s.</string>
     <string name="snackbar_queue_full">Warteschlange ist voll.</string>
     <string name="home_not_enough_coins_repeat">Nicht genug Münzen, um %1$s zu wiederholen.</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -1338,9 +1338,9 @@
     <string name="bonus_section_skills">Skill Bonuses</string>
     <string name="bonus_combat_stat_boost">Boosts combat stats</string>
     <string name="bonus_combined_xp">XP combinado</string>
-    <string name="bonus_yield">rendimiento</string>
+    <string name="bonus_yield">+%1$d%% rendimiento</string>
     <string name="bonus_session_shorter">%1$d min de sesiones más cortas</string>
-    <string name="bonus_coin_return">devolución de monedas</string>
+    <string name="bonus_coin_return">+%1$d%% devolución de monedas</string>
     <string name="snackbar_added_to_queue">Añadido a la cola: %1$s.</string>
     <string name="snackbar_queue_full">La cola está llena.</string>
     <string name="home_not_enough_coins_repeat">No hay suficientes monedas para repetir %1$s.</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -1336,9 +1336,9 @@
     <string name="bonus_section_skills">Bonus de compétences</string>
     <string name="bonus_combat_stat_boost">Améliore les stats de combat</string>
     <string name="bonus_combined_xp">XP combiné</string>
-    <string name="bonus_yield">rendement</string>
+    <string name="bonus_yield">+%1$d%% rendement</string>
     <string name="bonus_session_shorter">%1$d min de sessions en moins</string>
-    <string name="bonus_coin_return">retour de pièces</string>
+    <string name="bonus_coin_return">+%1$d%% retour de pièces</string>
     <string name="snackbar_added_to_queue">Ajouté à la file: %1$s.</string>
     <string name="snackbar_queue_full">La file est pleine.</string>
     <string name="home_not_enough_coins_repeat">Pas assez de pièces pour répéter %1$s.</string>

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -1200,9 +1200,8 @@
     <string name="bonus_section_skills">Bonus Keahlian</string>
     <string name="bonus_combat_stat_boost">Meningkatkan stat tempur</string>
     <string name="bonus_combined_xp">Combined XP</string>
-    <string name="bonus_yield">yield</string>
     <string name="bonus_session_shorter">%1$d menit sesi lebih singkat</string>
-    <string name="bonus_coin_return">pengembalian koin</string>
+    <string name="bonus_coin_return">+%1$d%% pengembalian koin</string>
     <string name="snackbar_added_to_queue">Ditambahkan ke antrian: %1$s.</string>
     <string name="snackbar_queue_full">Antrian penuh.</string>
     <string name="combat_start_failed">Tak dapat memulai: %1$s</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -1480,9 +1480,9 @@
     <string name="bonus_section_skills">Bonus da Abilità</string>
     <string name="bonus_combat_stat_boost">Potenzia statistiche combattimento</string>
     <string name="bonus_combined_xp">XP combinata</string>
-    <string name="bonus_yield">resa</string>
+    <string name="bonus_yield">+%1$d%% resa</string>
     <string name="bonus_session_shorter">%1$d min in meno per sessione</string>
-    <string name="bonus_coin_return">ritorno in monete</string>
+    <string name="bonus_coin_return">+%1$d%% ritorno in monete</string>
     <string name="snackbar_added_to_queue">Aggiunto alla coda: %1$s.</string>
     <string name="snackbar_queue_full">La coda è piena.</string>
     <string name="combat_start_failed">Impossibile avviare: %1$s</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -1476,9 +1476,9 @@
     <string name="bonus_section_skills">スキルボーナス</string>
     <string name="bonus_combat_stat_boost">戦闘ステータス向上</string>
     <string name="bonus_combined_xp">経験値合算</string>
-    <string name="bonus_yield">収穫量</string>
+    <string name="bonus_yield">+%1$d%% 収穫量</string>
     <string name="bonus_session_shorter">セッション時間を %1$d 分短縮</string>
-    <string name="bonus_coin_return">コイン獲得</string>
+    <string name="bonus_coin_return">+%1$d%% コイン獲得</string>
     <string name="snackbar_added_to_queue">キューに追加: %1$s</string>
     <string name="snackbar_queue_full">キューが満杯です。</string>
     <string name="combat_start_failed">開始できませんでした: %1$s</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -1304,9 +1304,9 @@
     <string name="bonus_section_skills">Skill Bonuses</string>
     <string name="bonus_combat_stat_boost">Boosts combat stats</string>
     <string name="bonus_combined_xp">Gecombineerde XP</string>
-    <string name="bonus_yield">opbrengst</string>
+    <string name="bonus_yield">+%1$d%% opbrengst</string>
     <string name="bonus_session_shorter">%1$d min kortere sessies</string>
-    <string name="bonus_coin_return">muntteruggave</string>
+    <string name="bonus_coin_return">+%1$d%% muntteruggave</string>
     <string name="snackbar_added_to_queue">Toegevoegd aan wachtrij: %1$s.</string>
     <string name="snackbar_queue_full">Wachtrij is vol.</string>
     <string name="home_not_enough_coins_repeat">Niet genoeg munten om %1$s te herhalen.</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -1497,9 +1497,9 @@
     <string name="bonus_section_skills">Bonusy umiejętności</string>
     <string name="bonus_combat_stat_boost">Wzmacnia statystyki bojowe</string>
     <string name="bonus_combined_xp">Łączne XP</string>
-    <string name="bonus_yield">wydajność</string>
+    <string name="bonus_yield">+%1$d%% wydajność</string>
     <string name="bonus_session_shorter">%1$d min krótsze sesje</string>
-    <string name="bonus_coin_return">zwrot monet</string>
+    <string name="bonus_coin_return">+%1$d%% zwrot monet</string>
     <string name="snackbar_added_to_queue">Dodano do kolejki: %1$s.</string>
     <string name="snackbar_queue_full">Kolejka jest pełna.</string>
     <string name="combat_start_failed">Nie udało się rozpocząć: %1$s</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -1472,9 +1472,9 @@
     <string name="bonus_section_skills">Bônus de Habilidade</string>
     <string name="bonus_combat_stat_boost">Aumenta atributos de combate</string>
     <string name="bonus_combined_xp">XP Combinado</string>
-    <string name="bonus_yield">rendimento</string>
+    <string name="bonus_yield">+%1$d%% rendimento</string>
     <string name="bonus_session_shorter">%1$d min de sessões mais curtas</string>
-    <string name="bonus_coin_return">retorno de moedas</string>
+    <string name="bonus_coin_return">+%1$d%% retorno de moedas</string>
     <string name="snackbar_added_to_queue">Adicionado à fila: %1$s.</string>
     <string name="snackbar_queue_full">A fila está cheia.</string>
     <string name="combat_start_failed">Não foi possível iniciar: %1$s</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -1372,9 +1372,9 @@
     <string name="bonus_section_skills">Бонусы навыков</string>
     <string name="bonus_combat_stat_boost">Boosts combat stats</string>
     <string name="bonus_combined_xp">Суммарный XP</string>
-    <string name="bonus_yield">выход</string>
+    <string name="bonus_yield">+%1$d%% выход</string>
     <string name="bonus_session_shorter">На %1$d мин короче сессии</string>
-    <string name="bonus_coin_return">возврат монет</string>
+    <string name="bonus_coin_return">+%1$d%% возврат монет</string>
     <string name="snackbar_added_to_queue">Добавлено в очередь: %1$s.</string>
     <string name="snackbar_queue_full">Очередь заполнена.</string>
     <string name="home_not_enough_coins_repeat">Недостаточно монет для повтора %1$s.</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -1343,9 +1343,9 @@
     <string name="bonus_section_skills">Skill Bonuses</string>
     <string name="bonus_combat_stat_boost">Boosts combat stats</string>
     <string name="bonus_combined_xp">Birleşik XP</string>
-    <string name="bonus_yield">verim</string>
+    <string name="bonus_yield">+%1$d%% verim</string>
     <string name="bonus_session_shorter">%1$d dk daha kısa oturumlar</string>
-    <string name="bonus_coin_return">altın getirisi</string>
+    <string name="bonus_coin_return">+%1$d%% altın getirisi</string>
     <string name="snackbar_added_to_queue">Sıraya eklendi: %1$s.</string>
     <string name="snackbar_queue_full">Sıra dolu.</string>
     <string name="home_not_enough_coins_repeat">%1$s tekrarlamak için yeterli altın yok.</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1626,5 +1626,4 @@
     <string name="home_welcome_greeting">Welcome back,</string>
     <string name="home_welcome_name">%1$s!</string>
     <string name="home_welcome_title">The %1$s!</string>
-    <string name="bonus_xp">+%1$d%% XP</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1480,9 +1480,9 @@
     <string name="bonus_section_skills">Skill Bonuses</string>
     <string name="bonus_combat_stat_boost">Boosts combat stats</string>
     <string name="bonus_combined_xp">Combined XP</string>
-    <string name="bonus_yield">yield</string>
+    <string name="bonus_yield">+%1$d%% yield</string>
     <string name="bonus_session_shorter">%1$d min shorter sessions</string>
-    <string name="bonus_coin_return">coin return</string>
+    <string name="bonus_coin_return">+%1$d%% coin return</string>
     <string name="snackbar_added_to_queue">Added to queue: %1$s.</string>
     <string name="snackbar_queue_full">Queue is full.</string>
     <string name="combat_start_failed">Could not start: %1$s</string>
@@ -1622,4 +1622,5 @@
     <string name="home_welcome_greeting">Welcome back,</string>
     <string name="home_welcome_name">%1$s!</string>
     <string name="home_welcome_title">The %1$s!</string>
+    <string name="bonus_xp">+%1$d%% XP</string>
 </resources>


### PR DESCRIPTION
Resolves the merge conflict blocking #1135 (rebased onto current main, keeping the newer bonus_tower/bonus_xp/bonus_coin_drops/bonus_hp strings and the corrected French snackbar_added_to_queue spacing from the latest fr retranslation, while taking this PR's percentage fix for bonus_coin_return).

Closes #1135

🤖 Generated with [Claude Code](https://claude.com/claude-code)