### PR TITLE
Fix OOM errors when queueing a very large amount of runes for the runecrafting skill

### DIFF
--- a/app/src/main/kotlin/com/fantasyidler/repository/QueuedSessionStarter.kt
+++ b/app/src/main/kotlin/com/fantasyidler/repository/QueuedSessionStarter.kt
@@ -420,26 +420,37 @@ class QueuedSessionStarter @Inject constructor(
                 val currentXp = xpMap[Skills.RUNECRAFTING] ?: 0L
                 val rcPetDropKey = petDropKey(Skills.RUNECRAFTING)
                 val rcPetDropChance = petDropChance(Skills.RUNECRAFTING)
+                val frameCount = minOf(qty, 60)
                 val frames = mutableListOf<SessionFrame>().also { list ->
                     var xp = currentXp
-                    for (i in 1..qty) {
-                        val before = XpTable.levelForXp(xp)
-                        val multiplier = when {
-                            before >= 75 -> 3
-                            before >= 50 -> 2
-                            else         -> 1
-                        } + ashBonus
-                        val gain = (runeData.xpPerRune * multiplier).toInt()
-                        xp += gain
+                    for (bucket in 0 until frameCount) {
+                        val itemsInBucket = ((bucket.toLong() + 1) * qty / frameCount - bucket.toLong() * qty / frameCount).toInt()
+                        val levelBefore = XpTable.levelForXp(xp)
+                        var bucketGain = 0
+                        var bucketRunes = 0
+                        repeat(itemsInBucket) {
+                            val level = XpTable.levelForXp(xp)
+                            val multiplier = when {
+                                level >= 75 -> 3
+                                level >= 50 -> 2
+                                else         -> 1
+                            } + ashBonus
+                            val gain = (runeData.xpPerRune * multiplier).toInt()
+                            xp += gain
+                            bucketGain += gain
+                            bucketRunes += multiplier
+                        }
+                        val levelAfter = XpTable.levelForXp(xp)
                         list.add(SessionFrame(
-                            minute      = i,
-                            xpGain      = gain,
-                            xpBefore    = xp - gain,
+                            minute      = bucket + 1,
+                            xpGain      = bucketGain,
+                            xpBefore    = xp - bucketGain,
                             xpAfter     = xp,
-                            levelBefore = before,
-                            levelAfter  = XpTable.levelForXp(xp),
-                            items       = mapOf(runeKey to multiplier),
-                            kills       = 1,
+                            levelBefore = levelBefore,
+                            levelAfter  = levelAfter,
+                            items       = mapOf(runeKey to bucketRunes),
+                            leveledUp   = levelAfter > levelBefore,
+                            kills       = itemsInBucket,
                         ))
                     }
                 }


### PR DESCRIPTION
## Before submitting

- [x] I've tested the changes by loading my save and the crash is gone
- [x] I've pulled and merged the latest changes from the repository

## Summary

Fix OutOfMemoryError when serializing very large queued sessions

Large queued crafting sessions can generate hundreds of thousands of SessionFrame objects. encodeFrames() serializes the entire list into a single JSON string, causing an OutOfMemoryError on Android (e.g. 620,000 queued runecrafting actions required a ~117 MB allocation).

This change limits the number of serialized frames by sampling evenly across the session, preserving the overall history while preventing excessive memory usage.

Queue something(I queued air runes for a quest)
Queue ~620,000 runecrafting actions.

Observe the crash in QueuedSessionStarter.encodeFrames() with OutOfMemoryError.



## Related issue(s) or discussion(s)

The issue was analyzed by AI and the fix was suggested by AI as well

The OOM crash is caused by the RUNECRAFTING implementation in   QueuedSessionStarter.kt, which creates one SessionFrame object for every single rune crafted. When a large quantity is queued (e.g., 620,000), this results in a massive array of frames that fails to serialize into a single JSON string, exhausting the app's memory.
I have fixed this by aggregating the Runecrafting progress into a maximum of 60 frames (one per "minute"), which is the standard used by all other skills in the app. This ensures that the resulting JSON string remains small and manageable, regardless of the quantity queued.
Changes made:
•
Modified   QueuedSessionStarter.kt:
◦
Updated the Skills.RUNECRAFTING block to use a bucket-based aggregation logic.
◦
It now calculates the total XP and items gained across all runes but distributes them into at most 60 SessionFrame objects.
◦
The dynamic XP multiplier (which increases at levels 50 and 75) is still correctly calculated rune-by-rune within each bucket to ensure progress accuracy.



## Anything else?
Please don't bash me for using AI. I don't really have the time to analyze a new project so I can understand its ins and outs so I can propose a proper implementation and AI is very convenient. If you decide this approach works feel free to approve and merge and if not just decline the PR, no issues on my side.
