### PR TITLE
feat(ui): Display inventory quantity for arrow loadout picker options

### DIFF
--- a/app/src/main/kotlin/com/fantasyidler/ui/screen/LoadoutEditorSheet.kt
+++ b/app/src/main/kotlin/com/fantasyidler/ui/screen/LoadoutEditorSheet.kt
@@ -66,8 +66,14 @@ internal fun ArrowLoadoutPicker(
             onDismissRequest = { expanded = false },
         ) {
             arrowOptions.forEach { key ->
+                val label = if (key == null) {
+                    stringResource(R.string.combat_arrow_auto)
+                } else {
+                    val qty = inventory[key] ?: 0
+                    "${GameStrings.itemName(context, key)} ($qty)"
+                }
                 DropdownMenuItem(
-                    text    = { Text(if (key == null) stringResource(R.string.combat_arrow_auto) else GameStrings.itemName(context, key)) },
+                    text    = { Text(label) },
                     onClick = { onArrowSelected(key); expanded = false },
                 )
             }


### PR DESCRIPTION
## Before submitting

- [x] I've tested any changes with the appropriate tests (eg. Unit tests, validation scripts)
- [x] I've pulled and merged the latest changes from the repository

## Summary

Displays available inventory quantity next to each arrow option in the combat loadout picker dropdown menu (e.g. `Rune Arrow (120)`), matching the magic spell picker pattern.

## Related issue(s) or discussion(s)

N/A

## Changelog

- Added inventory quantity formatting to dropdown menu items in `ArrowLoadoutPicker` (`LoadoutEditorSheet.kt`).

## Anything else?

Keeps the closed `OutlinedTextField` string static to avoid frame-by-frame text recomposition during active combat runs.