### PR TITLE
 feat(skills): add owned item quantity display to crafting windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,8 @@ Train **23 skills** at your own pace:
 - **Combat** (7): Attack, Strength, Defense, Ranged, Magic, Hitpoints, Prayer
 - **Support** (2): Mercantile, Slayer
 
-Better equipment means faster gathering and surviving tougher dungeons. Craft your own gear or buy it from the Shop. The **Mercantile** skill levels through trade routes and unlocks better prices. **Slayer** tasks are assigned by the Slayer Master in town and are completed by fighting specific enemies in dungeons.
+Better equipment means faster gathering and surviving tougher dungeons. Craft your own gear or buy it from the Shop. Crafting windows display required ingredients alongside your currently owned item count (`Owned: X`). The **Mercantile** skill levels through trade routes and unlocks better prices. **Slayer** tasks are assigned by the Slayer Master in town and are completed by fighting specific enemies in dungeons.
+
 
 ## Combat and dungeons
 

--- a/app/src/main/assets/changelog.txt
+++ b/app/src/main/assets/changelog.txt
@@ -1,5 +1,7 @@
 v1.12.7
+• Added owned item quantity display in skill crafting windows (Smithing, Cooking, Fletching, Crafting, Herblore, Construction, Runecrafting, Firemaking, and Worker Crafting)
 • Fixed collecting a large number of piled-up sessions (e.g. after queueing many boss fights) being slow and unresponsive, and fixed tapping Collect repeatedly during that time awarding the same rewards more than once
+
 • Fixed the Armory's "How to obtain" info showing an item's flavor text instead of how to get it for Dwarven gear, Divine gear, skill capes, and several dungeon-exclusive items (Shadow/Arcane Grappling Hook, Rogue's Lockpick, and others)
 • Fixed prestiging a combat skill (Attack, Strength, Defense, Ranged, Magic, Hitpoints, or Prayer) during an active fight leaving that fight to run on stale stats, which could later void it and wrongly show "Defeated by" the boss/dungeon even if you were never actually beaten; prestiging now properly ends the fight and refunds it, and a voided session can no longer show a misleading defeat message
 • Fixed a long queue of repeated boss fights losing track of how many fights had run (and undercounting the total) if a second queued item was waiting behind it and a fight's completion was delayed in the background

--- a/app/src/main/kotlin/com/fantasyidler/ui/screen/WorkerSkillsScreen.kt
+++ b/app/src/main/kotlin/com/fantasyidler/ui/screen/WorkerSkillsScreen.kt
@@ -652,7 +652,14 @@ private fun WorkerCraftRecipeRow(
                 style = MaterialTheme.typography.bodySmall,
                 color = if (enabled) MaterialTheme.colorScheme.onSurfaceVariant else dim,
             )
+            val ownedQty = state.inventory[recipe.outputKey] ?: 0
+            Text(
+                text  = stringResource(R.string.crafting_owned, ownedQty),
+                style = MaterialTheme.typography.labelSmall,
+                color = if (ownedQty > 0) GoldPrimary else dim,
+            )
             recipe.outputCombatStyle?.let { style ->
+
                 Text(
                     text  = "${context.getString(R.string.label_combat_style)}: ${style.replaceFirstChar { it.uppercase() }}",
                     style = MaterialTheme.typography.labelSmall,
@@ -753,7 +760,14 @@ private fun WorkerCraftQuantityContent(
             style      = MaterialTheme.typography.titleLarge,
             fontWeight = FontWeight.Bold,
         )
+        val ownedQty = state.inventory[recipe.outputKey] ?: 0
+        Text(
+            text  = stringResource(R.string.crafting_owned_detail, ownedQty),
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
         Spacer(Modifier.height(12.dp))
+
 
         Text(
             text  = stringResource(R.string.label_ingredients),

--- a/app/src/main/kotlin/com/fantasyidler/ui/screen/skills/CraftSkillSheet.kt
+++ b/app/src/main/kotlin/com/fantasyidler/ui/screen/skills/CraftSkillSheet.kt
@@ -324,7 +324,14 @@ private fun CraftRecipeRow(
                 style = MaterialTheme.typography.bodySmall,
                 color = if (enabled) MaterialTheme.colorScheme.onSurfaceVariant else dim,
             )
+            val ownedQty = craftState.inventory[recipe.outputKey] ?: 0
+            Text(
+                text  = stringResource(R.string.crafting_owned, ownedQty),
+                style = MaterialTheme.typography.labelSmall,
+                color = if (ownedQty > 0) GoldPrimary else dim,
+            )
             recipe.outputCombatStyle?.let { style ->
+
                 Text(
                     text  = "${context.getString(R.string.label_combat_style)}: ${style.replaceFirstChar { it.uppercase() }}",
                     style = MaterialTheme.typography.labelSmall,
@@ -429,7 +436,14 @@ private fun CraftQuantityContent(
             style      = MaterialTheme.typography.titleLarge,
             fontWeight = FontWeight.Bold,
         )
+        val ownedQty = state.inventory[recipe.outputKey] ?: 0
+        Text(
+            text  = stringResource(R.string.crafting_owned_detail, ownedQty),
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
         Spacer(Modifier.height(12.dp))
+
 
         Text(
             text  = stringResource(R.string.label_ingredients),

--- a/app/src/main/kotlin/com/fantasyidler/ui/screen/skills/FiremakingSheet.kt
+++ b/app/src/main/kotlin/com/fantasyidler/ui/screen/skills/FiremakingSheet.kt
@@ -187,8 +187,9 @@ internal fun FiremakingSheet(
                                         }
                                     }
                                 }
+                                val ashOwned = inventory[ashKey] ?: 0
                                 Text(
-                                    text  = stringResource(R.string.firemaking_burns_to, ashName) + "  •  ${log.xpPerLog} XP",
+                                    text  = stringResource(R.string.firemaking_burns_to, ashName) + "  •  ${log.xpPerLog} XP  •  " + stringResource(R.string.firemaking_ashes_owned, ashOwned),
                                     style = MaterialTheme.typography.bodySmall,
                                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                                 )
@@ -205,6 +206,13 @@ internal fun FiremakingSheet(
             }
         } else {
             val key      = selectedKey!!
+            val ashKey   = when (key) {
+                "oak_log" -> "oak_ashes"; "willow_log" -> "willow_ashes"
+                "maple_log" -> "maple_ashes"; "yew_log" -> "yew_ashes"
+                "magic_log" -> "magic_ashes"; "redwood_log" -> "redwood_ashes"
+                else -> "ashes"
+            }
+            val ashOwned = inventory[ashKey] ?: 0
             val maxQty   = (inventory[key] ?: 0).coerceAtMost(craftLimit)
             var qty      by remember(key) { androidx.compose.runtime.mutableIntStateOf(maxQty.coerceAtLeast(1)) }
             var textValue by remember(key) { mutableStateOf(maxQty.coerceAtLeast(1).toString()) }
@@ -219,12 +227,13 @@ internal fun FiremakingSheet(
                 modifier = Modifier.padding(horizontal = 16.dp),
             )
             Text(
-                text     = "${maxQty} ${stringResource(R.string.firemaking_logs_in_inventory)}",
+                text     = "${maxQty} ${stringResource(R.string.firemaking_logs_in_inventory)}  •  " + stringResource(R.string.firemaking_ashes_owned, ashOwned),
                 style    = MaterialTheme.typography.bodySmall,
                 color    = MaterialTheme.colorScheme.onSurfaceVariant,
                 modifier = Modifier.padding(horizontal = 16.dp, vertical = 4.dp),
             )
             Spacer(Modifier.height(12.dp))
+
             Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.Center, verticalAlignment = Alignment.CenterVertically) {
                 androidx.compose.material3.IconButton(onClick = { if (qty > 1) { qty--; textValue = qty.toString() } }, enabled = qty > 1) {
                     androidx.compose.material3.Icon(androidx.compose.material.icons.Icons.Filled.Remove, contentDescription = null)

--- a/app/src/main/kotlin/com/fantasyidler/ui/screen/skills/RunecraftingSheet.kt
+++ b/app/src/main/kotlin/com/fantasyidler/ui/screen/skills/RunecraftingSheet.kt
@@ -208,8 +208,9 @@ internal fun RunecraftingSheet(
                                     }
                                 }
                             }
+                            val runeOwned = inventory[key] ?: 0
                             Text(
-                                text  = stringResource(R.string.skills_rune_desc, rune.xpPerRune.toInt(), rune.levelRequired),
+                                text  = stringResource(R.string.skills_rune_desc, rune.xpPerRune.toInt(), rune.levelRequired) + "  •  " + stringResource(R.string.crafting_owned, runeOwned),
                                 style = MaterialTheme.typography.bodySmall,
                                 color = MaterialTheme.colorScheme.onSurfaceVariant,
                             )
@@ -240,13 +241,15 @@ internal fun RunecraftingSheet(
                 style    = MaterialTheme.typography.titleMedium,
                 modifier = Modifier.padding(horizontal = 16.dp),
             )
+            val ownedRune = selectedKey?.let { inventory[it] } ?: 0
             Text(
-                text     = stringResource(R.string.skills_rune_selected, selectedRune.xpPerRune.toInt(), inventoryMax),
+                text     = stringResource(R.string.skills_rune_selected, selectedRune.xpPerRune.toInt(), inventoryMax) + "  •  " + stringResource(R.string.crafting_owned, ownedRune),
                 style    = MaterialTheme.typography.bodySmall,
                 color    = MaterialTheme.colorScheme.onSurfaceVariant,
                 modifier = Modifier.padding(horizontal = 16.dp, vertical = 4.dp),
             )
             Spacer(Modifier.height(12.dp))
+
 
             Row(
                 modifier              = Modifier.fillMaxWidth(),

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -1311,7 +1311,7 @@
     <string name="carnival_queue">Sitzung einreihen</string>
     <string name="carnival_ring_toss">Ringewerfen</string>
     <string name="carnival_active_ring_desc">Macht Euren Wurf, wenn der Zeiger auf die goldene Zielzone zeigt.</string>
-    <string name="carnival_ring_target_hint">Zielt auf die Mitte (45%–55%)</string>
+    <string name="carnival_ring_target_hint" formatted="false">Zielt auf die Mitte (45%–55%)</string>
     <string name="carnival_throw">Werfen!</string>
     <string name="carnival_hammer_strike">Hammerschlag</string>
     <string name="carnival_active_hammer_desc">Schlagt zu, wenn der Kraftmesser seinen Höchstwert erreicht.</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -594,6 +594,11 @@
     <string name="skills_fish_desc">Lv. %1$d  •  %2$s XP/catch</string>
     <!-- Translator note: %1$d = required level, %2$s = skill name, %3$d = player level, %4$s = skill name again -->
     <string name="skills_req_with_have">Requires %1$d %2$s (You have %3$d %4$s)</string>
+    <!-- Translator note: %1$d = owned quantity -->
+    <string name="crafting_owned">Owned: %1$d</string>
+    <string name="crafting_owned_detail">Owned in inventory: %1$d</string>
+    <string name="firemaking_ashes_owned">Ashes owned: %1$d</string>
+
 
     <!-- ===== ShopScreen ===== -->
     <string name="shop_active">ACTIVE</string>
@@ -1316,7 +1321,7 @@
     <string name="carnival_queue">Queue Session</string>
     <string name="carnival_ring_toss">Ring Toss</string>
     <string name="carnival_active_ring_desc">Time your throw when the indicator hits the golden target zone.</string>
-    <string name="carnival_ring_target_hint">Aim for the centre (45%–55%)</string>
+    <string name="carnival_ring_target_hint" formatted="false">Aim for the centre (45%–55%)</string>
     <string name="carnival_throw">Throw!</string>
     <string name="carnival_hammer_strike">Hammer Strike</string>
     <string name="carnival_active_hammer_desc">Strike when the power meter is at its peak for maximum score.</string>
@@ -1372,7 +1377,8 @@
     <string name="carnival_difficulty_label">Difficulty</string>
     <string name="carnival_difficulty_normal">Normal</string>
     <string name="carnival_difficulty_hard">Hard</string>
-    <string name="carnival_ring_hard_hint">Hard: 52%–57% target, 7 tickets</string>
+    <string name="carnival_ring_hard_hint" formatted="false">Hard: 52%–57% target, 7 tickets</string>
+
 
     <!-- ===== Magic Bean / Farming ===== -->
     <string name="farming_bean_note_1">A tiny sprout has pushed through the soil.</string>

--- a/app/src/test/kotlin/com/fantasyidler/ui/viewmodel/CraftingUiTest.kt
+++ b/app/src/test/kotlin/com/fantasyidler/ui/viewmodel/CraftingUiTest.kt
@@ -1,0 +1,45 @@
+package com.fantasyidler.ui.viewmodel
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * Unit tests verifying that owned item quantities are correctly retrievable
+ * and computed from inventory state for crafting skills UI.
+ */
+class CraftingUiTest {
+
+    @Test
+    fun `owned inventory count is retrieved correctly for recipes`() {
+        val inventory = mapOf(
+            "bronze_bar" to 15,
+            "bronze_sword" to 3,
+            "cooked_shrimp" to 42,
+            "air_rune" to 100,
+        )
+
+        val state = CraftingUiState(inventory = inventory)
+
+        assertEquals(3, state.inventory["bronze_sword"] ?: 0)
+        assertEquals(42, state.inventory["cooked_shrimp"] ?: 0)
+        assertEquals(0, state.inventory["iron_sword"] ?: 0)
+    }
+
+    @Test
+    fun `maxCraftable calculates maximum quantity based on materials`() {
+        val recipe = CraftableRecipe(
+            key = "bronze_sword",
+            displayName = "Bronze Sword",
+            levelRequired = 1,
+            materials = mapOf("bronze_bar" to 2),
+            outputKey = "bronze_sword",
+            outputQty = 1,
+            xpPerItem = 10.0,
+            skillName = "smithing",
+        )
+
+        val state = CraftingUiState(effectiveInventory = mapOf("bronze_bar" to 9))
+
+        assertEquals(4, state.maxCraftable(recipe))
+    }
+}


### PR DESCRIPTION
## Before submitting

- [x] I've tested any changes with the appropriate tests (eg. Unit tests, validation scripts)
- [x] I've pulled and merged the latest changes from the repository

## Summary

Added owned inventory item quantity display (`Owned: X`) across all crafting skill sheets (Smithing, Cooking, Fletching, Crafting, Herblore, Construction, Runecrafting, Firemaking, and Worker Crafting).

Prior to this change, players could see required ingredient quantities, but had to open their Inventory to check how many of the output item they already possessed. This feature aligns all crafting sheets with existing inventory awareness patterns in the app (such as in Farming).

## Related issue(s) or discussion(s)

Relates to skill UI quality-of-life and inventory awareness during crafting.

## Changelog

- Added owned item quantity display (`Owned: X`) in skill crafting sheets (Smithing, Cooking, Fletching, Crafting, Herblore, Construction, Runecrafting, Firemaking, and Worker Crafting)
- Added `CraftingUiTest` unit test suite for inventory lookup and craftable quantity calculations
- Added `formatted="false"` attribute to static percentage strings in resource files to fix AAPT2 resource merger checks
- Updated documentation (`README.md`) and in-app `changelog.txt`

## Anything else?

- Automated unit tests (`./gradlew testDebugUnitTest`) pass cleanly.
