### PR TITLE
feat(construction): Add Artisan's Workshop town building

### DIFF
--- a/app/src/main/assets/data/buildings.json
+++ b/app/src/main/assets/data/buildings.json
@@ -277,5 +277,46 @@
         }
       }
     ]
+  },
+  "artisans_workshop": {
+    "key": "artisans_workshop",
+    "tiers": [
+      {
+        "construction_level_required": 80,
+        "coin_cost": 2000000,
+        "materials": {
+          "yew_plank": 1000,
+          "stone_block": 800,
+          "mithril_nail": 3000
+        },
+        "bonuses": {
+          "secondary_material_save_chance": 0.05
+        }
+      },
+      {
+        "construction_level_required": 90,
+        "coin_cost": 5000000,
+        "materials": {
+          "magic_plank": 1500,
+          "stone_block": 1500,
+          "mithril_nail": 5000
+        },
+        "bonuses": {
+          "secondary_material_save_chance": 0.10
+        }
+      },
+      {
+        "construction_level_required": 99,
+        "coin_cost": 10000000,
+        "materials": {
+          "magic_plank": 3000,
+          "stone_block": 3000,
+          "mithril_nail": 10000
+        },
+        "bonuses": {
+          "secondary_material_save_chance": 0.15
+        }
+      }
+    ]
   }
 }

--- a/app/src/main/kotlin/com/fantasyidler/repository/QueuedSessionStarter.kt
+++ b/app/src/main/kotlin/com/fantasyidler/repository/QueuedSessionStarter.kt
@@ -534,13 +534,23 @@ class QueuedSessionStarter @Inject constructor(
                 val qty = action.qty.takeIf { it > 0 } ?: return
                 val catalystKey = action.catalystKey
                 val outputKey   = if (catalystKey != null) "enhanced_${action.activityKey}" else action.activityKey
-                if (catalystKey != null) playerRepo.consumeItemsUnlocked(mapOf(catalystKey to qty))
+                val saveChance = townRepo.secondaryMaterialSaveChance(flags)
+                val catalystQtyToConsume = if (catalystKey != null) {
+                    var toConsume = 0
+                    for (u in 0 until qty) {
+                        if (Random.nextFloat() >= saveChance) toConsume++
+                    }
+                    toConsume
+                } else 0
+                if (catalystKey != null && catalystQtyToConsume > 0) {
+                    playerRepo.consumeItemsUnlocked(mapOf(catalystKey to catalystQtyToConsume))
+                }
                 val frames    = buildCraftFrames(xpMap[Skills.HERBLORE] ?: 0L, qty, r.xpPerItem, r.outputQuantity, outputKey,
                     petBoostPct = gatheringPetBoost(player.pets, Skills.HERBLORE),
                     petDropKey = petDropKey(Skills.HERBLORE), petDropChance = petDropChance(Skills.HERBLORE))
                 val perItemMs = SkillSimulator.sessionDurationMs(agilityLevel, agilityPrestige) / 60
                 sessionRepo.startSession(Skills.HERBLORE, action.activityKey, encodeFrames(frames), qty * perItemMs, action.skillDisplayName, insertAsCompleted = offline, backdateMs = backdateMs,
-                    catalystKey = catalystKey, catalystQty = if (catalystKey != null) qty else 0, levelAtStart = levelAtStart)
+                    catalystKey = catalystKey, catalystQty = catalystQtyToConsume, levelAtStart = levelAtStart)
             }
             Skills.MERCANTILE -> {
                 val route = gameData.tradeRoutes.firstOrNull { it.id == action.activityKey } ?: return

--- a/app/src/main/kotlin/com/fantasyidler/repository/QueuedSessionStarter.kt
+++ b/app/src/main/kotlin/com/fantasyidler/repository/QueuedSessionStarter.kt
@@ -534,23 +534,15 @@ class QueuedSessionStarter @Inject constructor(
                 val qty = action.qty.takeIf { it > 0 } ?: return
                 val catalystKey = action.catalystKey
                 val outputKey   = if (catalystKey != null) "enhanced_${action.activityKey}" else action.activityKey
-                val saveChance = townRepo.secondaryMaterialSaveChance(flags)
-                val catalystQtyToConsume = if (catalystKey != null) {
-                    var toConsume = 0
-                    for (u in 0 until qty) {
-                        if (Random.nextFloat() >= saveChance) toConsume++
-                    }
-                    toConsume
-                } else 0
-                if (catalystKey != null && catalystQtyToConsume > 0) {
-                    playerRepo.consumeItemsUnlocked(mapOf(catalystKey to catalystQtyToConsume))
-                }
+                // Ash is already consumed at enqueue time (CraftingViewModel);
+                // action.catalystQty carries that amount through for the refund-on-abandon path.
+                val ashCost   = action.catalystQty
                 val frames    = buildCraftFrames(xpMap[Skills.HERBLORE] ?: 0L, qty, r.xpPerItem, r.outputQuantity, outputKey,
                     petBoostPct = gatheringPetBoost(player.pets, Skills.HERBLORE),
                     petDropKey = petDropKey(Skills.HERBLORE), petDropChance = petDropChance(Skills.HERBLORE))
                 val perItemMs = SkillSimulator.sessionDurationMs(agilityLevel, agilityPrestige) / 60
                 sessionRepo.startSession(Skills.HERBLORE, action.activityKey, encodeFrames(frames), qty * perItemMs, action.skillDisplayName, insertAsCompleted = offline, backdateMs = backdateMs,
-                    catalystKey = catalystKey, catalystQty = catalystQtyToConsume, levelAtStart = levelAtStart)
+                    catalystKey = catalystKey, catalystQty = ashCost, levelAtStart = levelAtStart)
             }
             Skills.MERCANTILE -> {
                 val route = gameData.tradeRoutes.firstOrNull { it.id == action.activityKey } ?: return

--- a/app/src/main/kotlin/com/fantasyidler/repository/TownRepository.kt
+++ b/app/src/main/kotlin/com/fantasyidler/repository/TownRepository.kt
@@ -145,6 +145,21 @@ class TownRepository @Inject constructor(
         return 3 + extraSlots
     }
 
+    /** Secondary material preservation chance (Artisan's Workshop bonus). */
+    fun secondaryMaterialSaveChance(building: String, tier: Int): Float {
+        val bonuses = gameData.townBuildings[building]?.tiers?.getOrNull(tier - 1)?.bonuses ?: return 0.0f
+        return bonuses["secondary_material_save_chance"]?.toFloat() ?: 0.0f
+    }
+
+    /** Secondary material preservation chance based on Artisan's Workshop tier. */
+    fun secondaryMaterialSaveChance(flags: PlayerFlags): Float {
+        var chance = 0.0f
+        flags.townBuildingTiers.forEach { buildingName, tier ->
+            chance += secondaryMaterialSaveChance(buildingName, tier)
+        }
+        return chance
+    }
+
     // -------------------------------------------------------------------------
     // Upgrade action
     // -------------------------------------------------------------------------

--- a/app/src/main/kotlin/com/fantasyidler/ui/screen/BuilderScreen.kt
+++ b/app/src/main/kotlin/com/fantasyidler/ui/screen/BuilderScreen.kt
@@ -142,6 +142,19 @@ fun BuilderScreen(
                     inventory         = state.inventory,
                     onUpgrade         = { viewModel.upgrade("cape_rack") },
                 )
+            }
+            item {
+                Spacer(Modifier.height(16.dp))
+                BuildingUpgradeCard(
+                    buildingKey       = "artisans_workshop",
+                    currentTier       = state.artisansWorkshopTier,
+                    buildingDef       = viewModel.gameData.townBuildings["artisans_workshop"],
+                    townRepository    = viewModel.townRepo,
+                    constructionLevel = state.constructionLevel,
+                    coins             = state.coins,
+                    inventory         = state.inventory,
+                    onUpgrade         = { viewModel.upgrade("artisans_workshop") },
+                )
                 Spacer(Modifier.height(16.dp))
             }
         }

--- a/app/src/main/kotlin/com/fantasyidler/ui/screen/TownBuildingUpgrade.kt
+++ b/app/src/main/kotlin/com/fantasyidler/ui/screen/TownBuildingUpgrade.kt
@@ -62,6 +62,7 @@ fun BuildingUpgradeCard(
                 "garden"       -> R.string.town_building_garden_name
                 "queue_master" -> R.string.town_building_queue_master_name
                 "cape_rack"    -> R.string.town_building_cape_rack_name
+                "artisans_workshop" -> R.string.town_building_artisans_workshop_name
                 else           -> R.string.town_upgrade_section_title
             }
             Text(
@@ -183,6 +184,10 @@ fun buildingBonusText(buildingKey: String, tier: Int, townRepo: TownRepository):
         1    -> stringResource(R.string.town_cape_rack_t1_bonus)
         2    -> stringResource(R.string.town_cape_rack_t2_bonus)
         else -> stringResource(R.string.town_cape_rack_t3_bonus)
+    }
+    "artisans_workshop" -> when (tier) {
+        0    -> stringResource(R.string.town_artisans_workshop_no_bonus)
+        else -> stringResource(R.string.town_artisans_workshop_active_bonus, (townRepo.secondaryMaterialSaveChance("artisans_workshop", tier) * 100).roundToInt())
     }
     else -> ""
 }

--- a/app/src/main/kotlin/com/fantasyidler/ui/viewmodel/BuilderViewModel.kt
+++ b/app/src/main/kotlin/com/fantasyidler/ui/viewmodel/BuilderViewModel.kt
@@ -34,6 +34,7 @@ data class BuilderUiState(
     val gardenTier: Int = 0,
     val queueMasterTier: Int = 0,
     val capeRackTier: Int = 0,
+    val artisansWorkshopTier: Int = 0,
     val snackbarMessage: String? = null,
 )
 
@@ -68,19 +69,21 @@ class BuilderViewModel @Inject constructor(
             gardenTier        = flags.townBuildingTiers["garden"] ?: 0,
             queueMasterTier   = flags.townBuildingTiers["queue_master"] ?: 0,
             capeRackTier      = flags.townBuildingTiers["cape_rack"] ?: 0,
+            artisansWorkshopTier = flags.townBuildingTiers["artisans_workshop"] ?: 0,
         )
     }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), BuilderUiState())
 
     fun upgrade(buildingKey: String) {
         viewModelScope.launch {
             val currentTier = when (buildingKey) {
-                "inn"          -> uiState.value.innTier
-                "guild_hall"   -> uiState.value.guildHallTier
-                "fairgrounds"  -> uiState.value.fairgroundsTier
-                "garden"       -> uiState.value.gardenTier
-                "queue_master" -> uiState.value.queueMasterTier
-                "cape_rack"    -> uiState.value.capeRackTier
-                else           -> uiState.value.churchTier
+                "inn"               -> uiState.value.innTier
+                "guild_hall"        -> uiState.value.guildHallTier
+                "fairgrounds"       -> uiState.value.fairgroundsTier
+                "garden"            -> uiState.value.gardenTier
+                "queue_master"      -> uiState.value.queueMasterTier
+                "cape_rack"         -> uiState.value.capeRackTier
+                "artisans_workshop" -> uiState.value.artisansWorkshopTier
+                else                -> uiState.value.churchTier
             }
             val def = gameData.townBuildings[buildingKey]
             when (townRepo.upgradeBuilding(buildingKey)) {

--- a/app/src/main/kotlin/com/fantasyidler/ui/viewmodel/CraftingViewModel.kt
+++ b/app/src/main/kotlin/com/fantasyidler/ui/viewmodel/CraftingViewModel.kt
@@ -412,6 +412,7 @@ class CraftingViewModel @Inject constructor(
                     estimatedXpGain     = (qty * recipe.xpPerItem * xpQueueMult * toolEff * (1.0 + queuePetPct / 100.0)).toLong(),
                     estimatedDurationMs = qty.toLong() * perItemMs,
                     catalystKey         = ashKey,
+                    catalystQty         = ashQtyToConsume,
                 )
                 val enqueued = playerRepo.enqueueAction(action)
                 if (enqueued) {

--- a/app/src/main/kotlin/com/fantasyidler/ui/viewmodel/CraftingViewModel.kt
+++ b/app/src/main/kotlin/com/fantasyidler/ui/viewmodel/CraftingViewModel.kt
@@ -17,6 +17,7 @@ import com.fantasyidler.repository.PlayerRepository
 import com.fantasyidler.repository.QuestRepository
 import com.fantasyidler.repository.SeasonalEventRepository
 import com.fantasyidler.repository.SessionRepository
+import com.fantasyidler.repository.TownRepository
 import com.fantasyidler.repository.WeeklyQuestRepository
 import com.fantasyidler.simulator.SkillSimulator
 import com.fantasyidler.simulator.XpTable
@@ -154,6 +155,7 @@ class CraftingViewModel @Inject constructor(
     private val weeklyQuestRepo: WeeklyQuestRepository,
     private val guildRepo: GuildRepository,
     private val seasonalEventRepo: SeasonalEventRepository,
+    private val townRepo: TownRepository,
     private val json: Json,
 ) : ViewModel() {
 
@@ -387,15 +389,20 @@ class CraftingViewModel @Inject constructor(
         val ashKey = if (recipe.skillName == Skills.HERBLORE) state.herbloreAshKey else null
 
         viewModelScope.launch {
+            val player = playerRepo.getOrCreatePlayer()
+            val flags: PlayerFlags = json.decodeFromString(player.flags)
+            val saveChance = townRepo.secondaryMaterialSaveChance(flags)
+            val matsToConsume = applyMaterialPreservation(recipe.materials, qty, saveChance)
+            val ashQtyToConsume = if (ashKey != null) applyQtyPreservation(qty, saveChance) else 0
+
             // Enqueue if a session is already running
             if (sessionRepo.getActiveSession() != null) {
-                val craftFlags = playerRepo.getFlags()
                 val agility   = state.skillLevels[Skills.AGILITY] ?: 1
-                val toolEff   = craftToolEfficiency(recipe, json.decodeFromString(playerRepo.getOrCreatePlayer().equipped))
-                val perItemMs = (SkillSimulator.sessionDurationMs(agility, craftFlags.skillPrestige[Skills.AGILITY] ?: 0) / 60 / toolEff).toLong()
+                val toolEff   = craftToolEfficiency(recipe, json.decodeFromString(player.equipped))
+                val perItemMs = (SkillSimulator.sessionDurationMs(agility, flags.skillPrestige[Skills.AGILITY] ?: 0) / 60 / toolEff).toLong()
                 val totalOutput = qty * recipe.outputQty
-                val xpQueueMult = (if (craftFlags.xpBoostExpiresAt > System.currentTimeMillis()) 2.0 else 1.0) * ChurchRepository.xpMultiplier(craftFlags)
-                val queuePetPct = petBoostFor(playerRepo.getOrCreatePlayer().pets, recipe.skillName)
+                val xpQueueMult = (if (flags.xpBoostExpiresAt > System.currentTimeMillis()) 2.0 else 1.0) * ChurchRepository.xpMultiplier(flags)
+                val queuePetPct = petBoostFor(player.pets, recipe.skillName)
                 val action = QueuedAction(
                     skillName           = recipe.skillName,
                     activityKey         = recipe.key,
@@ -407,7 +414,10 @@ class CraftingViewModel @Inject constructor(
                     catalystKey         = ashKey,
                 )
                 val enqueued = playerRepo.enqueueAction(action)
-                if (enqueued) playerRepo.consumeItems(recipe.materials.mapValues { it.value * qty })
+                if (enqueued) {
+                    playerRepo.consumeItems(matsToConsume)
+                    if (ashKey != null && ashQtyToConsume > 0) playerRepo.consumeItems(mapOf(ashKey to ashQtyToConsume))
+                }
                 _extra.update {
                     it.copy(
                         snackbarMessage = if (enqueued) context.getString(R.string.snackbar_added_to_queue, recipe.displayName) else context.getString(R.string.snackbar_queue_full),
@@ -419,7 +429,6 @@ class CraftingViewModel @Inject constructor(
 
             // Build a single aggregate frame regardless of qty to stay within
             // Android's 2 MB CursorWindow per-row limit.
-            val player = playerRepo.getOrCreatePlayer()
             val freshInv: Map<String, Int> = json.decodeFromString(player.inventory)
             if (!recipe.materials.all { (item, needed) -> (freshInv[item] ?: 0) >= needed * qty }) {
                 _extra.update { it.copy(snackbarMessage = context.getString(R.string.skill_not_enough_materials)) }
@@ -451,7 +460,6 @@ class CraftingViewModel @Inject constructor(
             )
 
             val levels: Map<String, Int> = json.decodeFromString(player.skillLevels)
-            val flags = try { json.decodeFromString<PlayerFlags>(player.flags) } catch (_: Exception) { PlayerFlags() }
             val agilityLevel = levels[Skills.AGILITY] ?: 1
             // 1 item per minute, reduced by agility (same formula as gathering skills) and by tool efficiency
             val perItemMs = (SkillSimulator.sessionDurationMs(agilityLevel, flags.skillPrestige[Skills.AGILITY] ?: 0) / 60 / efficiency).toLong()
@@ -460,8 +468,8 @@ class CraftingViewModel @Inject constructor(
                 json.serializersModule.serializer<List<SessionFrame>>(),
                 frames,
             )
-            playerRepo.consumeItems(recipe.materials.mapValues { it.value * qty })
-            if (ashKey != null) playerRepo.consumeItems(mapOf(ashKey to qty))
+            playerRepo.consumeItems(matsToConsume)
+            if (ashKey != null && ashQtyToConsume > 0) playerRepo.consumeItems(mapOf(ashKey to ashQtyToConsume))
             sessionRepo.startSession(
                 skillName        = recipe.skillName,
                 activityKey      = recipe.key,
@@ -469,7 +477,7 @@ class CraftingViewModel @Inject constructor(
                 durationMs       = qty * perItemMs,
                 skillDisplayName = recipe.skillName,
                 catalystKey      = ashKey,
-                catalystQty      = if (ashKey != null) qty else 0,
+                catalystQty      = ashQtyToConsume,
             )
             _extra.update { it.copy(selectedRecipe = null, herbloreAshKey = null) }
         }
@@ -732,4 +740,30 @@ class CraftingViewModel @Inject constructor(
     }
 
     private fun ceilDiv(a: Int, b: Int) = if (b <= 0) a else (a + b - 1) / b
+
+    private fun applyMaterialPreservation(materials: Map<String, Int>, qty: Int, saveChance: Float): Map<String, Int> {
+        val totalMats = materials.mapValues { it.value * qty }
+        if (saveChance <= 0f || totalMats.size <= 1) return totalMats
+        val entries = totalMats.entries.toList()
+        val result = mutableMapOf<String, Int>()
+        result[entries[0].key] = entries[0].value
+        for (i in 1 until entries.size) {
+            val (item, totalQty) = entries[i]
+            var toConsume = 0
+            for (u in 0 until totalQty) {
+                if (kotlin.random.Random.nextFloat() >= saveChance) toConsume++
+            }
+            if (toConsume > 0) result[item] = toConsume
+        }
+        return result
+    }
+
+    private fun applyQtyPreservation(totalQty: Int, saveChance: Float): Int {
+        if (saveChance <= 0f) return totalQty
+        var toConsume = 0
+        for (u in 0 until totalQty) {
+            if (kotlin.random.Random.nextFloat() >= saveChance) toConsume++
+        }
+        return toConsume
+    }
 }

--- a/app/src/main/kotlin/com/fantasyidler/ui/viewmodel/SkillsViewModel.kt
+++ b/app/src/main/kotlin/com/fantasyidler/ui/viewmodel/SkillsViewModel.kt
@@ -18,6 +18,7 @@ import com.fantasyidler.data.model.SkillSession
 import com.fantasyidler.data.model.Skills
 import com.fantasyidler.repository.ChurchRepository
 import com.fantasyidler.repository.FarmingRepository
+import com.fantasyidler.repository.TownRepository
 import com.fantasyidler.repository.GameDataRepository
 import com.fantasyidler.repository.GuildRepository
 import com.fantasyidler.repository.PlayerRepository
@@ -138,6 +139,7 @@ class SkillsViewModel @Inject constructor(
     private val dailyQuestRepo: DailyQuestRepository,
     private val weeklyQuestRepo: WeeklyQuestRepository,
     private val seasonalEventRepo: SeasonalEventRepository,
+    private val townRepo: TownRepository,
     private val json: Json,
 ) : ViewModel() {
 
@@ -465,10 +467,12 @@ class SkillsViewModel @Inject constructor(
                         catalystQty         = ashCost,
                     )
                 )
+                val saveChance = townRepo.secondaryMaterialSaveChance(rcFlags)
+                val consumedAshCost = if (catalystKey != null) applyQtyPreservation(ashCost, saveChance) else 0
                 if (enqueued) {
                     playerRepo.consumeItems(mapOf("rune_essence" to runeData.essenceCost * qty))
-                    if (catalystKey != null) {
-                        playerRepo.consumeItems(mapOf(catalystKey to ashCost))
+                    if (catalystKey != null && consumedAshCost > 0) {
+                        playerRepo.consumeItems(mapOf(catalystKey to consumedAshCost))
                     }
                     queuedSessionStarter.startNextQueued()
                 }
@@ -527,8 +531,10 @@ class SkillsViewModel @Inject constructor(
                 )
                 playerRepo.consumeItems(mapOf("rune_essence" to runeData.essenceCost * qty))
                 val ashCost = if (catalystKey != null) (qty + 9) / 10 else 0
-                if (catalystKey != null) {
-                    playerRepo.consumeItems(mapOf(catalystKey to ashCost))
+                val saveChance = townRepo.secondaryMaterialSaveChance(rcActFlags)
+                val consumedAshCost = if (catalystKey != null) applyQtyPreservation(ashCost, saveChance) else 0
+                if (catalystKey != null && consumedAshCost > 0) {
+                    playerRepo.consumeItems(mapOf(catalystKey to consumedAshCost))
                 }
                 sessionRepo.startSession(
                     skillName        = Skills.RUNECRAFTING,
@@ -537,7 +543,7 @@ class SkillsViewModel @Inject constructor(
                     durationMs       = qty.toLong() * perEssenceMs,
                     skillDisplayName = "Runecrafting",
                     catalystKey      = catalystKey,
-                    catalystQty      = ashCost,
+                    catalystQty      = consumedAshCost,
                 )
             } catch (e: Exception) {
                 _uiState.update { it.copy(snackbarMessage = context.getString(R.string.skill_session_start_failed, e.message ?: "")) }
@@ -1193,6 +1199,15 @@ class SkillsViewModel @Inject constructor(
             val pd = gameData.pets[pet.id]
             if (pd != null && (pd.boostedSkill == skillKey || pd.boostedSkill == "all")) pd.boostPercent else 0
         }
+    }
+
+    private fun applyQtyPreservation(totalQty: Int, saveChance: Float): Int {
+        if (saveChance <= 0f) return totalQty
+        var toConsume = 0
+        for (u in 0 until totalQty) {
+            if (kotlin.random.Random.nextFloat() >= saveChance) toConsume++
+        }
+        return toConsume
     }
 }
 

--- a/app/src/main/kotlin/com/fantasyidler/ui/viewmodel/SkillsViewModel.kt
+++ b/app/src/main/kotlin/com/fantasyidler/ui/viewmodel/SkillsViewModel.kt
@@ -455,6 +455,8 @@ class SkillsViewModel @Inject constructor(
                 val mult       = when { rcLevel >= 75 -> 3; rcLevel >= 50 -> 2; else -> 1 } + ashBon
                 val xpQueueMult = (if (rcFlags.xpBoostExpiresAt > System.currentTimeMillis()) 2.0 else 1.0) * ChurchRepository.xpMultiplier(rcFlags)
                 val ashCost = if (catalystKey != null) (qty + 9) / 10 else 0
+                val saveChance = townRepo.secondaryMaterialSaveChance(rcFlags)
+                val consumedAshCost = if (catalystKey != null) applyQtyPreservation(ashCost, saveChance) else 0
                 val enqueued = playerRepo.enqueueAction(
                     QueuedAction(
                         skillName           = Skills.RUNECRAFTING,
@@ -464,11 +466,9 @@ class SkillsViewModel @Inject constructor(
                         estimatedXpGain     = (qty.toLong() * (runeData.xpPerRune * mult).toLong() * xpQueueMult).toLong(),
                         estimatedDurationMs = qty.toLong() * perItemMs,
                         catalystKey         = catalystKey,
-                        catalystQty         = ashCost,
+                        catalystQty         = consumedAshCost,
                     )
                 )
-                val saveChance = townRepo.secondaryMaterialSaveChance(rcFlags)
-                val consumedAshCost = if (catalystKey != null) applyQtyPreservation(ashCost, saveChance) else 0
                 if (enqueued) {
                     playerRepo.consumeItems(mapOf("rune_essence" to runeData.essenceCost * qty))
                     if (catalystKey != null && consumedAshCost > 0) {

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -14,4 +14,7 @@
     <string name="town_cape_rack_t1_bonus">Passive bonuses from Tier 1 (Gathering) capes are active</string>
     <string name="town_cape_rack_t2_bonus">Passive bonuses from Tier 1 &amp; 2 (Gathering, Artisan) capes are active</string>
     <string name="town_cape_rack_t3_bonus">Passive bonuses from all owned capes (Gathering, Artisan, Combat &amp; Guild) are active</string>
+    <string name="town_building_artisans_workshop_name">"Artisan's Workshop"</string>
+    <string name="town_artisans_workshop_no_bonus">Upgrade to grant a chance to preserve secondary crafting materials</string>
+    <string name="town_artisans_workshop_active_bonus">%1$d%% chance to preserve secondary crafting materials</string>
 </resources>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -1662,4 +1662,7 @@
     <string name="crafting_owned">Besitz: %1$d</string>
     <string name="crafting_owned_detail">Im Inventar: %1$d</string>
     <string name="firemaking_ashes_owned">Asche im Besitz: %1$d</string>
+    <string name="town_building_artisans_workshop_name">"Artisan's Workshop"</string>
+    <string name="town_artisans_workshop_no_bonus">Upgrade to grant a chance to preserve secondary crafting materials</string>
+    <string name="town_artisans_workshop_active_bonus">%1$d%% chance to preserve secondary crafting materials</string>
 </resources>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -1603,4 +1603,7 @@
     <string name="crafting_owned">Owned: %1$d</string>
     <string name="crafting_owned_detail">Owned in inventory: %1$d</string>
     <string name="firemaking_ashes_owned">Ashes owned: %1$d</string>
+    <string name="town_building_artisans_workshop_name">"Artisan's Workshop"</string>
+    <string name="town_artisans_workshop_no_bonus">Upgrade to grant a chance to preserve secondary crafting materials</string>
+    <string name="town_artisans_workshop_active_bonus">%1$d%% chance to preserve secondary crafting materials</string>
 </resources>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -1601,4 +1601,7 @@
     <string name="crafting_owned">Possédé: %1$d</string>
     <string name="crafting_owned_detail">Présent dans l\'inventaire: %1$d</string>
     <string name="firemaking_ashes_owned">Cendres possédées: %1$d</string>
+    <string name="town_building_artisans_workshop_name">"Artisan's Workshop"</string>
+    <string name="town_artisans_workshop_no_bonus">Upgrade to grant a chance to preserve secondary crafting materials</string>
+    <string name="town_artisans_workshop_active_bonus">%1$d%% chance to preserve secondary crafting materials</string>
 </resources>

--- a/app/src/main/res/values-ga/strings.xml
+++ b/app/src/main/res/values-ga/strings.xml
@@ -440,4 +440,7 @@
         <item quantity="many">%1$d tóraíochtaí críochnaithe</item>
         <item quantity="other">%1$d tóraíochtaí críochnaithe</item>
     </plurals>
+    <string name="town_building_artisans_workshop_name">"Artisan's Workshop"</string>
+    <string name="town_artisans_workshop_no_bonus">Upgrade to grant a chance to preserve secondary crafting materials</string>
+    <string name="town_artisans_workshop_active_bonus">%1$d%% chance to preserve secondary crafting materials</string>
 </resources>

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -1344,4 +1344,7 @@
     <string name="town_cape_rack_t1_bonus">Passive bonuses from Tier 1 (Gathering) capes are active</string>
     <string name="town_cape_rack_t2_bonus">Passive bonuses from Tier 1 &amp; 2 (Gathering, Artisan) capes are active</string>
     <string name="town_cape_rack_t3_bonus">Passive bonuses from all owned capes (Gathering, Artisan, Combat &amp; Guild) are active</string>
+    <string name="town_building_artisans_workshop_name">"Artisan's Workshop"</string>
+    <string name="town_artisans_workshop_no_bonus">Upgrade to grant a chance to preserve secondary crafting materials</string>
+    <string name="town_artisans_workshop_active_bonus">%1$d%% chance to preserve secondary crafting materials</string>
 </resources>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -1655,4 +1655,7 @@
     <string name="crafting_owned">In possesso: %1$d</string>
     <string name="crafting_owned_detail">In possesso: %1$d</string>
     <string name="firemaking_ashes_owned">Ceneri disponibili: %1$d</string>
+    <string name="town_building_artisans_workshop_name">"Artisan's Workshop"</string>
+    <string name="town_artisans_workshop_no_bonus">Upgrade to grant a chance to preserve secondary crafting materials</string>
+    <string name="town_artisans_workshop_active_bonus">%1$d%% chance to preserve secondary crafting materials</string>
 </resources>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -1646,4 +1646,7 @@
     <string name="town_cape_rack_t1_bonus">Passive bonuses from Tier 1 (Gathering) capes are active</string>
     <string name="town_cape_rack_t2_bonus">Passive bonuses from Tier 1 &amp; 2 (Gathering, Artisan) capes are active</string>
     <string name="town_cape_rack_t3_bonus">Passive bonuses from all owned capes (Gathering, Artisan, Combat &amp; Guild) are active</string>
+    <string name="town_building_artisans_workshop_name">"Artisan's Workshop"</string>
+    <string name="town_artisans_workshop_no_bonus">Upgrade to grant a chance to preserve secondary crafting materials</string>
+    <string name="town_artisans_workshop_active_bonus">%1$d%% chance to preserve secondary crafting materials</string>
 </resources>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -1631,4 +1631,7 @@
     <string name="town_cape_rack_t1_bonus">Passive bonuses from Tier 1 (Gathering) capes are active</string>
     <string name="town_cape_rack_t2_bonus">Passive bonuses from Tier 1 &amp; 2 (Gathering, Artisan) capes are active</string>
     <string name="town_cape_rack_t3_bonus">Passive bonuses from all owned capes (Gathering, Artisan, Combat &amp; Guild) are active</string>
+    <string name="town_building_artisans_workshop_name">"Artisan's Workshop"</string>
+    <string name="town_artisans_workshop_no_bonus">Upgrade to grant a chance to preserve secondary crafting materials</string>
+    <string name="town_artisans_workshop_active_bonus">%1$d%% chance to preserve secondary crafting materials</string>
 </resources>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -1667,4 +1667,7 @@
     <string name="town_cape_rack_t1_bonus">Passive bonuses from Tier 1 (Gathering) capes are active</string>
     <string name="town_cape_rack_t2_bonus">Passive bonuses from Tier 1 &amp; 2 (Gathering, Artisan) capes are active</string>
     <string name="town_cape_rack_t3_bonus">Passive bonuses from all owned capes (Gathering, Artisan, Combat &amp; Guild) are active</string>
+    <string name="town_building_artisans_workshop_name">"Artisan's Workshop"</string>
+    <string name="town_artisans_workshop_no_bonus">Upgrade to grant a chance to preserve secondary crafting materials</string>
+    <string name="town_artisans_workshop_active_bonus">%1$d%% chance to preserve secondary crafting materials</string>
 </resources>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -1642,4 +1642,7 @@
     <string name="town_cape_rack_t1_bonus">Passive bonuses from Tier 1 (Gathering) capes are active</string>
     <string name="town_cape_rack_t2_bonus">Passive bonuses from Tier 1 &amp; 2 (Gathering, Artisan) capes are active</string>
     <string name="town_cape_rack_t3_bonus">Passive bonuses from all owned capes (Gathering, Artisan, Combat &amp; Guild) are active</string>
+    <string name="town_building_artisans_workshop_name">"Artisan's Workshop"</string>
+    <string name="town_artisans_workshop_no_bonus">Upgrade to grant a chance to preserve secondary crafting materials</string>
+    <string name="town_artisans_workshop_active_bonus">%1$d%% chance to preserve secondary crafting materials</string>
 </resources>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -1643,4 +1643,7 @@
     <string name="town_cape_rack_t1_bonus">Passive bonuses from Tier 1 (Gathering) capes are active</string>
     <string name="town_cape_rack_t2_bonus">Passive bonuses from Tier 1 &amp; 2 (Gathering, Artisan) capes are active</string>
     <string name="town_cape_rack_t3_bonus">Passive bonuses from all owned capes (Gathering, Artisan, Combat &amp; Guild) are active</string>
+    <string name="town_building_artisans_workshop_name">"Artisan's Workshop"</string>
+    <string name="town_artisans_workshop_no_bonus">Upgrade to grant a chance to preserve secondary crafting materials</string>
+    <string name="town_artisans_workshop_active_bonus">%1$d%% chance to preserve secondary crafting materials</string>
 </resources>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -1608,4 +1608,7 @@
     <string name="crafting_owned">Owned: %1$d</string>
     <string name="crafting_owned_detail">Owned in inventory: %1$d</string>
     <string name="firemaking_ashes_owned">Ashes owned: %1$d</string>
+    <string name="town_building_artisans_workshop_name">"Artisan's Workshop"</string>
+    <string name="town_artisans_workshop_no_bonus">Upgrade to grant a chance to preserve secondary crafting materials</string>
+    <string name="town_artisans_workshop_active_bonus">%1$d%% chance to preserve secondary crafting materials</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1248,6 +1248,9 @@
     <string name="town_cape_rack_t1_bonus">Passive bonuses from Tier 1 (Gathering) capes are active</string>
     <string name="town_cape_rack_t2_bonus">Passive bonuses from Tier 1 &amp; 2 (Gathering, Artisan) capes are active</string>
     <string name="town_cape_rack_t3_bonus">Passive bonuses from all owned capes (Gathering, Artisan, Combat &amp; Guild) are active</string>
+    <string name="town_building_artisans_workshop_name">"Artisan's Workshop"</string>
+    <string name="town_artisans_workshop_no_bonus">Upgrade to grant a chance to preserve secondary crafting materials</string>
+    <string name="town_artisans_workshop_active_bonus">%1$d%% chance to preserve secondary crafting materials</string>
 
     <!-- Town achievements -->
     <string name="achievement_town_first_upgrade_name">First Renovation</string>


### PR DESCRIPTION
## Before submitting

- [x] I've tested the final changes (with unit tests) to ensure the feature works
- [x] I have pulled and merged the latest changes from the repository

## Related discussion/issue(s)



## Summary

Adds the **Artisan's Workshop** town building for the Construction skill, expanding mid-to-endgame Construction progression (Levels 80, 90, and 99) with a passive secondary material save chance for player crafting sessions.

## Changelog

- Added `"artisans_workshop"` town building definition to `buildings.json` requiring Construction level 80 (Tier 1: 5%), 90 (Tier 2: 10%), and 99 (Tier 3: 15%).
- Implemented `secondaryMaterialSaveChance()` bonus accessors in `TownRepository.kt`.
- Applied secondary material preservation checks exclusively to player crafting and Runecrafting sessions in `CraftingViewModel.kt`, `SkillsViewModel.kt`, and `QueuedSessionStarter.kt` (leaving worker resource consumption untouched).
- Added building upgrade card UI in `BuilderScreen.kt` and `TownBuildingUpgrade.kt`.
- Added localized string entries across all 13 supported locale `strings.xml` files.

## Additional work

None

## Anything else?

- Follows the permanent, set-and-forget progression model without introducing micromanagement or database schema migrations.