### PR TITLE
feat(town): Allow Skill Capes and Guild Capes to stack additively on Cape Rack

### DIFF
--- a/app/src/main/kotlin/com/fantasyidler/repository/PlayerRepository.kt
+++ b/app/src/main/kotlin/com/fantasyidler/repository/PlayerRepository.kt
@@ -1295,40 +1295,44 @@ fun resolveCapeMultiplier(
         else -> rackTier >= 3
     }
 
-    val eligibleCapeBonuses = mutableListOf<Float>()
+    var bestSkillCapeBonus = 0f
+    var bestGuildCapeBonus = 0f
 
-    // Check equipped cape
-    val equippedCapeSkill = equippedCape?.capeSkill
-    if (equippedCapeSkill != null) {
-        val isMatch = equippedCapeSkill == normSkill || isGuildCapeForSkill(equippedCapeSkill, normSkill)
-        if (isMatch && equippedCape.capeBonus > 0f) {
-            eligibleCapeBonuses.add(equippedCape.capeBonus)
+    fun considerCape(capeDef: EquipmentData?) {
+        if (capeDef == null || capeDef.capeBonus <= 0f) return
+        val capeSkill = capeDef.capeSkill ?: return
+        val isMatch = capeSkill == normSkill || isGuildCapeForSkill(capeSkill, normSkill)
+        if (!isMatch) return
+
+        val isGuildCape = capeDef.name.endsWith("_guild_cape") || capeSkill in setOf("warriors", "archers", "mages")
+        if (isGuildCape) {
+            bestGuildCapeBonus = maxOf(bestGuildCapeBonus, capeDef.capeBonus)
+        } else {
+            bestSkillCapeBonus = maxOf(bestSkillCapeBonus, capeDef.capeBonus)
         }
     }
+
+    // Check equipped cape
+    considerCape(equippedCape)
 
     // Check passive capes in inventory
     if (isCategoryUnlocked) {
         val candidateKeys = resolveOwnedCapeKeysForSkill(normSkill)
         for (key in candidateKeys) {
             if (inventoryKeys.contains(key)) {
-                val capeDef = allEquipment[key]
-                if (capeDef != null && capeDef.capeBonus > 0f) {
-                    eligibleCapeBonuses.add(capeDef.capeBonus)
-                }
+                considerCape(allEquipment[key])
             }
         }
     }
 
-    if (eligibleCapeBonuses.isEmpty()) return 1.0f
-
-    val maxBonus = eligibleCapeBonuses.maxOrNull() ?: 0f
-    if (maxBonus <= 0f) return 1.0f
+    val totalBonus = bestSkillCapeBonus + bestGuildCapeBonus
+    if (totalBonus <= 0f) return 1.0f
 
     val prestigeLevel = skillPrestige[normSkill] ?: 0
     val isCombatSkill = normSkill in setOf("attack", "strength", "defense", "ranged", "magic", "hp", "slayer")
     return if (isCombatSkill) {
-        1.0f + maxBonus
+        1.0f + totalBonus
     } else {
-        1.0f + maxBonus * (prestigeLevel + 1)
+        1.0f + totalBonus * (prestigeLevel + 1)
     }
 }

--- a/app/src/main/kotlin/com/fantasyidler/ui/screen/BonusesTab.kt
+++ b/app/src/main/kotlin/com/fantasyidler/ui/screen/BonusesTab.kt
@@ -119,14 +119,32 @@ internal fun BonusesTab(
 
         val activeCapeName = run {
             if (capeMult <= 1.0f) return@run null
-            val equippedCapeSkill = cape?.capeSkill
-            if (equippedCapeSkill != null && (equippedCapeSkill == skillKey || isGuildCapeForSkill(equippedCapeSkill, skillKey))) {
-                return@run cape.displayName
+            val activeNames = mutableListOf<String>()
+            val rackTier = state.townBuildingTiers["cape_rack"] ?: 0
+            val isCategoryUnlocked = when {
+                skillKey in Skills.GATHERING -> rackTier >= 1
+                skillKey in Skills.CRAFTING_SKILLS -> rackTier >= 2
+                else -> rackTier >= 3
             }
             val candidateKeys = resolveOwnedCapeKeysForSkill(skillKey)
-            val bestCapeKey = candidateKeys.filter { state.inventory.containsKey(it) }
+            val availableKeys = mutableSetOf<String>()
+            if (isCategoryUnlocked) {
+                candidateKeys.filterTo(availableKeys) { state.inventory.containsKey(it) }
+            }
+            if (cape?.capeSkill != null) {
+                val capeSkill = cape.capeSkill!!
+                if (capeSkill == skillKey || isGuildCapeForSkill(capeSkill, skillKey)) {
+                    availableKeys.add(cape.name)
+                }
+            }
+            val skillCapeKey = availableKeys.filter { !it.endsWith("_guild_cape") && allEquipment[it]?.capeSkill !in setOf("warriors", "archers", "mages") }
                 .maxByOrNull { allEquipment[it]?.capeBonus ?: 0f }
-            bestCapeKey?.let { allEquipment[it]?.displayName }
+            val guildCapeKey = availableKeys.filter { it.endsWith("_guild_cape") || allEquipment[it]?.capeSkill in setOf("warriors", "archers", "mages") }
+                .maxByOrNull { allEquipment[it]?.capeBonus ?: 0f }
+
+            skillCapeKey?.let { allEquipment[it]?.displayName }?.let { activeNames.add(it) }
+            guildCapeKey?.let { allEquipment[it]?.displayName }?.let { activeNames.add(it) }
+            if (activeNames.isNotEmpty()) activeNames.distinct().joinToString(" + ") else null
         }
 
         val xpSources = buildList {


### PR DESCRIPTION
## Before submitting

- [x] I've tested any changes with the appropriate tests (eg. Unit tests, validation scripts)
- [x] I've pulled and merged the latest changes from the repository

## Summary

Allows Skill Capes (e.g. +10% bonus) and Guild Capes (e.g. +5% bonus) for the same skill to stack additively (yielding a combined +15% bonus) when unlocked on the Cape Rack or equipped.

Double-dipping duplicate capes of the same category (e.g. equipped Skill Cape + inventory Skill Cape) remains strictly prevented; `resolveCapeMultiplier` takes the highest single Skill Cape bonus and the highest single Guild Cape bonus for that skill.

## Related issue(s) or discussion(s)

Relates to #1287

## Changelog

- Updated `resolveCapeMultiplier` in `PlayerRepository.kt` to sum the best Skill Cape bonus + best Guild Cape bonus for each skill.
- Updated `activeCapeName` display in `BonusesTab.kt` to list both active capes (e.g. "Smithing Cape + Smithing Guild Cape") on the Profile > Bonuses screen when both are active.

## Anything else?

N/A