### PR TITLE
feat(construction): Add Chronos Spire town building

### DIFF
--- a/app/src/main/assets/data/buildings.json
+++ b/app/src/main/assets/data/buildings.json
@@ -277,5 +277,46 @@
         }
       }
     ]
+  },
+  "chronos_spire": {
+    "key": "chronos_spire",
+    "tiers": [
+      {
+        "construction_level_required": 82,
+        "coin_cost": 3000000,
+        "materials": {
+          "magic_plank": 800,
+          "stone_block": 1000,
+          "mithril_nail": 3000
+        },
+        "bonuses": {
+          "player_session_speed_reduction": 0.02
+        }
+      },
+      {
+        "construction_level_required": 92,
+        "coin_cost": 7500000,
+        "materials": {
+          "magic_plank": 1800,
+          "stone_block": 2000,
+          "mithril_nail": 6000
+        },
+        "bonuses": {
+          "player_session_speed_reduction": 0.04
+        }
+      },
+      {
+        "construction_level_required": 99,
+        "coin_cost": 15000000,
+        "materials": {
+          "magic_plank": 4000,
+          "stone_block": 4000,
+          "mithril_nail": 12000
+        },
+        "bonuses": {
+          "player_session_speed_reduction": 0.06
+        }
+      }
+    ]
   }
 }

--- a/app/src/main/kotlin/com/fantasyidler/repository/PlayerRepository.kt
+++ b/app/src/main/kotlin/com/fantasyidler/repository/PlayerRepository.kt
@@ -382,11 +382,15 @@ class PlayerRepository @Inject constructor(
         val weaponSlot = flags.activeWeaponSlot
             ?: EquipSlot.WEAPON_SLOTS.firstOrNull { equipped[it] != null }
             ?: EquipSlot.WEAPON_ATK
+        val chronosReduction = flags.townBuildingTiers.entries.sumOf { (b, t) ->
+            gameData.townBuildings[b]?.tiers?.getOrNull(t - 1)?.bonuses?.get("player_session_speed_reduction")?.toDouble() ?: 0.0
+        }.toFloat()
+        val chronosMult = (1.0f - chronosReduction).coerceAtLeast(0.5f)
         enqueueActionUnlocked(QueuedAction(
             skillName           = "combat",
             activityKey         = dungeonKey,
             skillDisplayName    = dungeonDisplayName,
-            estimatedDurationMs = SkillSimulator.sessionDurationMs(agility, agilityPrestige),
+            estimatedDurationMs = SkillSimulator.sessionDurationMs(agility, agilityPrestige, chronosMult),
             equippedSnapshot    = player.equipped,
             arrowsKey           = flags.equippedArrows,
             spellName           = flags.activeSpell,

--- a/app/src/main/kotlin/com/fantasyidler/repository/QueuedSessionStarter.kt
+++ b/app/src/main/kotlin/com/fantasyidler/repository/QueuedSessionStarter.kt
@@ -144,8 +144,8 @@ class QueuedSessionStarter @Inject constructor(
      * Estimates how long [action] would take without running the full simulation.
      * Used to decide whether a queued session fits within remaining catch-up time.
      */
-    private fun estimateDuration(action: QueuedAction, agilityLevel: Int, agilityPrestige: Int = 0): Long {
-        val base = SkillSimulator.sessionDurationMs(agilityLevel, agilityPrestige)
+    private fun estimateDuration(action: QueuedAction, agilityLevel: Int, agilityPrestige: Int = 0, chronosMult: Float = 1.0f): Long {
+        val base = SkillSimulator.sessionDurationMs(agilityLevel, agilityPrestige, chronosMult)
         val perItem = base / 60L
         return when (action.skillName) {
             Skills.MINING, Skills.WOODCUTTING, Skills.FISHING,

--- a/app/src/main/kotlin/com/fantasyidler/repository/QueuedSessionStarter.kt
+++ b/app/src/main/kotlin/com/fantasyidler/repository/QueuedSessionStarter.kt
@@ -187,6 +187,7 @@ class QueuedSessionStarter @Inject constructor(
             val flags: PlayerFlags       = json.decodeFromString(player.flags)
             val agilityLevel    = levels[Skills.AGILITY] ?: 1
             val agilityPrestige = flags.skillPrestige[Skills.AGILITY] ?: 0
+            val chronosMult     = townRepo.playerSessionDurationMultiplier(flags)
             // A boss repeat run (queued as one entry, tracked via PlayerFlags rather than N
             // separate queue entries) is advanced here one fight at a time, same as the live
             // (non-offline) chain in startNextQueued() -- returning before ever reaching the
@@ -201,7 +202,7 @@ class QueuedSessionStarter @Inject constructor(
                     return 0L
                 }
                 val snapshot = flags.activeBossRepeatSnapshot!!
-                val duration = estimateDuration(snapshot, agilityLevel, agilityPrestige)
+                val duration = estimateDuration(snapshot, agilityLevel, agilityPrestige, chronosMult)
                 if (duration > remainingMs) return 0L
                 return try {
                     startQueuedAction(snapshot, offline = true, backdateMs = remainingMs)
@@ -222,7 +223,7 @@ class QueuedSessionStarter @Inject constructor(
                     return 0L
                 }
                 val snapshot = flags.activeDungeonRepeatSnapshot!!
-                val duration = estimateDuration(snapshot, agilityLevel, agilityPrestige)
+                val duration = estimateDuration(snapshot, agilityLevel, agilityPrestige, chronosMult)
                 if (duration > remainingMs) return 0L
                 return try {
                     startQueuedAction(snapshot, offline = true, backdateMs = remainingMs)
@@ -242,7 +243,7 @@ class QueuedSessionStarter @Inject constructor(
             while (maxAttempts-- >= 0) {
                 val next = remaining.firstOrNull() ?: break
                 remaining = remaining.drop(1)
-                val duration = estimateDuration(next, agilityLevel, agilityPrestige)
+                val duration = estimateDuration(next, agilityLevel, agilityPrestige, chronosMult)
                 if (duration > remainingMs) return 0L
                 try {
                     // backdateMs = remainingMs so each fast-forwarded session in the same
@@ -275,6 +276,7 @@ class QueuedSessionStarter @Inject constructor(
         val flags: PlayerFlags             = json.decodeFromString(player.flags)
         val agilityLevel    = levels[Skills.AGILITY] ?: 1
         val agilityPrestige = flags.skillPrestige[Skills.AGILITY] ?: 0
+        val chronosMult     = townRepo.playerSessionDurationMultiplier(flags)
         val equippedCapeData = equipped[EquipSlot.CAPE]?.let { gameData.equipment[it] }
         val attackCapeMult   = resolveCapeMultiplier("attack", equippedCapeData, inventory.keys, flags.townBuildingTiers, flags.skillPrestige, gameData.equipment)
         val strengthCapeMult = resolveCapeMultiplier("strength", equippedCapeData, inventory.keys, flags.townBuildingTiers, flags.skillPrestige, gameData.equipment)
@@ -305,6 +307,7 @@ class QueuedSessionStarter @Inject constructor(
                     toolEfficiency  = gameData.toolEfficiency(equipped[EquipSlot.PICKAXE], EquipSlot.PICKAXE, oreData.levelRequired),
                     petDropKey      = petDropKey(Skills.MINING),
                     petDropChance   = petDropChance(Skills.MINING),
+                    chronosMultiplier = chronosMult,
                 )
                 startSession(action, result, offline, backdateMs, levelAtStart)
             }
@@ -320,6 +323,7 @@ class QueuedSessionStarter @Inject constructor(
                     toolEfficiency  = gameData.toolEfficiency(equipped[EquipSlot.AXE], EquipSlot.AXE, treeData.levelRequired),
                     petDropKey      = petDropKey(Skills.WOODCUTTING),
                     petDropChance   = petDropChance(Skills.WOODCUTTING),
+                    chronosMultiplier = chronosMult,
                 )
                 startSession(action, result, offline, backdateMs, levelAtStart)
             }
@@ -337,6 +341,7 @@ class QueuedSessionStarter @Inject constructor(
                     petDropKey       = petDropKey(Skills.FISHING),
                     petDropChance    = petDropChance(Skills.FISHING),
                     fishingSkillData = gameData.fishingSkillData,
+                    chronosMultiplier = chronosMult,
                 )
                 startSession(action, result, offline, backdateMs, levelAtStart)
             }
@@ -352,6 +357,7 @@ class QueuedSessionStarter @Inject constructor(
                     toolEfficiency = gameData.toolEfficiency(equipped[EquipSlot.GRAPPLING_HOOK], EquipSlot.GRAPPLING_HOOK, courseData.levelRequired),
                     petDropKey   = petDropKey(Skills.AGILITY),
                     petDropChance = petDropChance(Skills.AGILITY),
+                    chronosMultiplier = chronosMult,
                 )
                 startSession(action, result, offline, backdateMs, levelAtStart)
             }
@@ -369,6 +375,7 @@ class QueuedSessionStarter @Inject constructor(
                     petDropKey    = petDropKey(Skills.THIEVING),
                     petDropChance = petDropChance(Skills.THIEVING),
                     toolEfficiency = gameData.toolEfficiency(equipped[EquipSlot.LOCKPICK], EquipSlot.LOCKPICK, npc.levelRequired),
+                    chronosMultiplier = chronosMult,
                 )
                 sessionRepo.startSession(
                     skillName         = Skills.THIEVING,
@@ -390,7 +397,7 @@ class QueuedSessionStarter @Inject constructor(
                 val frames  = buildCraftFrames(xpMap[Skills.FIREMAKING] ?: 0L, qty, logData.xpPerLog.toDouble(), 1, ashKey,
                     efficiency = efficiency,
                     petDropKey = petDropKey(Skills.FIREMAKING), petDropChance = petDropChance(Skills.FIREMAKING))
-                val perLogMs = (SkillSimulator.sessionDurationMs(agilityLevel, agilityPrestige) / 60L / efficiency).toLong()
+                val perLogMs = (SkillSimulator.sessionDurationMs(agilityLevel, agilityPrestige, chronosMult) / 60L / efficiency).toLong()
                 sessionRepo.startSession(
                     skillName         = Skills.FIREMAKING,
                     activityKey       = logKey,
@@ -443,7 +450,7 @@ class QueuedSessionStarter @Inject constructor(
                         frames[frames.size - 1] = last.copy(items = last.items + (rcPetDropKey to 1))
                     }
                 }
-                val perEssenceMs = SkillSimulator.sessionDurationMs(agilityLevel, agilityPrestige) / 60
+                val perEssenceMs = SkillSimulator.sessionDurationMs(agilityLevel, agilityPrestige, chronosMult) / 60
                 sessionRepo.startSession(Skills.RUNECRAFTING, runeKey, encodeFrames(frames), qty.toLong() * perEssenceMs, action.skillDisplayName, insertAsCompleted = offline, backdateMs = backdateMs,
                     catalystKey = action.catalystKey, catalystQty = ashCost, levelAtStart = levelAtStart)
             }
@@ -471,7 +478,7 @@ class QueuedSessionStarter @Inject constructor(
                         ))
                     }
                 }
-                val perBoneMs = SkillSimulator.sessionDurationMs(agilityLevel, agilityPrestige) / 60
+                val perBoneMs = SkillSimulator.sessionDurationMs(agilityLevel, agilityPrestige, chronosMult) / 60
                 sessionRepo.startSession(
                     skillName         = Skills.PRAYER,
                     activityKey       = boneKey,
@@ -490,7 +497,7 @@ class QueuedSessionStarter @Inject constructor(
                 val frames = buildCraftFrames(xpMap[Skills.SMITHING] ?: 0L, qty, r.xpPerItem, r.outputQuantity, action.activityKey,
                     efficiency = efficiency, petBoostPct = gatheringPetBoost(player.pets, Skills.SMITHING),
                     petDropKey = petDropKey(Skills.SMITHING), petDropChance = petDropChance(Skills.SMITHING))
-                val perItemMs = (SkillSimulator.sessionDurationMs(agilityLevel, agilityPrestige) / 60 / efficiency).toLong()
+                val perItemMs = (SkillSimulator.sessionDurationMs(agilityLevel, agilityPrestige, chronosMult) / 60 / efficiency).toLong()
                 sessionRepo.startSession(Skills.SMITHING, action.activityKey, encodeFrames(frames), qty * perItemMs, action.skillDisplayName, insertAsCompleted = offline, backdateMs = backdateMs, levelAtStart = levelAtStart)
             }
             Skills.COOKING -> {
@@ -499,7 +506,7 @@ class QueuedSessionStarter @Inject constructor(
                 val efficiency = gameData.toolEfficiency(equipped[EquipSlot.FRYING_PAN], EquipSlot.FRYING_PAN, r.levelRequired)
                 val frames = buildCraftFrames(xpMap[Skills.COOKING] ?: 0L, qty, r.xpPerItem, 1, r.cookedItem,
                     efficiency = efficiency, petBoostPct = gatheringPetBoost(player.pets, Skills.COOKING))
-                val perItemMs = (SkillSimulator.sessionDurationMs(agilityLevel, agilityPrestige) / 60 / efficiency).toLong()
+                val perItemMs = (SkillSimulator.sessionDurationMs(agilityLevel, agilityPrestige, chronosMult) / 60 / efficiency).toLong()
                 sessionRepo.startSession(Skills.COOKING, action.activityKey, encodeFrames(frames), qty * perItemMs, action.skillDisplayName, insertAsCompleted = offline, backdateMs = backdateMs, levelAtStart = levelAtStart)
             }
             Skills.FLETCHING -> {
@@ -508,7 +515,7 @@ class QueuedSessionStarter @Inject constructor(
                 val frames = buildCraftFrames(xpMap[Skills.FLETCHING] ?: 0L, qty, r.xpPerItem, r.outputQuantity, r.itemName,
                     petBoostPct = gatheringPetBoost(player.pets, Skills.FLETCHING),
                     petDropKey = petDropKey(Skills.FLETCHING), petDropChance = petDropChance(Skills.FLETCHING))
-                val perItemMs = SkillSimulator.sessionDurationMs(agilityLevel, agilityPrestige) / 60
+                val perItemMs = SkillSimulator.sessionDurationMs(agilityLevel, agilityPrestige, chronosMult) / 60
                 sessionRepo.startSession(Skills.FLETCHING, action.activityKey, encodeFrames(frames), qty * perItemMs, action.skillDisplayName, insertAsCompleted = offline, backdateMs = backdateMs, levelAtStart = levelAtStart)
             }
             Skills.CRAFTING -> {
@@ -517,7 +524,7 @@ class QueuedSessionStarter @Inject constructor(
                 val frames = buildCraftFrames(xpMap[Skills.CRAFTING] ?: 0L, qty, r.xpPerItem, r.outputQuantity, action.activityKey,
                     petBoostPct = gatheringPetBoost(player.pets, Skills.CRAFTING),
                     petDropKey = petDropKey(Skills.CRAFTING), petDropChance = petDropChance(Skills.CRAFTING))
-                val perItemMs = SkillSimulator.sessionDurationMs(agilityLevel, agilityPrestige) / 60
+                val perItemMs = SkillSimulator.sessionDurationMs(agilityLevel, agilityPrestige, chronosMult) / 60
                 sessionRepo.startSession(Skills.CRAFTING, action.activityKey, encodeFrames(frames), qty * perItemMs, action.skillDisplayName, insertAsCompleted = offline, backdateMs = backdateMs, levelAtStart = levelAtStart)
             }
             Skills.CONSTRUCTION -> {
@@ -526,7 +533,7 @@ class QueuedSessionStarter @Inject constructor(
                 val frames = buildCraftFrames(xpMap[Skills.CONSTRUCTION] ?: 0L, qty, r.xpPerItem, r.outputQuantity, action.activityKey,
                     petBoostPct = gatheringPetBoost(player.pets, Skills.CONSTRUCTION),
                     petDropKey = petDropKey(Skills.CONSTRUCTION), petDropChance = petDropChance(Skills.CONSTRUCTION))
-                val perItemMs = SkillSimulator.sessionDurationMs(agilityLevel, agilityPrestige) / 60
+                val perItemMs = SkillSimulator.sessionDurationMs(agilityLevel, agilityPrestige, chronosMult) / 60
                 sessionRepo.startSession(Skills.CONSTRUCTION, action.activityKey, encodeFrames(frames), qty * perItemMs, action.skillDisplayName, insertAsCompleted = offline, backdateMs = backdateMs, levelAtStart = levelAtStart)
             }
             Skills.HERBLORE -> {
@@ -538,7 +545,7 @@ class QueuedSessionStarter @Inject constructor(
                 val frames    = buildCraftFrames(xpMap[Skills.HERBLORE] ?: 0L, qty, r.xpPerItem, r.outputQuantity, outputKey,
                     petBoostPct = gatheringPetBoost(player.pets, Skills.HERBLORE),
                     petDropKey = petDropKey(Skills.HERBLORE), petDropChance = petDropChance(Skills.HERBLORE))
-                val perItemMs = SkillSimulator.sessionDurationMs(agilityLevel, agilityPrestige) / 60
+                val perItemMs = SkillSimulator.sessionDurationMs(agilityLevel, agilityPrestige, chronosMult) / 60
                 sessionRepo.startSession(Skills.HERBLORE, action.activityKey, encodeFrames(frames), qty * perItemMs, action.skillDisplayName, insertAsCompleted = offline, backdateMs = backdateMs,
                     catalystKey = catalystKey, catalystQty = if (catalystKey != null) qty else 0, levelAtStart = levelAtStart)
             }
@@ -551,6 +558,7 @@ class QueuedSessionStarter @Inject constructor(
                     agilityPrestige = agilityPrestige,
                     petDropKey    = petDropKey(Skills.MERCANTILE),
                     petDropChance = petDropChance(Skills.MERCANTILE),
+                    chronosMultiplier = chronosMult,
                 )
                 sessionRepo.startSession(
                     skillName         = action.skillName,
@@ -628,7 +636,7 @@ class QueuedSessionStarter @Inject constructor(
                     attackSpeedSec     = bossWeapon?.attackSpeed ?: CombatSimulator.BASE_ATTACK_SPEED_SEC,
                     eatThresholdPct    = flags.foodEatThresholdPct,
                 )
-                val frameMs        = SkillSimulator.sessionDurationMs(agilityLevel, agilityPrestige) / 60L
+                val frameMs        = SkillSimulator.sessionDurationMs(agilityLevel, agilityPrestige, chronosMult) / 60L
                 val bossDurationMs = boss.durationMinutes * frameMs
                 sessionRepo.startSession(
                     skillName         = "boss",
@@ -660,6 +668,7 @@ class QueuedSessionStarter @Inject constructor(
                     agilityLevel    = agilityLevel,
                     agilityPrestige = flags.skillPrestige[Skills.AGILITY] ?: 0,
                     toolEfficiency  = toolEfficiency,
+                    chronosMultiplier = chronosMult,
                 )
                 startSession(action, result, offline, backdateMs, levelAtStart)
             }
@@ -737,6 +746,7 @@ class QueuedSessionStarter @Inject constructor(
                     availableRunes      = if (queueRuneKey != null) inventory[queueRuneKey] ?: 0 else Int.MAX_VALUE,
                     attackSpeedSec      = weapon?.attackSpeed ?: CombatSimulator.BASE_ATTACK_SPEED_SEC,
                     eatThresholdPct     = flags.foodEatThresholdPct,
+                    chronosMultiplier   = chronosMult,
                 )
                 startSession(action, result, offline, backdateMs, levelAtStart)
             }
@@ -821,6 +831,7 @@ class QueuedSessionStarter @Inject constructor(
                     availableRunes      = if (towerRuneKey != null) inventory[towerRuneKey] ?: 0 else Int.MAX_VALUE,
                     attackSpeedSec      = weapon?.attackSpeed ?: CombatSimulator.BASE_ATTACK_SPEED_SEC,
                     eatThresholdPct     = flags.foodEatThresholdPct,
+                    chronosMultiplier   = chronosMult,
                 )
                 sessionRepo.startSession(
                     skillName         = "tower",
@@ -847,7 +858,8 @@ class QueuedSessionStarter @Inject constructor(
                     petBoostPct        = gatheringPetBoost(player.pets, CarnivalSimulator.relevantSkill(action.activityKey)),
                     agilityLevel       = agilityLevel,
                     agilityPrestige    = flags.skillPrestige[Skills.AGILITY] ?: 0,
-                    tierBonus          = townRepo.idleTicketBonusChance(flags)
+                    tierBonus          = townRepo.idleTicketBonusChance(flags),
+                    chronosMultiplier  = chronosMult,
                 )
                 startSession(action, result, offline, backdateMs, levelAtStart)
             }

--- a/app/src/main/kotlin/com/fantasyidler/repository/TownRepository.kt
+++ b/app/src/main/kotlin/com/fantasyidler/repository/TownRepository.kt
@@ -145,6 +145,21 @@ class TownRepository @Inject constructor(
         return 3 + extraSlots
     }
 
+    /** Player session speed reduction factor (Chronos Spire bonus). */
+    fun playerSessionSpeedReduction(building: String, tier: Int): Float {
+        val bonuses = gameData.townBuildings[building]?.tiers?.getOrNull(tier - 1)?.bonuses ?: return 0.0f
+        return bonuses["player_session_speed_reduction"]?.toFloat() ?: 0.0f
+    }
+
+    /** Player session duration multiplier (e.g. 0.98 for 2% reduction). */
+    fun playerSessionDurationMultiplier(flags: PlayerFlags): Float {
+        var reduction = 0.0f
+        flags.townBuildingTiers.forEach { buildingName, tier ->
+            reduction += playerSessionSpeedReduction(buildingName, tier)
+        }
+        return (1.0f - reduction).coerceAtLeast(0.5f)
+    }
+
     // -------------------------------------------------------------------------
     // Upgrade action
     // -------------------------------------------------------------------------

--- a/app/src/main/kotlin/com/fantasyidler/simulator/CarnivalSimulator.kt
+++ b/app/src/main/kotlin/com/fantasyidler/simulator/CarnivalSimulator.kt
@@ -36,6 +36,7 @@ object CarnivalSimulator {
         agilityLevel: Int,
         agilityPrestige: Int = 0,
         tierBonus: Float = 0f,
+        chronosMultiplier: Float = 1.0f,
     ): SkillSimulator.Result {
         val chance = ticketChance(relevantSkillLevel) + tierBonus
         val baseXpFrame = xpPerFrame(activityKey)
@@ -60,7 +61,7 @@ object CarnivalSimulator {
 
         return SkillSimulator.Result(
             frames     = frames,
-            durationMs = SkillSimulator.sessionDurationMs(agilityLevel, agilityPrestige),
+            durationMs = SkillSimulator.sessionDurationMs(agilityLevel, agilityPrestige, chronosMultiplier),
         )
     }
 

--- a/app/src/main/kotlin/com/fantasyidler/simulator/CombatSimulator.kt
+++ b/app/src/main/kotlin/com/fantasyidler/simulator/CombatSimulator.kt
@@ -49,6 +49,7 @@ object CombatSimulator {
         availableRunes: Int = Int.MAX_VALUE,
         attackSpeedSec: Double = BASE_ATTACK_SPEED_SEC,
         eatThresholdPct: Int = 50,
+        chronosMultiplier: Float = 1.0f,
         random: Random = Random.Default,
     ): SkillSimulator.Result {
         val speed = attackSpeedSec.coerceIn(1.2, BASE_ATTACK_SPEED_SEC)
@@ -64,7 +65,7 @@ object CombatSimulator {
 
         val spawnPool = dungeon.enemySpawns.flatMap { spawn ->
             List(spawn.weight) { spawn.enemy }
-        }.ifEmpty { return SkillSimulator.Result(emptyList(), SkillSimulator.sessionDurationMs(agilityLevel, agilityPrestige)) }
+        }.ifEmpty { return SkillSimulator.Result(emptyList(), SkillSimulator.sessionDurationMs(agilityLevel, agilityPrestige, chronosMultiplier)) }
 
         val maxHp = playerHp * 10
         var currentHp = maxHp
@@ -283,7 +284,7 @@ object CombatSimulator {
             }
         }
 
-        val fullDurationMs = SkillSimulator.sessionDurationMs(agilityLevel, agilityPrestige)
+        val fullDurationMs = SkillSimulator.sessionDurationMs(agilityLevel, agilityPrestige, chronosMultiplier)
         return SkillSimulator.Result(frames, fullDurationMs)
     }
 

--- a/app/src/main/kotlin/com/fantasyidler/simulator/MercantileSimulator.kt
+++ b/app/src/main/kotlin/com/fantasyidler/simulator/MercantileSimulator.kt
@@ -20,6 +20,7 @@ object MercantileSimulator {
         agilityPrestige: Int = 0,
         petDropKey: String? = null,
         petDropChance: Double = 0.0,
+        chronosMultiplier: Float = 1.0f,
         random: Random = Random.Default,
     ): Result {
         var currentXp = startXp
@@ -59,7 +60,7 @@ object MercantileSimulator {
 
         return Result(
             frames    = frames,
-            durationMs = SkillSimulator.sessionDurationMs(agilityLevel, agilityPrestige),
+            durationMs = SkillSimulator.sessionDurationMs(agilityLevel, agilityPrestige, chronosMultiplier),
         )
     }
 

--- a/app/src/main/kotlin/com/fantasyidler/simulator/SkillSimulator.kt
+++ b/app/src/main/kotlin/com/fantasyidler/simulator/SkillSimulator.kt
@@ -55,6 +55,7 @@ object SkillSimulator {
         toolEfficiency: Float = 1.0f,
         petDropKey: String? = null,
         petDropChance: Double = 0.0,
+        chronosMultiplier: Float = 1.0f,
         random: Random = Random.Default,
     ): Result {
         var currentXp = startXp
@@ -102,7 +103,7 @@ object SkillSimulator {
             )
         }
 
-        return Result(frames, sessionDurationMs(agilityLevel, agilityPrestige))
+        return Result(frames, sessionDurationMs(agilityLevel, agilityPrestige, chronosMultiplier))
     }
 
     // ------------------------------------------------------------------
@@ -123,6 +124,7 @@ object SkillSimulator {
         toolEfficiency: Float = 1.0f,
         petDropKey: String? = null,
         petDropChance: Double = 0.0,
+        chronosMultiplier: Float = 1.0f,
         random: Random = Random.Default,
     ): Result {
         var currentXp = startXp
@@ -161,7 +163,7 @@ object SkillSimulator {
             )
         }
 
-        return Result(frames, sessionDurationMs(agilityLevel, agilityPrestige))
+        return Result(frames, sessionDurationMs(agilityLevel, agilityPrestige, chronosMultiplier))
     }
 
     // ------------------------------------------------------------------
@@ -179,6 +181,7 @@ object SkillSimulator {
         petDropKey: String? = null,
         petDropChance: Double = 0.0,
         fishingSkillData: GatheringSkillData? = null,
+        chronosMultiplier: Float = 1.0f,
         random: Random = Random.Default,
     ): Result {
         var currentXp = startXp
@@ -228,7 +231,7 @@ object SkillSimulator {
             )
         }
 
-        return Result(frames, sessionDurationMs(agilityLevel, agilityPrestige))
+        return Result(frames, sessionDurationMs(agilityLevel, agilityPrestige, chronosMultiplier))
     }
 
     // ------------------------------------------------------------------
@@ -250,6 +253,7 @@ object SkillSimulator {
         petDropKey: String? = null,
         petDropChance: Double = 0.0,
         forcedDropPerFrame: String? = null,
+        chronosMultiplier: Float = 1.0f,
         random: Random = Random.Default,
     ): Result {
         var currentXp = startXp
@@ -296,7 +300,7 @@ object SkillSimulator {
             )
         }
 
-        return Result(frames, sessionDurationMs(agilityLevel, agilityPrestige))
+        return Result(frames, sessionDurationMs(agilityLevel, agilityPrestige, chronosMultiplier))
     }
 
     // ------------------------------------------------------------------
@@ -323,6 +327,7 @@ object SkillSimulator {
         toolEfficiency: Float = 1.0f,
         petDropKey: String? = null,
         petDropChance: Double = 0.0,
+        chronosMultiplier: Float = 1.0f,
         random: Random = Random.Default,
     ): Result {
         var currentXp = startXp
@@ -363,7 +368,7 @@ object SkillSimulator {
             )
         }
 
-        return Result(frames, sessionDurationMs(agilityLevel, agilityPrestige))
+        return Result(frames, sessionDurationMs(agilityLevel, agilityPrestige, chronosMultiplier))
     }
 
     // ------------------------------------------------------------------
@@ -403,11 +408,11 @@ object SkillSimulator {
      *   level 75 → 45 min
      *   level 99 → 40 min
      */
-    fun sessionDurationMs(agilityLevel: Int, agilityPrestige: Int = 0): Long {
+    fun sessionDurationMs(agilityLevel: Int, agilityPrestige: Int = 0, chronosMultiplier: Float = 1.0f): Long {
         val fraction = (agilityLevel - 1).coerceIn(0, 98) / 98.0
         val maxReduction = 20.0 + agilityPrestige.coerceIn(0, 3) * (10.0 / 3.0)
-        val minutes = (60.0 - maxReduction * fraction).roundToInt()
-        return minutes * 60_000L
+        val minutes = (60.0 - maxReduction * fraction) * chronosMultiplier.coerceIn(0.5f, 1.0f)
+        return (minutes.roundToInt() * 60_000L).coerceAtLeast(60_000L)
     }
 
     /**

--- a/app/src/main/kotlin/com/fantasyidler/simulator/SkillingDungeonSimulator.kt
+++ b/app/src/main/kotlin/com/fantasyidler/simulator/SkillingDungeonSimulator.kt
@@ -24,6 +24,7 @@ object SkillingDungeonSimulator {
         agilityPrestige: Int = 0,
         toolEfficiency: Float = 1.0f,
         petBoostPct: Int = 0,
+        chronosMultiplier: Float = 1.0f,
         random: Random = Random.Default,
     ): SkillSimulator.Result {
         var currentXp = startXp
@@ -68,7 +69,7 @@ object SkillingDungeonSimulator {
             )
         }
 
-        return SkillSimulator.Result(frames, SkillSimulator.sessionDurationMs(agilityLevel, agilityPrestige))
+        return SkillSimulator.Result(frames, SkillSimulator.sessionDurationMs(agilityLevel, agilityPrestige, chronosMultiplier))
     }
 
     private fun <T> getTierData(tiers: Map<String, T>, currentLevel: Int): T {

--- a/app/src/main/kotlin/com/fantasyidler/simulator/ThievingSimulator.kt
+++ b/app/src/main/kotlin/com/fantasyidler/simulator/ThievingSimulator.kt
@@ -32,6 +32,7 @@ object ThievingSimulator {
         petDropKey: String? = null,
         petDropChance: Double = 0.0,
         toolEfficiency: Float = 1.0f,
+        chronosMultiplier: Float = 1.0f,
         random: Random = Random.Default,
     ): Result {
         val successChance = (0.40 + (thievingLevel - npc.levelRequired) * 0.02 * toolEfficiency)
@@ -121,6 +122,6 @@ object ThievingSimulator {
             )
         }
 
-        return Result(frames, SkillSimulator.sessionDurationMs(agilityLevel, agilityPrestige))
+        return Result(frames, SkillSimulator.sessionDurationMs(agilityLevel, agilityPrestige, chronosMultiplier))
     }
 }

--- a/app/src/main/kotlin/com/fantasyidler/ui/screen/BuilderScreen.kt
+++ b/app/src/main/kotlin/com/fantasyidler/ui/screen/BuilderScreen.kt
@@ -142,6 +142,19 @@ fun BuilderScreen(
                     inventory         = state.inventory,
                     onUpgrade         = { viewModel.upgrade("cape_rack") },
                 )
+            }
+            item {
+                Spacer(Modifier.height(16.dp))
+                BuildingUpgradeCard(
+                    buildingKey       = "chronos_spire",
+                    currentTier       = state.chronosSpireTier,
+                    buildingDef       = viewModel.gameData.townBuildings["chronos_spire"],
+                    townRepository    = viewModel.townRepo,
+                    constructionLevel = state.constructionLevel,
+                    coins             = state.coins,
+                    inventory         = state.inventory,
+                    onUpgrade         = { viewModel.upgrade("chronos_spire") },
+                )
                 Spacer(Modifier.height(16.dp))
             }
         }

--- a/app/src/main/kotlin/com/fantasyidler/ui/screen/TownBuildingUpgrade.kt
+++ b/app/src/main/kotlin/com/fantasyidler/ui/screen/TownBuildingUpgrade.kt
@@ -62,6 +62,7 @@ fun BuildingUpgradeCard(
                 "garden"       -> R.string.town_building_garden_name
                 "queue_master" -> R.string.town_building_queue_master_name
                 "cape_rack"    -> R.string.town_building_cape_rack_name
+                "chronos_spire" -> R.string.town_building_chronos_spire_name
                 else           -> R.string.town_upgrade_section_title
             }
             Text(
@@ -183,6 +184,10 @@ fun buildingBonusText(buildingKey: String, tier: Int, townRepo: TownRepository):
         1    -> stringResource(R.string.town_cape_rack_t1_bonus)
         2    -> stringResource(R.string.town_cape_rack_t2_bonus)
         else -> stringResource(R.string.town_cape_rack_t3_bonus)
+    }
+    "chronos_spire" -> when (tier) {
+        0    -> stringResource(R.string.town_chronos_spire_no_bonus)
+        else -> stringResource(R.string.town_chronos_spire_active_bonus, (townRepo.playerSessionSpeedReduction("chronos_spire", tier) * 100).roundToInt())
     }
     else -> ""
 }

--- a/app/src/main/kotlin/com/fantasyidler/ui/viewmodel/BuilderViewModel.kt
+++ b/app/src/main/kotlin/com/fantasyidler/ui/viewmodel/BuilderViewModel.kt
@@ -34,6 +34,7 @@ data class BuilderUiState(
     val gardenTier: Int = 0,
     val queueMasterTier: Int = 0,
     val capeRackTier: Int = 0,
+    val chronosSpireTier: Int = 0,
     val snackbarMessage: String? = null,
 )
 
@@ -68,19 +69,21 @@ class BuilderViewModel @Inject constructor(
             gardenTier        = flags.townBuildingTiers["garden"] ?: 0,
             queueMasterTier   = flags.townBuildingTiers["queue_master"] ?: 0,
             capeRackTier      = flags.townBuildingTiers["cape_rack"] ?: 0,
+            chronosSpireTier  = flags.townBuildingTiers["chronos_spire"] ?: 0,
         )
     }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), BuilderUiState())
 
     fun upgrade(buildingKey: String) {
         viewModelScope.launch {
             val currentTier = when (buildingKey) {
-                "inn"          -> uiState.value.innTier
-                "guild_hall"   -> uiState.value.guildHallTier
-                "fairgrounds"  -> uiState.value.fairgroundsTier
-                "garden"       -> uiState.value.gardenTier
-                "queue_master" -> uiState.value.queueMasterTier
-                "cape_rack"    -> uiState.value.capeRackTier
-                else           -> uiState.value.churchTier
+                "inn"           -> uiState.value.innTier
+                "guild_hall"    -> uiState.value.guildHallTier
+                "fairgrounds"   -> uiState.value.fairgroundsTier
+                "garden"        -> uiState.value.gardenTier
+                "queue_master"  -> uiState.value.queueMasterTier
+                "cape_rack"     -> uiState.value.capeRackTier
+                "chronos_spire" -> uiState.value.chronosSpireTier
+                else            -> uiState.value.churchTier
             }
             val def = gameData.townBuildings[buildingKey]
             when (townRepo.upgradeBuilding(buildingKey)) {

--- a/app/src/main/kotlin/com/fantasyidler/ui/viewmodel/CarnivalViewModel.kt
+++ b/app/src/main/kotlin/com/fantasyidler/ui/viewmodel/CarnivalViewModel.kt
@@ -236,7 +236,7 @@ class CarnivalViewModel @Inject constructor(
                     skillName           = "carnival",
                     activityKey         = activityKey,
                     skillDisplayName    = displayName,
-                    estimatedDurationMs = SkillSimulator.sessionDurationMs(agility, carnivalFlags.skillPrestige[Skills.AGILITY] ?: 0),
+                    estimatedDurationMs = SkillSimulator.sessionDurationMs(agility, carnivalFlags.skillPrestige[Skills.AGILITY] ?: 0, townRepo.playerSessionDurationMultiplier(carnivalFlags)),
                 )
             )
             if (enqueued) queuedSessionStarter.startNextQueued()

--- a/app/src/main/kotlin/com/fantasyidler/ui/viewmodel/CombatViewModel.kt
+++ b/app/src/main/kotlin/com/fantasyidler/ui/viewmodel/CombatViewModel.kt
@@ -27,6 +27,7 @@ import com.fantasyidler.repository.QueuedSessionStarter
 import com.fantasyidler.repository.SeasonalEventRepository
 import com.fantasyidler.repository.SessionRepository
 import com.fantasyidler.repository.SlayerRepository
+import com.fantasyidler.repository.TownRepository
 import com.fantasyidler.simulator.CombatSimulator
 import com.fantasyidler.simulator.SkillSimulator
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -116,6 +117,7 @@ class CombatViewModel @Inject constructor(
     private val slayerRepo: SlayerRepository,
     private val seasonalEventRepo: SeasonalEventRepository,
     private val queuedSessionStarter: QueuedSessionStarter,
+    private val townRepo: TownRepository,
     private val json: Json,
 ) : ViewModel() {
 
@@ -392,7 +394,7 @@ class CombatViewModel @Inject constructor(
                         skillName           = "combat",
                         activityKey         = dungeonKey,
                         skillDisplayName    = dungeonName,
-                        estimatedDurationMs = SkillSimulator.sessionDurationMs(agility, dungeonFlags.skillPrestige[Skills.AGILITY] ?: 0),
+                        estimatedDurationMs = SkillSimulator.sessionDurationMs(agility, dungeonFlags.skillPrestige[Skills.AGILITY] ?: 0, townRepo.playerSessionDurationMultiplier(dungeonFlags)),
                         estimatedXpGain     = previewXp,
                         equippedSnapshot    = player.equipped,
                         arrowsKey           = _extra.value.selectedArrowKey ?: dungeonFlags.equippedArrows,
@@ -550,6 +552,7 @@ class CombatViewModel @Inject constructor(
                     availableRunes      = if (simulatorRuneKey != null) inventory[simulatorRuneKey] ?: 0 else Int.MAX_VALUE,
                     attackSpeedSec      = weapon?.attackSpeed ?: CombatSimulator.BASE_ATTACK_SPEED_SEC,
                     eatThresholdPct     = flags.foodEatThresholdPct,
+                    chronosMultiplier   = townRepo.playerSessionDurationMultiplier(flags),
                 )
 
                 val framesJson = json.encodeToString(
@@ -757,7 +760,7 @@ class CombatViewModel @Inject constructor(
                     bossFrames,
                 )
                 val agilityLevel   = levels[Skills.AGILITY] ?: 1
-                val frameMs        = SkillSimulator.sessionDurationMs(agilityLevel, flags.skillPrestige[Skills.AGILITY] ?: 0) / 60L
+                val frameMs        = SkillSimulator.sessionDurationMs(agilityLevel, flags.skillPrestige[Skills.AGILITY] ?: 0, townRepo.playerSessionDurationMultiplier(flags)) / 60L
                 val bossDurationMs = boss.durationMinutes * frameMs
                 sessionRepo.startSession(
                     skillName        = "boss",
@@ -991,6 +994,7 @@ class CombatViewModel @Inject constructor(
                     arrowStrengthBonuses = ARROW_STRENGTH_BONUS,
                     attackSpeedSec      = weapon?.attackSpeed ?: CombatSimulator.BASE_ATTACK_SPEED_SEC,
                     eatThresholdPct     = flags.foodEatThresholdPct,
+                    chronosMultiplier   = townRepo.playerSessionDurationMultiplier(flags),
                     random              = Random.Default,
                 )
                 if (result.frames.none { it.died }) survived++
@@ -1116,6 +1120,7 @@ class CombatViewModel @Inject constructor(
             availableRunes      = Int.MAX_VALUE,
             attackSpeedSec      = weapon?.attackSpeed ?: CombatSimulator.BASE_ATTACK_SPEED_SEC,
             eatThresholdPct     = flags.foodEatThresholdPct,
+            chronosMultiplier   = townRepo.playerSessionDurationMultiplier(flags),
         )
         return result.frames.sumOf { it.xpGain.toLong() }
     }

--- a/app/src/main/kotlin/com/fantasyidler/ui/viewmodel/CraftingViewModel.kt
+++ b/app/src/main/kotlin/com/fantasyidler/ui/viewmodel/CraftingViewModel.kt
@@ -18,6 +18,7 @@ import com.fantasyidler.repository.QuestRepository
 import com.fantasyidler.repository.SeasonalEventRepository
 import com.fantasyidler.repository.SessionRepository
 import com.fantasyidler.repository.WeeklyQuestRepository
+import com.fantasyidler.repository.TownRepository
 import com.fantasyidler.simulator.SkillSimulator
 import com.fantasyidler.simulator.XpTable
 import com.fantasyidler.util.craftDurationEfficiency
@@ -154,6 +155,7 @@ class CraftingViewModel @Inject constructor(
     private val weeklyQuestRepo: WeeklyQuestRepository,
     private val guildRepo: GuildRepository,
     private val seasonalEventRepo: SeasonalEventRepository,
+    private val townRepo: TownRepository,
     private val json: Json,
 ) : ViewModel() {
 
@@ -392,7 +394,7 @@ class CraftingViewModel @Inject constructor(
                 val craftFlags = playerRepo.getFlags()
                 val agility   = state.skillLevels[Skills.AGILITY] ?: 1
                 val toolEff   = craftToolEfficiency(recipe, json.decodeFromString(playerRepo.getOrCreatePlayer().equipped))
-                val perItemMs = (SkillSimulator.sessionDurationMs(agility, craftFlags.skillPrestige[Skills.AGILITY] ?: 0) / 60 / toolEff).toLong()
+                val perItemMs = (SkillSimulator.sessionDurationMs(agility, craftFlags.skillPrestige[Skills.AGILITY] ?: 0, townRepo.playerSessionDurationMultiplier(craftFlags)) / 60 / toolEff).toLong()
                 val totalOutput = qty * recipe.outputQty
                 val xpQueueMult = (if (craftFlags.xpBoostExpiresAt > System.currentTimeMillis()) 2.0 else 1.0) * ChurchRepository.xpMultiplier(craftFlags)
                 val queuePetPct = petBoostFor(playerRepo.getOrCreatePlayer().pets, recipe.skillName)
@@ -454,7 +456,7 @@ class CraftingViewModel @Inject constructor(
             val flags = try { json.decodeFromString<PlayerFlags>(player.flags) } catch (_: Exception) { PlayerFlags() }
             val agilityLevel = levels[Skills.AGILITY] ?: 1
             // 1 item per minute, reduced by agility (same formula as gathering skills) and by tool efficiency
-            val perItemMs = (SkillSimulator.sessionDurationMs(agilityLevel, flags.skillPrestige[Skills.AGILITY] ?: 0) / 60 / efficiency).toLong()
+            val perItemMs = (SkillSimulator.sessionDurationMs(agilityLevel, flags.skillPrestige[Skills.AGILITY] ?: 0, townRepo.playerSessionDurationMultiplier(flags)) / 60 / efficiency).toLong()
 
             val framesJson = json.encodeToString(
                 json.serializersModule.serializer<List<SessionFrame>>(),

--- a/app/src/main/kotlin/com/fantasyidler/ui/viewmodel/ExpeditionsViewModel.kt
+++ b/app/src/main/kotlin/com/fantasyidler/ui/viewmodel/ExpeditionsViewModel.kt
@@ -14,6 +14,7 @@ import com.fantasyidler.repository.GameDataRepository
 import com.fantasyidler.repository.PlayerRepository
 import com.fantasyidler.repository.QueuedSessionStarter
 import com.fantasyidler.repository.SessionRepository
+import com.fantasyidler.repository.TownRepository
 import com.fantasyidler.simulator.SkillingDungeonSimulator
 import com.fantasyidler.util.GameStrings
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -52,6 +53,7 @@ class ExpeditionsViewModel @Inject constructor(
     private val sessionRepo: SessionRepository,
     private val gameData: GameDataRepository,
     private val queuedSessionStarter: QueuedSessionStarter,
+    private val townRepo: TownRepository,
     private val json: Json,
 ) : ViewModel() {
 
@@ -136,7 +138,7 @@ class ExpeditionsViewModel @Inject constructor(
                         skillName           = "expedition",
                         activityKey         = key,
                         skillDisplayName    = dungeon.displayName,
-                        estimatedDurationMs = SkillSimulator.sessionDurationMs(agilityLevel, agilityPrestige),
+                        estimatedDurationMs = SkillSimulator.sessionDurationMs(agilityLevel, agilityPrestige, townRepo.playerSessionDurationMultiplier(flags)),
                     )
                 )
                 _extra.update {
@@ -160,6 +162,7 @@ class ExpeditionsViewModel @Inject constructor(
                 agilityLevel    = agilityLevel,
                 agilityPrestige = agilityPrestige,
                 toolEfficiency  = toolEfficiency,
+                chronosMultiplier = townRepo.playerSessionDurationMultiplier(flags),
             )
             sessionRepo.startSession(
                 skillName        = "expedition",

--- a/app/src/main/kotlin/com/fantasyidler/ui/viewmodel/MercantileViewModel.kt
+++ b/app/src/main/kotlin/com/fantasyidler/ui/viewmodel/MercantileViewModel.kt
@@ -17,6 +17,7 @@ import com.fantasyidler.repository.QuestRepository
 import com.fantasyidler.repository.GuildRepository
 import com.fantasyidler.repository.DailyQuestRepository
 import com.fantasyidler.repository.WeeklyQuestRepository
+import com.fantasyidler.repository.TownRepository
 import com.fantasyidler.simulator.MercantileSimulator
 import com.fantasyidler.simulator.SkillSimulator
 import com.fantasyidler.simulator.XpTable
@@ -62,6 +63,7 @@ class MercantileViewModel @Inject constructor(
     private val guildRepo: GuildRepository,
     private val dailyQuestRepo: DailyQuestRepository,
     private val weeklyQuestRepo: WeeklyQuestRepository,
+    private val townRepo: TownRepository,
     private val json: Json,
 ) : ViewModel() {
 
@@ -134,7 +136,7 @@ class MercantileViewModel @Inject constructor(
                         activityKey         = routeId,
                         skillDisplayName    = "Mercantile",
                         estimatedXpGain     = estimatedXpGain,
-                        estimatedDurationMs = SkillSimulator.sessionDurationMs(agilityLevel, mercFlags.skillPrestige[Skills.AGILITY] ?: 0),
+                        estimatedDurationMs = SkillSimulator.sessionDurationMs(agilityLevel, mercFlags.skillPrestige[Skills.AGILITY] ?: 0, townRepo.playerSessionDurationMultiplier(mercFlags)),
                         coinRefund          = route.coinCost.toLong(),
                     )
                 )
@@ -162,6 +164,7 @@ class MercantileViewModel @Inject constructor(
                 val result  = MercantileSimulator.simulate(
                     route, startXp, agilityLevel,
                     agilityPrestige = mercFlags.skillPrestige[Skills.AGILITY] ?: 0,
+                    chronosMultiplier = townRepo.playerSessionDurationMultiplier(mercFlags),
                 )
                 val framesJson = json.encodeToString(
                     json.serializersModule.serializer<List<SessionFrame>>(),

--- a/app/src/main/kotlin/com/fantasyidler/ui/viewmodel/SkillsViewModel.kt
+++ b/app/src/main/kotlin/com/fantasyidler/ui/viewmodel/SkillsViewModel.kt
@@ -27,6 +27,7 @@ import com.fantasyidler.repository.WeeklyQuestRepository
 import com.fantasyidler.repository.QueuedSessionStarter
 import com.fantasyidler.repository.SeasonalEventRepository
 import com.fantasyidler.repository.SessionRepository
+import com.fantasyidler.repository.TownRepository
 import com.fantasyidler.simulator.SkillSimulator
 import com.fantasyidler.simulator.ThievingSimulator
 import com.fantasyidler.simulator.XpTable
@@ -138,6 +139,7 @@ class SkillsViewModel @Inject constructor(
     private val dailyQuestRepo: DailyQuestRepository,
     private val weeklyQuestRepo: WeeklyQuestRepository,
     private val seasonalEventRepo: SeasonalEventRepository,
+    private val townRepo: TownRepository,
     private val json: Json,
 ) : ViewModel() {
 
@@ -181,10 +183,10 @@ class SkillsViewModel @Inject constructor(
                 xpBonusMult           = (if (flags.xpBoostExpiresAt > System.currentTimeMillis()) 2.0f else 1.0f) * ChurchRepository.xpMultiplier(flags),
                 petBoosts             = listOf(Skills.MINING, Skills.WOODCUTTING, Skills.FISHING, Skills.AGILITY)
                     .associateWith { petBoostFor(player.pets, it) },
-                sessionDurationMs     = SkillSimulator.sessionDurationMs(levels[Skills.AGILITY] ?: 1, flags.skillPrestige[Skills.AGILITY] ?: 0),
+                sessionDurationMs     = SkillSimulator.sessionDurationMs(levels[Skills.AGILITY] ?: 1, flags.skillPrestige[Skills.AGILITY] ?: 0, townRepo.playerSessionDurationMultiplier(flags)),
                 firemakingPerLogMs    = gameData.logs.mapValues { (_, log) ->
                     val toolEff = gameData.toolEfficiency(equipped[EquipSlot.TINDERBOX], EquipSlot.TINDERBOX, log.levelRequired)
-                    (SkillSimulator.sessionDurationMs(levels[Skills.AGILITY] ?: 1, flags.skillPrestige[Skills.AGILITY] ?: 0) / 60L / toolEff).toLong()
+                    (SkillSimulator.sessionDurationMs(levels[Skills.AGILITY] ?: 1, flags.skillPrestige[Skills.AGILITY] ?: 0, townRepo.playerSessionDurationMultiplier(flags)) / 60L / toolEff).toLong()
                 },
                 skillPrestige         = flags.skillPrestige,
                 inventory             = inv,
@@ -335,6 +337,7 @@ class SkillsViewModel @Inject constructor(
             toolEfficiency   = gameData.toolEfficiency(equipped[EquipSlot.PICKAXE], EquipSlot.PICKAXE, oreData.levelRequired),
             petDropKey       = petKey,
             petDropChance    = petChance,
+            chronosMultiplier = townRepo.playerSessionDurationMultiplier(flags),
         )
     }
 
@@ -357,6 +360,7 @@ class SkillsViewModel @Inject constructor(
             toolEfficiency   = gameData.toolEfficiency(equipped[EquipSlot.AXE], EquipSlot.AXE, treeData.levelRequired),
             petDropKey       = petKey,
             petDropChance    = petChance,
+            chronosMultiplier = townRepo.playerSessionDurationMultiplier(flags),
         )
     }
 
@@ -375,6 +379,7 @@ class SkillsViewModel @Inject constructor(
             agilityPrestige = flags.skillPrestige[Skills.AGILITY] ?: 0,
             petBoostPct     = petBoostFor(player.pets, Skills.AGILITY),
             toolEfficiency  = gameData.toolEfficiency(equipped[EquipSlot.GRAPPLING_HOOK], EquipSlot.GRAPPLING_HOOK, courseData.levelRequired),
+            chronosMultiplier = townRepo.playerSessionDurationMultiplier(flags),
         )
     }
 
@@ -394,7 +399,7 @@ class SkillsViewModel @Inject constructor(
             val equipped: Map<String, String?> = json.decodeFromString(player.equipped)
             val logData = gameData.logs[logKey]
             val toolEff = gameData.toolEfficiency(equipped[EquipSlot.TINDERBOX], EquipSlot.TINDERBOX, logData?.levelRequired ?: 0)
-            val perLogMs = (SkillSimulator.sessionDurationMs(agility, flags.skillPrestige[Skills.AGILITY] ?: 0) / 60L / toolEff).toLong()
+            val perLogMs = (SkillSimulator.sessionDurationMs(agility, flags.skillPrestige[Skills.AGILITY] ?: 0, townRepo.playerSessionDurationMultiplier(flags)) / 60L / toolEff).toLong()
             val logXp = logData?.xpPerLog?.toLong() ?: 0L
             val xpQueueMult = (if (flags.xpBoostExpiresAt > System.currentTimeMillis()) 2.0 else 1.0) * ChurchRepository.xpMultiplier(flags)
             val action = QueuedAction(
@@ -448,7 +453,7 @@ class SkillsViewModel @Inject constructor(
                 val agility    = levels[Skills.AGILITY]      ?: 1
                 val rcLevel    = levels[Skills.RUNECRAFTING]  ?: 1
                 val rcFlags = try { json.decodeFromString<PlayerFlags>(player.flags) } catch (_: Exception) { PlayerFlags() }
-                val perItemMs  = SkillSimulator.sessionDurationMs(agility, rcFlags.skillPrestige[Skills.AGILITY] ?: 0) / 60
+                val perItemMs  = SkillSimulator.sessionDurationMs(agility, rcFlags.skillPrestige[Skills.AGILITY] ?: 0, townRepo.playerSessionDurationMultiplier(rcFlags)) / 60
                 val ashBon     = catalystKey?.let { ashRuneBonusForKey(it) } ?: 0
                 val mult       = when { rcLevel >= 75 -> 3; rcLevel >= 50 -> 2; else -> 1 } + ashBon
                 val xpQueueMult = (if (rcFlags.xpBoostExpiresAt > System.currentTimeMillis()) 2.0 else 1.0) * ChurchRepository.xpMultiplier(rcFlags)
@@ -561,7 +566,7 @@ class SkillsViewModel @Inject constructor(
             if (sessionRepo.getActiveSession() != null) {
                 val agility   = (json.decodeFromString<Map<String, Int>>(player.skillLevels))[Skills.AGILITY] ?: 1
                 val prayerFlags = try { json.decodeFromString<PlayerFlags>(player.flags) } catch (_: Exception) { PlayerFlags() }
-                val perBoneMs = SkillSimulator.sessionDurationMs(agility, prayerFlags.skillPrestige[Skills.AGILITY] ?: 0) / 60
+                val perBoneMs = SkillSimulator.sessionDurationMs(agility, prayerFlags.skillPrestige[Skills.AGILITY] ?: 0, townRepo.playerSessionDurationMultiplier(prayerFlags)) / 60
                 val xpQueueMult = (if (prayerFlags.xpBoostExpiresAt > System.currentTimeMillis()) 2.0 else 1.0) * ChurchRepository.xpMultiplier(prayerFlags)
                 val enqueued = playerRepo.enqueueAction(
                     QueuedAction(
@@ -650,6 +655,7 @@ class SkillsViewModel @Inject constructor(
             petDropKey       = petKey,
             petDropChance    = petChance,
             fishingSkillData = gameData.fishingSkillData,
+            chronosMultiplier = townRepo.playerSessionDurationMultiplier(flags),
         )
     }
 
@@ -680,7 +686,7 @@ class SkillsViewModel @Inject constructor(
                         activityKey         = npcKey,
                         skillDisplayName    = "Thieving",
                         estimatedXpGain     = estimatedXpGain,
-                        estimatedDurationMs = SkillSimulator.sessionDurationMs(agility, thievingFlags.skillPrestige[Skills.AGILITY] ?: 0),
+                        estimatedDurationMs = SkillSimulator.sessionDurationMs(agility, thievingFlags.skillPrestige[Skills.AGILITY] ?: 0, townRepo.playerSessionDurationMultiplier(thievingFlags)),
                     )
                 )
                 if (enqueued) queuedSessionStarter.startNextQueued()
@@ -712,6 +718,7 @@ class SkillsViewModel @Inject constructor(
                     petDropKey      = petKey,
                     petDropChance   = petChance,
                     toolEfficiency  = gameData.toolEfficiency(equipped[EquipSlot.LOCKPICK], EquipSlot.LOCKPICK, npc.levelRequired),
+                    chronosMultiplier = townRepo.playerSessionDurationMultiplier(flags),
                 )
                 val framesJson = json.encodeToString(
                     json.serializersModule.serializer<List<SessionFrame>>(),

--- a/app/src/main/kotlin/com/fantasyidler/ui/viewmodel/SlayerViewModel.kt
+++ b/app/src/main/kotlin/com/fantasyidler/ui/viewmodel/SlayerViewModel.kt
@@ -15,6 +15,7 @@ import com.fantasyidler.repository.GameDataRepository
 import com.fantasyidler.repository.PlayerRepository
 import com.fantasyidler.repository.QueuedSessionStarter
 import com.fantasyidler.repository.SlayerRepository
+import com.fantasyidler.repository.TownRepository
 import com.fantasyidler.util.GameStrings
 import com.fantasyidler.util.formatXp
 import com.fantasyidler.util.withAppLocale
@@ -75,6 +76,7 @@ class SlayerViewModel @Inject constructor(
     val gameData: GameDataRepository,
     private val queuedSessionStarter: QueuedSessionStarter,
     @ApplicationContext private val context: Context,
+    private val townRepo: TownRepository,
     private val json: Json,
 ) : ViewModel() {
 
@@ -260,7 +262,7 @@ class SlayerViewModel @Inject constructor(
                     skillName           = "combat",
                     activityKey         = dungeonKey,
                     skillDisplayName    = dungeonName,
-                    estimatedDurationMs = SkillSimulator.sessionDurationMs(agility, flags.skillPrestige[Skills.AGILITY] ?: 0),
+                    estimatedDurationMs = SkillSimulator.sessionDurationMs(agility, flags.skillPrestige[Skills.AGILITY] ?: 0, townRepo.playerSessionDurationMultiplier(flags)),
                     equippedSnapshot    = player.equipped,
                     arrowsKey           = flags.equippedArrows,
                     spellName           = flags.activeSpell,

--- a/app/src/main/kotlin/com/fantasyidler/ui/viewmodel/TowerViewModel.kt
+++ b/app/src/main/kotlin/com/fantasyidler/ui/viewmodel/TowerViewModel.kt
@@ -24,6 +24,7 @@ import com.fantasyidler.repository.QueuedSessionStarter
 import com.fantasyidler.repository.QuestRepository
 import com.fantasyidler.repository.SessionRepository
 import com.fantasyidler.repository.SlayerRepository
+import com.fantasyidler.repository.TownRepository
 import com.fantasyidler.simulator.CombatSimulator
 import com.fantasyidler.simulator.SkillSimulator
 import com.fantasyidler.util.GameStrings
@@ -76,6 +77,7 @@ class TowerViewModel @Inject constructor(
     private val questRepo: QuestRepository,
     private val guildRepo: GuildRepository,
     private val slayerRepo: SlayerRepository,
+    private val townRepo: TownRepository,
     private val json: Json,
 ) : ViewModel() {
 
@@ -277,7 +279,7 @@ class TowerViewModel @Inject constructor(
                         skillName           = "tower",
                         activityKey         = "tower_floor_$nextFloor",
                         skillDisplayName    = "Infinite Tower: Floor $nextFloor",
-                        estimatedDurationMs = SkillSimulator.sessionDurationMs(agility, flags.skillPrestige[Skills.AGILITY] ?: 0),
+                        estimatedDurationMs = SkillSimulator.sessionDurationMs(agility, flags.skillPrestige[Skills.AGILITY] ?: 0, townRepo.playerSessionDurationMultiplier(flags)),
                     )
                 )
                 if (enqueued) queuedSessionStarter.startNextQueued()
@@ -398,6 +400,7 @@ class TowerViewModel @Inject constructor(
                     runeCostPerAttack   = runeCost,
                     attackSpeedSec      = weaponAttackSpeed,
                     eatThresholdPct     = flags.foodEatThresholdPct,
+                    chronosMultiplier   = townRepo.playerSessionDurationMultiplier(flags),
                 )
 
                 // Runes are consumed after the session, not upfront.

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -14,4 +14,7 @@
     <string name="town_cape_rack_t1_bonus">Passive bonuses from Tier 1 (Gathering) capes are active</string>
     <string name="town_cape_rack_t2_bonus">Passive bonuses from Tier 1 &amp; 2 (Gathering, Artisan) capes are active</string>
     <string name="town_cape_rack_t3_bonus">Passive bonuses from all owned capes (Gathering, Artisan, Combat &amp; Guild) are active</string>
+    <string name="town_building_chronos_spire_name">Chronos Spire</string>
+    <string name="town_chronos_spire_no_bonus">Upgrade to reduce player session durations</string>
+    <string name="town_chronos_spire_active_bonus">%1$d%% reduction to player session durations</string>
 </resources>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -1662,4 +1662,7 @@
     <string name="crafting_owned">Besitz: %1$d</string>
     <string name="crafting_owned_detail">Im Inventar: %1$d</string>
     <string name="firemaking_ashes_owned">Asche im Besitz: %1$d</string>
+    <string name="town_building_chronos_spire_name">Chronos Spire</string>
+    <string name="town_chronos_spire_no_bonus">Upgrade to reduce player session durations</string>
+    <string name="town_chronos_spire_active_bonus">%1$d%% reduction to player session durations</string>
 </resources>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -1603,4 +1603,7 @@
     <string name="crafting_owned">Owned: %1$d</string>
     <string name="crafting_owned_detail">Owned in inventory: %1$d</string>
     <string name="firemaking_ashes_owned">Ashes owned: %1$d</string>
+    <string name="town_building_chronos_spire_name">Chronos Spire</string>
+    <string name="town_chronos_spire_no_bonus">Upgrade to reduce player session durations</string>
+    <string name="town_chronos_spire_active_bonus">%1$d%% reduction to player session durations</string>
 </resources>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -1601,4 +1601,7 @@
     <string name="crafting_owned">Possédé: %1$d</string>
     <string name="crafting_owned_detail">Présent dans l\'inventaire: %1$d</string>
     <string name="firemaking_ashes_owned">Cendres possédées: %1$d</string>
+    <string name="town_building_chronos_spire_name">Chronos Spire</string>
+    <string name="town_chronos_spire_no_bonus">Upgrade to reduce player session durations</string>
+    <string name="town_chronos_spire_active_bonus">%1$d%% reduction to player session durations</string>
 </resources>

--- a/app/src/main/res/values-ga/strings.xml
+++ b/app/src/main/res/values-ga/strings.xml
@@ -440,4 +440,7 @@
         <item quantity="many">%1$d tóraíochtaí críochnaithe</item>
         <item quantity="other">%1$d tóraíochtaí críochnaithe</item>
     </plurals>
+    <string name="town_building_chronos_spire_name">Chronos Spire</string>
+    <string name="town_chronos_spire_no_bonus">Upgrade to reduce player session durations</string>
+    <string name="town_chronos_spire_active_bonus">%1$d%% reduction to player session durations</string>
 </resources>

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -1344,4 +1344,7 @@
     <string name="town_cape_rack_t1_bonus">Passive bonuses from Tier 1 (Gathering) capes are active</string>
     <string name="town_cape_rack_t2_bonus">Passive bonuses from Tier 1 &amp; 2 (Gathering, Artisan) capes are active</string>
     <string name="town_cape_rack_t3_bonus">Passive bonuses from all owned capes (Gathering, Artisan, Combat &amp; Guild) are active</string>
+    <string name="town_building_chronos_spire_name">Chronos Spire</string>
+    <string name="town_chronos_spire_no_bonus">Upgrade to reduce player session durations</string>
+    <string name="town_chronos_spire_active_bonus">%1$d%% reduction to player session durations</string>
 </resources>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -1655,4 +1655,7 @@
     <string name="crafting_owned">In possesso: %1$d</string>
     <string name="crafting_owned_detail">In possesso: %1$d</string>
     <string name="firemaking_ashes_owned">Ceneri disponibili: %1$d</string>
+    <string name="town_building_chronos_spire_name">Chronos Spire</string>
+    <string name="town_chronos_spire_no_bonus">Upgrade to reduce player session durations</string>
+    <string name="town_chronos_spire_active_bonus">%1$d%% reduction to player session durations</string>
 </resources>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -1646,4 +1646,7 @@
     <string name="town_cape_rack_t1_bonus">Passive bonuses from Tier 1 (Gathering) capes are active</string>
     <string name="town_cape_rack_t2_bonus">Passive bonuses from Tier 1 &amp; 2 (Gathering, Artisan) capes are active</string>
     <string name="town_cape_rack_t3_bonus">Passive bonuses from all owned capes (Gathering, Artisan, Combat &amp; Guild) are active</string>
+    <string name="town_building_chronos_spire_name">Chronos Spire</string>
+    <string name="town_chronos_spire_no_bonus">Upgrade to reduce player session durations</string>
+    <string name="town_chronos_spire_active_bonus">%1$d%% reduction to player session durations</string>
 </resources>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -1631,4 +1631,7 @@
     <string name="town_cape_rack_t1_bonus">Passive bonuses from Tier 1 (Gathering) capes are active</string>
     <string name="town_cape_rack_t2_bonus">Passive bonuses from Tier 1 &amp; 2 (Gathering, Artisan) capes are active</string>
     <string name="town_cape_rack_t3_bonus">Passive bonuses from all owned capes (Gathering, Artisan, Combat &amp; Guild) are active</string>
+    <string name="town_building_chronos_spire_name">Chronos Spire</string>
+    <string name="town_chronos_spire_no_bonus">Upgrade to reduce player session durations</string>
+    <string name="town_chronos_spire_active_bonus">%1$d%% reduction to player session durations</string>
 </resources>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -1667,4 +1667,7 @@
     <string name="town_cape_rack_t1_bonus">Passive bonuses from Tier 1 (Gathering) capes are active</string>
     <string name="town_cape_rack_t2_bonus">Passive bonuses from Tier 1 &amp; 2 (Gathering, Artisan) capes are active</string>
     <string name="town_cape_rack_t3_bonus">Passive bonuses from all owned capes (Gathering, Artisan, Combat &amp; Guild) are active</string>
+    <string name="town_building_chronos_spire_name">Chronos Spire</string>
+    <string name="town_chronos_spire_no_bonus">Upgrade to reduce player session durations</string>
+    <string name="town_chronos_spire_active_bonus">%1$d%% reduction to player session durations</string>
 </resources>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -1642,4 +1642,7 @@
     <string name="town_cape_rack_t1_bonus">Passive bonuses from Tier 1 (Gathering) capes are active</string>
     <string name="town_cape_rack_t2_bonus">Passive bonuses from Tier 1 &amp; 2 (Gathering, Artisan) capes are active</string>
     <string name="town_cape_rack_t3_bonus">Passive bonuses from all owned capes (Gathering, Artisan, Combat &amp; Guild) are active</string>
+    <string name="town_building_chronos_spire_name">Chronos Spire</string>
+    <string name="town_chronos_spire_no_bonus">Upgrade to reduce player session durations</string>
+    <string name="town_chronos_spire_active_bonus">%1$d%% reduction to player session durations</string>
 </resources>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -1643,4 +1643,7 @@
     <string name="town_cape_rack_t1_bonus">Passive bonuses from Tier 1 (Gathering) capes are active</string>
     <string name="town_cape_rack_t2_bonus">Passive bonuses from Tier 1 &amp; 2 (Gathering, Artisan) capes are active</string>
     <string name="town_cape_rack_t3_bonus">Passive bonuses from all owned capes (Gathering, Artisan, Combat &amp; Guild) are active</string>
+    <string name="town_building_chronos_spire_name">Chronos Spire</string>
+    <string name="town_chronos_spire_no_bonus">Upgrade to reduce player session durations</string>
+    <string name="town_chronos_spire_active_bonus">%1$d%% reduction to player session durations</string>
 </resources>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -1608,4 +1608,7 @@
     <string name="crafting_owned">Owned: %1$d</string>
     <string name="crafting_owned_detail">Owned in inventory: %1$d</string>
     <string name="firemaking_ashes_owned">Ashes owned: %1$d</string>
+    <string name="town_building_chronos_spire_name">Chronos Spire</string>
+    <string name="town_chronos_spire_no_bonus">Upgrade to reduce player session durations</string>
+    <string name="town_chronos_spire_active_bonus">%1$d%% reduction to player session durations</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1248,6 +1248,9 @@
     <string name="town_cape_rack_t1_bonus">Passive bonuses from Tier 1 (Gathering) capes are active</string>
     <string name="town_cape_rack_t2_bonus">Passive bonuses from Tier 1 &amp; 2 (Gathering, Artisan) capes are active</string>
     <string name="town_cape_rack_t3_bonus">Passive bonuses from all owned capes (Gathering, Artisan, Combat &amp; Guild) are active</string>
+    <string name="town_building_chronos_spire_name">Chronos Spire</string>
+    <string name="town_chronos_spire_no_bonus">Upgrade to reduce player session durations</string>
+    <string name="town_chronos_spire_active_bonus">%1$d%% reduction to player session durations</string>
 
     <!-- Town achievements -->
     <string name="achievement_town_first_upgrade_name">First Renovation</string>

--- a/app/src/test/kotlin/com/fantasyidler/simulator/SkillSimulatorPureTest.kt
+++ b/app/src/test/kotlin/com/fantasyidler/simulator/SkillSimulatorPureTest.kt
@@ -63,4 +63,21 @@ class SkillSimulatorPureTest {
             previous = ms
         }
     }
+
+    @Test
+    fun `sessionDurationMs applies chronosMultiplier correctly`() {
+        // Base 60 minutes = 3,600,000 ms
+        val baseMs = SkillSimulator.sessionDurationMs(1, 0, 1.0f)
+        assertEquals(3_600_000L, baseMs)
+
+        // Chronos Spire Tier 1 (-2% reduction -> 0.98 multiplier)
+        // 60 min * 0.98 = 58.8 min -> rounded to 59 min = 3,540,000 ms
+        val tier1Ms = SkillSimulator.sessionDurationMs(1, 0, 0.98f)
+        assertEquals(3_540_000L, tier1Ms)
+
+        // Chronos Spire Tier 3 (-6% reduction -> 0.94 multiplier)
+        // 60 min * 0.94 = 56.4 min -> rounded to 56 min = 3,360,000 ms
+        val tier3Ms = SkillSimulator.sessionDurationMs(1, 0, 0.94f)
+        assertEquals(3_360_000L, tier3Ms)
+    }
 }


### PR DESCRIPTION
## Before submitting

- [x] I've tested the final changes (with unit tests) to ensure the feature works
- [x] I have pulled and merged the latest changes from the repository

## Related discussion/issue(s)



## Summary

Adds the **Chronos Spire** town building for the Construction skill, expanding mid-to-endgame Construction progression (Levels 82, 92, and 99) with a passive speed bonus (session duration reduction) strictly for player skilling and combat sessions.

## Changelog

- Added `"chronos_spire"` town building definition to `buildings.json` requiring Construction level 82 (Tier 1: -2%), 92 (Tier 2: -4%), and 99 (Tier 3: -6%).
- Implemented `playerSessionSpeedReduction()` and `playerSessionDurationMultiplier()` bonus accessors in `TownRepository.kt`.
- Updated `SkillSimulator.sessionDurationMs()` and `QueuedSessionStarter.kt` to apply the speed multiplier exclusively to player sessions (worker session durations are left untouched).
- Added building upgrade card UI in `BuilderScreen.kt` and `TownBuildingUpgrade.kt`.
- Added localized string entries across all 13 supported locale `strings.xml` files.

## Additional work

None

## Anything else?

- Maintains set-and-forget progression rules without adding micromanagement or Room database schema migrations.