### PR TITLE
fix(town): Apply Chronos Spire duration reduction to home queue endsAt countdown

### DIFF
--- a/app/src/main/kotlin/com/fantasyidler/ui/viewmodel/CraftingViewModel.kt
+++ b/app/src/main/kotlin/com/fantasyidler/ui/viewmodel/CraftingViewModel.kt
@@ -184,7 +184,7 @@ class CraftingViewModel @Inject constructor(
             val perItemMs = if (selectedRecipe != null) {
                 val agility = levels[Skills.AGILITY] ?: 1
                 val eff = craftToolEfficiency(selectedRecipe, equipped)
-                (SkillSimulator.sessionDurationMs(agility, flags.skillPrestige[Skills.AGILITY] ?: 0) / 60 / eff).toLong()
+                (SkillSimulator.sessionDurationMs(agility, flags.skillPrestige[Skills.AGILITY] ?: 0, townRepo.playerSessionDurationMultiplier(flags)) / 60 / eff).toLong()
             } else 0L
             extra.copy(
                 smithingLevel      = levels[Skills.SMITHING]      ?: 1,

--- a/app/src/main/kotlin/com/fantasyidler/ui/viewmodel/HomeViewModel.kt
+++ b/app/src/main/kotlin/com/fantasyidler/ui/viewmodel/HomeViewModel.kt
@@ -279,7 +279,8 @@ class HomeViewModel @Inject constructor(
             val equipped: Map<String, String?> = json.decodeFromString(player.equipped)
             val agilityLevel    = levels[Skills.AGILITY] ?: 1
             val agilityPrestige = flags.skillPrestige[Skills.AGILITY] ?: 0
-            val sessionMs       = SkillSimulator.sessionDurationMs(agilityLevel, agilityPrestige)
+            val chronosMult     = townRepo.playerSessionDurationMultiplier(flags)
+            val sessionMs       = SkillSimulator.sessionDurationMs(agilityLevel, agilityPrestige, chronosMult)
             val perItemMs    = sessionMs / 60
             val queueStart   = session?.takeIf { !it.completed }?.endsAt ?: System.currentTimeMillis()
             // Recomputed live from current agility/gear rather than the frozen value stored at

--- a/app/src/main/kotlin/com/fantasyidler/ui/viewmodel/SkillsViewModel.kt
+++ b/app/src/main/kotlin/com/fantasyidler/ui/viewmodel/SkillsViewModel.kt
@@ -783,13 +783,14 @@ class SkillsViewModel @Inject constructor(
                 val petBoostedXp = if (petBoostPct > 0) (rawXp * (1.0 + petBoostPct / 100.0)).toLong() else rawXp
                 val estimatedXpGain = (petBoostedXp * xpQueueMult).toLong()
                 val agilityPrestige = gatherFlags.skillPrestige[Skills.AGILITY] ?: 0
+                val chronosMult     = townRepo.playerSessionDurationMultiplier(gatherFlags)
                 val enqueued = playerRepo.enqueueAction(
                     QueuedAction(
                         skillName           = skillName,
                         activityKey         = activityKey,
                         skillDisplayName    = displayName,
                         estimatedXpGain     = estimatedXpGain,
-                        estimatedDurationMs = SkillSimulator.sessionDurationMs(agility, agilityPrestige),
+                        estimatedDurationMs = SkillSimulator.sessionDurationMs(agility, agilityPrestige, chronosMult),
                     )
                 )
                 if (enqueued) queuedSessionStarter.startNextQueued()


### PR DESCRIPTION
## Before submitting

- [x] I've tested any changes with the appropriate tests (eg. Unit tests, validation scripts)
- [x] I've pulled and merged the latest changes from the repository

## Summary

Fixes an issue where the Home screen Queue card countdown (`queueEndsAt`) and queue action estimates ignored the Chronos Spire duration multiplier, causing the queue completion time to display without the 2/4/6% session duration reduction.

## Related issue(s) or discussion(s)

Fixes #1285

## Changelog

- Passed `chronosMultiplier = townRepo.playerSessionDurationMultiplier(flags)` to `SkillSimulator.sessionDurationMs` when computing `queueEndsAt` in `HomeViewModel.kt`.
- Updated missing `chronosMultiplier` parameters in `CraftingViewModel.kt` and `SkillsViewModel.kt`.

## Anything else?

N/A