### PR TITLE
Develop custom theme feature allowing importing of custom themes

### DIFF
--- a/app/schemas/com.fantasyidler.data.db.AppDatabase/6.json
+++ b/app/schemas/com.fantasyidler.data.db.AppDatabase/6.json
@@ -1,0 +1,369 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 6,
+    "identityHash": "43949232e851b6ac97c8612209cf67a7",
+    "entities": [
+      {
+        "tableName": "players",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `skill_levels` TEXT NOT NULL, `skill_xp` TEXT NOT NULL, `inventory` TEXT NOT NULL, `equipped` TEXT NOT NULL, `flags` TEXT NOT NULL, `pets` TEXT NOT NULL, `coins` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "skillLevels",
+            "columnName": "skill_levels",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "skillXp",
+            "columnName": "skill_xp",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "inventory",
+            "columnName": "inventory",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "equipped",
+            "columnName": "equipped",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "flags",
+            "columnName": "flags",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "pets",
+            "columnName": "pets",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "coins",
+            "columnName": "coins",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "skill_sessions",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`session_id` TEXT NOT NULL, `user_id` INTEGER NOT NULL, `skill_name` TEXT NOT NULL, `started_at` INTEGER NOT NULL, `ends_at` INTEGER NOT NULL, `data` TEXT NOT NULL, `completed` INTEGER NOT NULL, `activity_key` TEXT NOT NULL, `is_worker_session` INTEGER NOT NULL DEFAULT 0, `efficiency_multiplier` REAL NOT NULL DEFAULT 1.0, `worker_slot` INTEGER NOT NULL DEFAULT 0, `catalyst_key` TEXT, `catalyst_qty` INTEGER NOT NULL DEFAULT 0, `level_at_start` INTEGER NOT NULL DEFAULT 0, PRIMARY KEY(`session_id`))",
+        "fields": [
+          {
+            "fieldPath": "sessionId",
+            "columnName": "session_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "playerId",
+            "columnName": "user_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "skillName",
+            "columnName": "skill_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "startedAt",
+            "columnName": "started_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "endsAt",
+            "columnName": "ends_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "frames",
+            "columnName": "data",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "completed",
+            "columnName": "completed",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "activityKey",
+            "columnName": "activity_key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isWorkerSession",
+            "columnName": "is_worker_session",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "efficiencyMultiplier",
+            "columnName": "efficiency_multiplier",
+            "affinity": "REAL",
+            "notNull": true,
+            "defaultValue": "1.0"
+          },
+          {
+            "fieldPath": "workerSlot",
+            "columnName": "worker_slot",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "catalystKey",
+            "columnName": "catalyst_key",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "catalystQty",
+            "columnName": "catalyst_qty",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "levelAtStart",
+            "columnName": "level_at_start",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "session_id"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "quest_progress",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`quest_id` TEXT NOT NULL, `progress` INTEGER NOT NULL, `completed` INTEGER NOT NULL, `completed_at` INTEGER, PRIMARY KEY(`quest_id`))",
+        "fields": [
+          {
+            "fieldPath": "questId",
+            "columnName": "quest_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "progress",
+            "columnName": "progress",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "completed",
+            "columnName": "completed",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "completedAt",
+            "columnName": "completed_at",
+            "affinity": "INTEGER",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "quest_id"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "farming_patches",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`patch_number` INTEGER NOT NULL, `crop_type` TEXT, `planted_at` INTEGER, PRIMARY KEY(`patch_number`))",
+        "fields": [
+          {
+            "fieldPath": "patchNumber",
+            "columnName": "patch_number",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cropType",
+            "columnName": "crop_type",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "plantedAt",
+            "columnName": "planted_at",
+            "affinity": "INTEGER",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "patch_number"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "global_state",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`key` TEXT NOT NULL, `value` TEXT NOT NULL, `updated_at` INTEGER NOT NULL, PRIMARY KEY(`key`))",
+        "fields": [
+          {
+            "fieldPath": "key",
+            "columnName": "key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "value",
+            "columnName": "value",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updated_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "key"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "arena_records",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `opponent_name` TEXT NOT NULL, `won` INTEGER NOT NULL, `combat_log` TEXT NOT NULL, `completed_at` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "opponentName",
+            "columnName": "opponent_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "won",
+            "columnName": "won",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "combatLog",
+            "columnName": "combat_log",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "completedAt",
+            "columnName": "completed_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "themes",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`name` TEXT NOT NULL, `display_name` TEXT NOT NULL, `base` TEXT NOT NULL, `colours` TEXT NOT NULL, `scheme` TEXT NOT NULL, PRIMARY KEY(`name`))",
+        "fields": [
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayName",
+            "columnName": "display_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "base",
+            "columnName": "base",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "colours",
+            "columnName": "colours",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "scheme",
+            "columnName": "scheme",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "name"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": []
+      }
+    ],
+    "views": [],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '43949232e851b6ac97c8612209cf67a7')"
+    ]
+  }
+}

--- a/app/src/main/assets/data/official_themes.json
+++ b/app/src/main/assets/data/official_themes.json
@@ -1,0 +1,108 @@
+{
+  "dark": {
+    "base": "dark",
+    "colours": {
+      "gold_primary": "0xFFC9A94D",
+      "gold_container": "0xFF3D2E00",
+      "gold_on_container": "0xFFFAD77B",
+      "brown_secondary": "0xFF8B5E3C",
+      "brown_container": "0xFF3E1F0A",
+      "brown_on_container": "0xFFD6A882",
+      "dark_background": "0xFF1A1A2E",
+      "dark_surface": "0xFF16213E",
+      "dark_surface_variant": "0xFF0F3460",
+      "parchment_text": "0xFFE8DCC8",
+      "parchment_text_muted": "0xFFA89880",
+      "error_red": "0xFFCF6679"
+    },
+    "colour_scheme": {
+      "primary": "gold_primary",
+      "on_primary": "dark_background",
+      "primary_container": "gold_container",
+      "on_primary_container": "gold_on_container",
+      "secondary": "brown_secondary",
+      "on_secondary": "parchment_text",
+      "secondary_container": "brown_container",
+      "on_secondary_container": "brown_on_container",
+      "background": "dark_background",
+      "on_background": "parchment_text",
+      "surface": "dark_surface",
+      "on_surface": "parchment_text",
+      "surface_variant": "dark_surface_variant",
+      "on_surface_variant": "parchment_text_muted",
+      "error": "error_red",
+      "on_error": "parchment_text"
+    }
+  },
+  "midnight": {
+    "base": "dark",
+    "colours": {
+      "gold_primary": "0xFFC9A94D",
+      "gold_container": "0xFF3D2E00",
+      "gold_on_container": "0xFFFAD77B",
+      "brown_secondary": "0xFF8B5E3C",
+      "brown_container": "0xFF3E1F0A",
+      "brown_on_container": "0xFFD6A882",
+      "midnight_background": "0xFF000000",
+      "midnight_surface": "0xFF111827",
+      "midnight_surface_variant": "0xFF24344D",
+      "parchment_text": "0xFFE8DCC8",
+      "midnight_text_muted": "0xFFC7BBA7",
+      "error_red": "0xFFCF6679"
+    },
+    "colour_scheme": {
+      "primary": "gold_primary",
+      "on_primary": "midnight_background",
+      "primary_container": "gold_container",
+      "on_primary_container": "gold_on_container",
+      "secondary": "brown_secondary",
+      "on_secondary": "parchment_text",
+      "secondary_container": "brown_container",
+      "on_secondary_container": "brown_on_container",
+      "background": "midnight_background",
+      "on_background": "parchment_text",
+      "surface": "midnight_surface",
+      "on_surface": "parchment_text",
+      "surface_variant": "midnight_surface_variant",
+      "on_surface_variant": "midnight_text_muted",
+      "error": "error_red",
+      "on_error": "parchment_text"
+    }
+  },
+  "light": {
+    "base": "light",
+    "colours": {
+      "gold_primary": "0xFFC9A94D",
+      "gold_container_light": "0xFFFFEFB0",
+      "gold_on_container_light": "0xFF2A1A00",
+      "brown_secondary": "0xFF8B5E3C",
+      "brown_container_light": "0xFFF5DEC4",
+      "brown_on_container_light": "0xFF2A1208",
+      "light_background": "0xFFF5EDD8",
+      "light_surface": "0xFFFAF4E6",
+      "light_surface_variant": "0xFFE5D5B0",
+      "dark_text": "0xFF1C1408",
+      "dark_text_muted": "0xFF4A3820",
+      "parchment_text": "0xFFE8DCC8",
+      "error_red": "0xFFCF6679"
+    },
+    "colour_scheme": {
+      "primary": "gold_primary",
+      "on_primary": "dark_text",
+      "primary_container": "gold_container_light",
+      "on_primary_container": "gold_on_container_light",
+      "secondary": "brown_secondary",
+      "on_secondary": "light_background",
+      "secondary_container": "brown_container_light",
+      "on_secondary_container": "brown_on_container_light",
+      "background": "light_background",
+      "on_background": "dark_text",
+      "surface": "light_surface",
+      "on_surface": "dark_text",
+      "surface_variant": "light_surface_variant",
+      "on_surface_variant": "dark_text_muted",
+      "error": "error_red",
+      "on_error": "parchment_text"
+    }
+  }
+}

--- a/app/src/main/kotlin/com/fantasyidler/MainActivity.kt
+++ b/app/src/main/kotlin/com/fantasyidler/MainActivity.kt
@@ -66,10 +66,10 @@ class MainActivity : AppCompatActivity() {
         enableEdgeToEdge()
         setContent {
             val settingsViewModel: SettingsViewModel = hiltViewModel()
-            val themePreference by settingsViewModel.themePreference.collectAsStateWithLifecycle()
-            val fontScale       by settingsViewModel.fontScale.collectAsStateWithLifecycle()
+            val colourScheme by settingsViewModel.colourScheme.collectAsStateWithLifecycle()
+            val fontScale    by settingsViewModel.fontScale.collectAsStateWithLifecycle()
             val baseDensity = LocalDensity.current
-            FantasyIdlerTheme(themePreference = themePreference) {
+            FantasyIdlerTheme(colorScheme = colourScheme) {
                 CompositionLocalProvider(
                     LocalDensity provides Density(baseDensity.density, fontScale),
                     LocalAppFontScale provides fontScale,

--- a/app/src/main/kotlin/com/fantasyidler/data/db/AppDatabase.kt
+++ b/app/src/main/kotlin/com/fantasyidler/data/db/AppDatabase.kt
@@ -34,6 +34,20 @@ val MIGRATION_4_5 = object : Migration(4, 5) {
     }
 }
 
+val MIGRATION_5_6 = object : Migration(5, 6) {
+    override fun migrate(db: SupportSQLiteDatabase) {
+        db.execSQL(
+            "CREATE TABLE IF NOT EXISTS `themes` (" +
+                "`name` TEXT NOT NULL, " +
+                "`display_name` TEXT NOT NULL, " +
+                "`base` TEXT NOT NULL, " +
+                "`colours` TEXT NOT NULL, " +
+                "`scheme` TEXT NOT NULL, " +
+                "PRIMARY KEY(`name`))"
+        )
+    }
+}
+
 @Database(
     entities = [
         Player::class,
@@ -42,8 +56,9 @@ val MIGRATION_4_5 = object : Migration(4, 5) {
         FarmingPatch::class,
         GlobalState::class,
         ArenaRecord::class,
+        CustomTheme::class,
     ],
-    version = 5,
+    version = 6,
     exportSchema = true,
 )
 abstract class AppDatabase : RoomDatabase() {
@@ -53,4 +68,5 @@ abstract class AppDatabase : RoomDatabase() {
     abstract fun farmingPatchDao(): FarmingPatchDao
     abstract fun globalStateDao(): GlobalStateDao
     abstract fun arenaRecordDao(): ArenaRecordDao
+    abstract fun customThemeDao(): CustomThemeDao
 }

--- a/app/src/main/kotlin/com/fantasyidler/data/db/dao/CustomThemeDao.kt
+++ b/app/src/main/kotlin/com/fantasyidler/data/db/dao/CustomThemeDao.kt
@@ -1,0 +1,29 @@
+package com.fantasyidler.data.db.dao
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import com.fantasyidler.data.model.CustomTheme
+import kotlinx.coroutines.flow.Flow
+
+@Dao
+interface CustomThemeDao {
+    @Query("SELECT * FROM themes WHERE name = :theme")
+    suspend fun getTheme(theme: String): CustomTheme?
+
+    @Query("SELECT * FROM themes")
+    suspend fun getAllThemes(): List<CustomTheme>
+
+    @Query("SELECT * FROM themes")
+    fun observeAllThemes(): Flow<List<CustomTheme>>
+
+    @Query("DELETE FROM themes WHERE name = :theme")
+    suspend fun delete(theme: String)
+
+    @Query("DELETE FROM themes")
+    suspend fun deleteAll()
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun upsert(customTheme: CustomTheme)
+}

--- a/app/src/main/kotlin/com/fantasyidler/data/json/ThemeData.kt
+++ b/app/src/main/kotlin/com/fantasyidler/data/json/ThemeData.kt
@@ -1,0 +1,55 @@
+package com.fantasyidler.data.json
+
+import com.fantasyidler.data.model.ThemeBase
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/** All adjustable colour roles on Material 3 [androidx.compose.material3.ColorScheme]. */
+@Serializable
+enum class ColourSchemeParameter {
+    @SerialName("primary") PRIMARY,
+    @SerialName("on_primary") ON_PRIMARY,
+    @SerialName("primary_container") PRIMARY_CONTAINER,
+    @SerialName("on_primary_container") ON_PRIMARY_CONTAINER,
+    @SerialName("inverse_primary") INVERSE_PRIMARY,
+    @SerialName("secondary") SECONDARY,
+    @SerialName("on_secondary") ON_SECONDARY,
+    @SerialName("secondary_container") SECONDARY_CONTAINER,
+    @SerialName("on_secondary_container") ON_SECONDARY_CONTAINER,
+    @SerialName("tertiary") TERTIARY,
+    @SerialName("on_tertiary") ON_TERTIARY,
+    @SerialName("tertiary_container") TERTIARY_CONTAINER,
+    @SerialName("on_tertiary_container") ON_TERTIARY_CONTAINER,
+    @SerialName("background") BACKGROUND,
+    @SerialName("on_background") ON_BACKGROUND,
+    @SerialName("surface") SURFACE,
+    @SerialName("on_surface") ON_SURFACE,
+    @SerialName("surface_variant") SURFACE_VARIANT,
+    @SerialName("on_surface_variant") ON_SURFACE_VARIANT,
+    @SerialName("surface_tint") SURFACE_TINT,
+    @SerialName("inverse_surface") INVERSE_SURFACE,
+    @SerialName("inverse_on_surface") INVERSE_ON_SURFACE,
+    @SerialName("error") ERROR,
+    @SerialName("on_error") ON_ERROR,
+    @SerialName("error_container") ERROR_CONTAINER,
+    @SerialName("on_error_container") ON_ERROR_CONTAINER,
+    @SerialName("outline") OUTLINE,
+    @SerialName("outline_variant") OUTLINE_VARIANT,
+    @SerialName("scrim") SCRIM,
+    @SerialName("surface_bright") SURFACE_BRIGHT,
+    @SerialName("surface_dim") SURFACE_DIM,
+    @SerialName("surface_container") SURFACE_CONTAINER,
+    @SerialName("surface_container_high") SURFACE_CONTAINER_HIGH,
+    @SerialName("surface_container_highest") SURFACE_CONTAINER_HIGHEST,
+    @SerialName("surface_container_low") SURFACE_CONTAINER_LOW,
+    @SerialName("surface_container_lowest") SURFACE_CONTAINER_LOWEST,
+}
+
+@Serializable
+data class ThemeData(
+    val base: ThemeBase,
+    @SerialName("display_name") val displayName: String = "",
+    /** Named palette entries; values are ARGB hex strings such as `"0xFFC9A94D"`. */
+    val colours: Map<String, String>,
+    @SerialName("colour_scheme") val schemes: Map<ColourSchemeParameter, String>,
+)

--- a/app/src/main/kotlin/com/fantasyidler/data/model/CustomTheme.kt
+++ b/app/src/main/kotlin/com/fantasyidler/data/model/CustomTheme.kt
@@ -1,0 +1,41 @@
+package com.fantasyidler.data.model
+
+import androidx.room.ColumnInfo
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+enum class ThemeBase {
+    @SerialName("light") LIGHT,
+    @SerialName("dark") DARK,
+}
+
+/**
+ * Theme entity for management of application themes.
+ *
+ * Complex fields are stored as JSON strings — identical to the IdleApes Python/SQLite schema.
+ * Use [com.fantasyidler.repository.ThemeRepository] to read and write typed domain objects
+ * rather than touching these raw columns directly.
+ */
+@Entity(tableName = "themes")
+data class CustomTheme(
+    @PrimaryKey
+    @ColumnInfo(name = "name")
+    val name: String = "",
+
+    @ColumnInfo(name = "display_name")
+    val displayName: String = "",
+
+    @ColumnInfo(name = "base")
+    val base: ThemeBase = ThemeBase.DARK,
+
+    /** JSON: Map<String, String> — colour name → ARGB hex (e.g. `"0xFFC9A94D"`). */
+    @ColumnInfo(name = "colours")
+    val colours: String = "{}",
+
+    /** JSON: Map<String, String> — [com.fantasyidler.data.json.ColourSchemeParameter] → colour name. */
+    @ColumnInfo(name = "scheme")
+    val scheme: String = "{}",
+)

--- a/app/src/main/kotlin/com/fantasyidler/di/DatabaseModule.kt
+++ b/app/src/main/kotlin/com/fantasyidler/di/DatabaseModule.kt
@@ -7,6 +7,7 @@ import com.fantasyidler.data.db.MIGRATION_1_2
 import com.fantasyidler.data.db.MIGRATION_2_3
 import com.fantasyidler.data.db.MIGRATION_3_4
 import com.fantasyidler.data.db.MIGRATION_4_5
+import com.fantasyidler.data.db.MIGRATION_5_6
 import com.fantasyidler.data.db.dao.*
 import dagger.Module
 import dagger.Provides
@@ -23,7 +24,7 @@ object DatabaseModule {
     @Singleton
     fun provideDatabase(@ApplicationContext context: Context): AppDatabase =
         Room.databaseBuilder(context, AppDatabase::class.java, "fantasy_idler.db")
-            .addMigrations(MIGRATION_1_2, MIGRATION_2_3, MIGRATION_3_4, MIGRATION_4_5)
+            .addMigrations(MIGRATION_1_2, MIGRATION_2_3, MIGRATION_3_4, MIGRATION_4_5, MIGRATION_5_6)
             .build()
 
     @Provides fun providePlayerDao(db: AppDatabase): PlayerDao = db.playerDao()
@@ -32,4 +33,5 @@ object DatabaseModule {
     @Provides fun provideFarmingPatchDao(db: AppDatabase): FarmingPatchDao = db.farmingPatchDao()
     @Provides fun provideGlobalStateDao(db: AppDatabase): GlobalStateDao = db.globalStateDao()
     @Provides fun provideArenaRecordDao(db: AppDatabase): ArenaRecordDao = db.arenaRecordDao()
+    @Provides fun provideCustomThemeDao(db: AppDatabase): CustomThemeDao = db.customThemeDao()
 }

--- a/app/src/main/kotlin/com/fantasyidler/repository/GameDataRepository.kt
+++ b/app/src/main/kotlin/com/fantasyidler/repository/GameDataRepository.kt
@@ -30,6 +30,7 @@ import com.fantasyidler.data.json.RuneData
 import com.fantasyidler.data.json.SkillData
 import com.fantasyidler.data.json.SmithingRecipe
 import com.fantasyidler.data.json.ConstructionRecipe
+import com.fantasyidler.data.json.ThemeData
 import com.fantasyidler.data.json.ThievingNpcData
 import com.fantasyidler.data.json.SpellData
 import com.fantasyidler.data.json.TownBuildingData
@@ -312,6 +313,12 @@ class GameDataRepository @Inject constructor(
             .filter { it.endsWith(".json") }
             .map { filename -> asset<TradeRouteData>("data/trade_routes/$filename") }
             .sortedBy { it.levelRequired }
+    }
+
+    // ------------------------------------------------------------------ official themes
+
+    val officialThemes: Map<String, ThemeData> by lazy {
+        asset("data/official_themes.json")
     }
 
     // ------------------------------------------------------------------ sell helpers

--- a/app/src/main/kotlin/com/fantasyidler/repository/ThemeRepository.kt
+++ b/app/src/main/kotlin/com/fantasyidler/repository/ThemeRepository.kt
@@ -1,0 +1,162 @@
+package com.fantasyidler.repository
+
+import android.content.Context
+import android.content.res.Configuration
+import androidx.compose.material3.ColorScheme
+import androidx.compose.material3.darkColorScheme
+import androidx.compose.material3.lightColorScheme
+import androidx.compose.ui.graphics.Color
+import com.fantasyidler.data.db.dao.CustomThemeDao
+import com.fantasyidler.data.json.ColourSchemeParameter
+import com.fantasyidler.data.json.ColourSchemeParameter.*
+import com.fantasyidler.data.json.ThemeData
+import com.fantasyidler.data.model.CustomTheme
+import com.fantasyidler.data.model.ThemeBase
+import com.fantasyidler.util.toTitleCase
+import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.flow.Flow
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class ThemeRepository @Inject constructor(
+    @ApplicationContext private val context: Context,
+    private val customThemeDao: CustomThemeDao,
+    private val gameData: GameDataRepository,
+    private val json: Json,
+) {
+    fun getOfficialThemes(): List<String> =
+        gameData.officialThemes.keys.toList() + listOf("system")
+
+    fun observeCustomThemes(): Flow<List<CustomTheme>> = customThemeDao.observeAllThemes()
+
+    /**
+     * Resolves [theme] to a Material 3 [ColorScheme], preferring official asset themes
+     * and falling back to a user-defined custom theme from the database.
+     *
+     * `"system"` follows the device night-mode setting and resolves to `"dark"` or `"light"`.
+     */
+    suspend fun getColourScheme(theme: String): ColorScheme {
+        val themeKey = if (theme == "system") systemThemeKey() else theme
+        gameData.officialThemes[themeKey]?.let { official ->
+            return buildColourScheme(official.base, official.colours, official.schemes)
+        }
+        val custom = customThemeDao.getTheme(themeKey)
+        if (custom != null) {
+            val colours = json.decodeFromString<Map<String, String>>(custom.colours)
+            val schemes = json.decodeFromString<Map<ColourSchemeParameter, String>>(custom.scheme)
+            return buildColourScheme(custom.base, colours, schemes)
+        }
+        // If the theme is not "dark", fall back to "dark"
+        if (themeKey != "dark") {
+            return getColourScheme("dark")
+        }
+        // If the dark theme is not available, use the default Material 3 dark theme
+        return darkColorScheme()
+    }
+
+    private fun systemThemeKey(): String {
+        val night = context.resources.configuration.uiMode and Configuration.UI_MODE_NIGHT_MASK
+        return if (night == Configuration.UI_MODE_NIGHT_YES) "dark" else "light"
+    }
+
+    /**
+     * Imports one or more themes from a JSON string in the same shape as
+     * `assets/data/official_themes.json` (`Map` of theme key → theme data).
+     * Existing custom themes with the same name are replaced.
+     * Names that clash with [getOfficialThemes] are rejected.
+     */
+    suspend fun importTheme(jsonString: String) {
+        val themes = json.decodeFromString<Map<String, ThemeData>>(jsonString)
+        require(themes.isNotEmpty()) { "Theme import contained no themes" }
+        val officialNames = getOfficialThemes().toSet()
+        val reserved = themes.keys.filter { it in officialNames }
+        require(reserved.isEmpty()) {
+            "Cannot import theme(s) that clash with official names: ${reserved.joinToString()}"
+        }
+        for ((name, data) in themes) {
+            customThemeDao.upsert(
+                CustomTheme(
+                    name = name,
+                    displayName = data.displayName.ifBlank { name.replace("_", " ").toTitleCase() },
+                    base = data.base,
+                    colours = json.encodeToString(data.colours),
+                    scheme = json.encodeToString(data.schemes),
+                )
+            )
+        }
+    }
+
+    /** Deletes a custom theme. Returns false if [name] is official or reserved. */
+    suspend fun deleteTheme(name: String): Boolean {
+        if (name in getOfficialThemes()) return false
+        customThemeDao.delete(name)
+        return true
+    }
+
+    private fun buildColourScheme(
+        base: ThemeBase,
+        colours: Map<String, String>,
+        schemes: Map<ColourSchemeParameter, String>,
+    ): ColorScheme {
+        fun resolve(param: ColourSchemeParameter): Color? {
+            val colourName = schemes[param] ?: return null
+            val raw = colours[colourName] ?: return null
+            return try { Color(parseArgb(raw)) } catch (_: Exception) { null }
+        }
+
+        val fallback = when (base) {
+            ThemeBase.LIGHT -> lightColorScheme()
+            ThemeBase.DARK -> darkColorScheme()
+        }
+
+        return fallback.copy(
+            primary = resolve(PRIMARY) ?: fallback.primary,
+            onPrimary = resolve(ON_PRIMARY) ?: fallback.onPrimary,
+            primaryContainer = resolve(PRIMARY_CONTAINER) ?: fallback.primaryContainer,
+            onPrimaryContainer = resolve(ON_PRIMARY_CONTAINER) ?: fallback.onPrimaryContainer,
+            inversePrimary = resolve(INVERSE_PRIMARY) ?: fallback.inversePrimary,
+            secondary = resolve(SECONDARY) ?: fallback.secondary,
+            onSecondary = resolve(ON_SECONDARY) ?: fallback.onSecondary,
+            secondaryContainer = resolve(SECONDARY_CONTAINER) ?: fallback.secondaryContainer,
+            onSecondaryContainer = resolve(ON_SECONDARY_CONTAINER) ?: fallback.onSecondaryContainer,
+            tertiary = resolve(TERTIARY) ?: fallback.tertiary,
+            onTertiary = resolve(ON_TERTIARY) ?: fallback.onTertiary,
+            tertiaryContainer = resolve(TERTIARY_CONTAINER) ?: fallback.tertiaryContainer,
+            onTertiaryContainer = resolve(ON_TERTIARY_CONTAINER) ?: fallback.onTertiaryContainer,
+            background = resolve(BACKGROUND) ?: fallback.background,
+            onBackground = resolve(ON_BACKGROUND) ?: fallback.onBackground,
+            surface = resolve(SURFACE) ?: fallback.surface,
+            onSurface = resolve(ON_SURFACE) ?: fallback.onSurface,
+            surfaceVariant = resolve(SURFACE_VARIANT) ?: fallback.surfaceVariant,
+            onSurfaceVariant = resolve(ON_SURFACE_VARIANT) ?: fallback.onSurfaceVariant,
+            surfaceTint = resolve(SURFACE_TINT) ?: fallback.surfaceTint,
+            inverseSurface = resolve(INVERSE_SURFACE) ?: fallback.inverseSurface,
+            inverseOnSurface = resolve(INVERSE_ON_SURFACE) ?: fallback.inverseOnSurface,
+            error = resolve(ERROR) ?: fallback.error,
+            onError = resolve(ON_ERROR) ?: fallback.onError,
+            errorContainer = resolve(ERROR_CONTAINER) ?: fallback.errorContainer,
+            onErrorContainer = resolve(ON_ERROR_CONTAINER) ?: fallback.onErrorContainer,
+            outline = resolve(OUTLINE) ?: fallback.outline,
+            outlineVariant = resolve(OUTLINE_VARIANT) ?: fallback.outlineVariant,
+            scrim = resolve(SCRIM) ?: fallback.scrim,
+            surfaceBright = resolve(SURFACE_BRIGHT) ?: fallback.surfaceBright,
+            surfaceDim = resolve(SURFACE_DIM) ?: fallback.surfaceDim,
+            surfaceContainer = resolve(SURFACE_CONTAINER) ?: fallback.surfaceContainer,
+            surfaceContainerHigh = resolve(SURFACE_CONTAINER_HIGH) ?: fallback.surfaceContainerHigh,
+            surfaceContainerHighest = resolve(SURFACE_CONTAINER_HIGHEST) ?: fallback.surfaceContainerHighest,
+            surfaceContainerLow = resolve(SURFACE_CONTAINER_LOW) ?: fallback.surfaceContainerLow,
+            surfaceContainerLowest = resolve(SURFACE_CONTAINER_LOWEST) ?: fallback.surfaceContainerLowest,
+        )
+    }
+
+    private fun parseArgb(raw: String): Long {
+        val cleaned = raw.trim()
+            .removePrefix("0x")
+            .removePrefix("0X")
+            .removePrefix("#")
+        return cleaned.toULong(16).toLong()
+    }
+}

--- a/app/src/main/kotlin/com/fantasyidler/ui/screen/ArmoryTab.kt
+++ b/app/src/main/kotlin/com/fantasyidler/ui/screen/ArmoryTab.kt
@@ -39,7 +39,6 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.fantasyidler.R
 import com.fantasyidler.data.json.EquipmentData
-import com.fantasyidler.ui.theme.GoldPrimary
 import com.fantasyidler.ui.viewmodel.ArmoryEntry
 import com.fantasyidler.ui.viewmodel.ArmoryFilter
 import com.fantasyidler.ui.viewmodel.ArmorySort
@@ -103,7 +102,7 @@ fun ArmoryTab(viewModel: ArmoryViewModel = hiltViewModel()) {
                     Text(
                         text     = groupName,
                         style    = MaterialTheme.typography.labelMedium,
-                        color    = GoldPrimary,
+                        color    = MaterialTheme.colorScheme.primary,
                         modifier = Modifier.padding(horizontal = 16.dp, vertical = 6.dp),
                     )
                     HorizontalDivider()
@@ -202,7 +201,7 @@ private fun ArmoryDetailContent(entry: ArmoryEntry) {
             Text(
                 text  = slotLabel(item.slot),
                 style = MaterialTheme.typography.labelMedium,
-                color = GoldPrimary,
+                color = MaterialTheme.colorScheme.primary,
             )
             Spacer(Modifier.height(16.dp))
         }
@@ -304,7 +303,7 @@ private fun ArmorySectionHeader(text: String) {
         text       = text,
         style      = MaterialTheme.typography.labelMedium,
         fontWeight = FontWeight.SemiBold,
-        color      = GoldPrimary,
+        color      = MaterialTheme.colorScheme.primary,
     )
 }
 
@@ -420,14 +419,14 @@ private fun CollectionProgressBar(obtained: Int, total: Int, label: String) {
                 text  = "$pct%",
                 style = MaterialTheme.typography.labelSmall,
                 fontWeight = FontWeight.SemiBold,
-                color = GoldPrimary,
+                color = MaterialTheme.colorScheme.primary,
             )
         }
         Spacer(Modifier.height(4.dp))
         LinearProgressIndicator(
             progress = { fraction },
             modifier = Modifier.fillMaxWidth(),
-            color    = GoldPrimary,
+            color    = MaterialTheme.colorScheme.primary,
             trackColor = MaterialTheme.colorScheme.surfaceVariant,
         )
     }

--- a/app/src/main/kotlin/com/fantasyidler/ui/screen/BestiaryTab.kt
+++ b/app/src/main/kotlin/com/fantasyidler/ui/screen/BestiaryTab.kt
@@ -42,7 +42,6 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import com.fantasyidler.R
 import com.fantasyidler.data.json.BossData
 import com.fantasyidler.data.json.EnemyData
-import com.fantasyidler.ui.theme.GoldPrimary
 import com.fantasyidler.ui.viewmodel.BestiaryEntry
 import com.fantasyidler.ui.viewmodel.BestiarySort
 import com.fantasyidler.ui.viewmodel.BestiaryViewModel
@@ -141,7 +140,7 @@ private fun BestiaryList(
                     Text(
                         text     = groupName,
                         style    = MaterialTheme.typography.labelMedium,
-                        color    = GoldPrimary,
+                        color    = MaterialTheme.colorScheme.primary,
                         modifier = Modifier.padding(horizontal = 16.dp, vertical = 6.dp),
                     )
                     HorizontalDivider()
@@ -211,7 +210,7 @@ private fun BestiaryRow(entry: BestiaryEntry, onClick: () -> Unit) {
             Text(
                 text  = "${entry.killCount} kills",
                 style = MaterialTheme.typography.labelSmall,
-                color = GoldPrimary,
+                color = MaterialTheme.colorScheme.primary,
             )
         }
     }
@@ -247,7 +246,7 @@ private fun EnemyDetailContent(
                     Text(
                         text  = "${entry.killCount} kills",
                         style = MaterialTheme.typography.labelMedium,
-                        color = GoldPrimary,
+                        color = MaterialTheme.colorScheme.primary,
                     )
                 }
             }
@@ -354,7 +353,7 @@ private fun BossDetailContent(
                     Text(
                         text  = "${entry.killCount} kills",
                         style = MaterialTheme.typography.labelMedium,
-                        color = GoldPrimary,
+                        color = MaterialTheme.colorScheme.primary,
                     )
                 }
             }
@@ -507,13 +506,13 @@ private fun BestiaryDropTable(rows: List<Triple<String, String, String?>>) {
                 text     = stringResource(R.string.bestiary_loot_item_header),
                 modifier = Modifier.weight(1f),
                 style    = MaterialTheme.typography.labelSmall,
-                color    = GoldPrimary,
+                color    = MaterialTheme.colorScheme.primary,
             )
             Text(
                 text      = "Qty",
                 modifier  = Modifier.width(80.dp),
                 style     = MaterialTheme.typography.labelSmall,
-                color     = GoldPrimary,
+                color     = MaterialTheme.colorScheme.primary,
                 textAlign = TextAlign.End,
             )
             if (hasChance) {
@@ -521,7 +520,7 @@ private fun BestiaryDropTable(rows: List<Triple<String, String, String?>>) {
                     text      = "Chance",
                     modifier  = Modifier.width(52.dp),
                     style     = MaterialTheme.typography.labelSmall,
-                    color     = GoldPrimary,
+                    color     = MaterialTheme.colorScheme.primary,
                     textAlign = TextAlign.End,
                 )
             }
@@ -558,7 +557,7 @@ private fun BestiaryDropTable(rows: List<Triple<String, String, String?>>) {
                         text      = chance ?: "",
                         modifier  = Modifier.width(52.dp),
                         style     = MaterialTheme.typography.bodySmall,
-                        color     = if (chance != null) GoldPrimary else MaterialTheme.colorScheme.onSurfaceVariant,
+                        color     = if (chance != null) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onSurfaceVariant,
                         textAlign = TextAlign.End,
                     )
                 }
@@ -600,14 +599,14 @@ private fun BestiaryProgressBar(encountered: Int, total: Int) {
                 text       = "$pct%",
                 style      = MaterialTheme.typography.labelSmall,
                 fontWeight = FontWeight.SemiBold,
-                color      = GoldPrimary,
+                color      = MaterialTheme.colorScheme.primary,
             )
         }
         Spacer(Modifier.height(4.dp))
         LinearProgressIndicator(
             progress  = { fraction },
             modifier  = Modifier.fillMaxWidth(),
-            color     = GoldPrimary,
+            color     = MaterialTheme.colorScheme.primary,
             trackColor = MaterialTheme.colorScheme.surfaceVariant,
         )
     }
@@ -623,7 +622,7 @@ private fun BestiarySectionHeader(text: String) {
         text       = text,
         style      = MaterialTheme.typography.labelMedium,
         fontWeight = FontWeight.SemiBold,
-        color      = GoldPrimary,
+        color      = MaterialTheme.colorScheme.primary,
     )
 }
 

--- a/app/src/main/kotlin/com/fantasyidler/ui/screen/BoneAltarScreen.kt
+++ b/app/src/main/kotlin/com/fantasyidler/ui/screen/BoneAltarScreen.kt
@@ -45,7 +45,6 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.fantasyidler.R
-import com.fantasyidler.ui.theme.GoldPrimary
 import com.fantasyidler.ui.viewmodel.BoneAltarUiState
 import com.fantasyidler.ui.viewmodel.BoneAltarViewModel
 import com.fantasyidler.util.GameStrings
@@ -146,7 +145,7 @@ private fun BoneSelectionContent(
                         Text(
                             text  = stringResource(R.string.btn_select),
                             style = MaterialTheme.typography.labelMedium,
-                            color = GoldPrimary,
+                            color = MaterialTheme.colorScheme.primary,
                         )
                     }
                     HorizontalDivider(modifier = Modifier.padding(horizontal = 16.dp))
@@ -168,7 +167,7 @@ private fun BoneTapContent(
     val bone        = state.availableBones[boneKey] ?: return
     val boneName    = GameStrings.itemName(context, boneKey)
     val comboActive = state.combo >= BoneAltarViewModel.COMBO_THRESHOLD
-    val comboColor  = if (comboActive) GoldPrimary else MaterialTheme.colorScheme.onSurfaceVariant
+    val comboColor  = if (comboActive) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onSurfaceVariant
     val qty         = state.inventory[boneKey] ?: 0
 
     Column(modifier = modifier.fillMaxSize()) {
@@ -200,7 +199,7 @@ private fun BoneTapContent(
             Text(
                 text       = stringResource(R.string.bone_altar_session_xp, state.sessionXp.formatXp()),
                 style      = MaterialTheme.typography.bodyMedium,
-                color      = GoldPrimary,
+                color      = MaterialTheme.colorScheme.primary,
                 fontWeight = FontWeight.SemiBold,
                 modifier   = Modifier.weight(1f),
             )
@@ -229,7 +228,7 @@ private fun BoneTapContent(
                     Text(
                         text  = stringResource(R.string.bone_altar_bonus_active),
                         style = MaterialTheme.typography.labelMedium,
-                        color = GoldPrimary,
+                        color = MaterialTheme.colorScheme.primary,
                     )
                 }
             }

--- a/app/src/main/kotlin/com/fantasyidler/ui/screen/BonusesTab.kt
+++ b/app/src/main/kotlin/com/fantasyidler/ui/screen/BonusesTab.kt
@@ -27,7 +27,6 @@ import com.fantasyidler.data.json.PetData
 import com.fantasyidler.data.model.EquipSlot
 import com.fantasyidler.data.model.Skills
 import com.fantasyidler.simulator.SkillSimulator
-import com.fantasyidler.ui.theme.GoldPrimary
 import com.fantasyidler.ui.viewmodel.InventoryViewModel
 import com.fantasyidler.repository.resolveCapeMultiplier
 import com.fantasyidler.repository.isGuildCapeForSkill
@@ -367,7 +366,7 @@ private fun BonusRow(
         Text(
             text  = pct,
             style = MaterialTheme.typography.labelLarge,
-            color = GoldPrimary,
+            color = MaterialTheme.colorScheme.primary,
         )
         Spacer(Modifier.width(8.dp))
         Text(

--- a/app/src/main/kotlin/com/fantasyidler/ui/screen/BossInfoSheet.kt
+++ b/app/src/main/kotlin/com/fantasyidler/ui/screen/BossInfoSheet.kt
@@ -91,8 +91,6 @@ import com.fantasyidler.data.model.EquipSlot
 import com.fantasyidler.data.model.SessionFrame
 import com.fantasyidler.data.model.SkillSession
 import com.fantasyidler.data.model.Skills
-import com.fantasyidler.ui.theme.GoldPrimary
-import com.fantasyidler.ui.theme.SuccessGreen
 import com.fantasyidler.ui.viewmodel.CombatViewModel
 import com.fantasyidler.ui.viewmodel.CombatViewModel.Companion.MAX_BOSS_REPEAT_COUNT
 import com.fantasyidler.ui.viewmodel.InventoryViewModel
@@ -177,7 +175,7 @@ internal fun BossInfoSheet(
                 text       = boss.combatLevelRequired.toString(),
                 style      = MaterialTheme.typography.bodySmall,
                 fontWeight = FontWeight.SemiBold,
-                color      = if (canFight) GoldPrimary else MaterialTheme.colorScheme.error,
+                color      = if (canFight) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.error,
             )
         }
         Row(
@@ -198,7 +196,7 @@ internal fun BossInfoSheet(
             Text(stringResource(R.string.combat_duration_min, boss.durationMinutes), style = MaterialTheme.typography.bodySmall,
                 fontWeight = FontWeight.SemiBold)
         }
-        StatRow(label = stringResource(R.string.label_combat_style), value = styleLabel, valueColor = GoldPrimary)
+        StatRow(label = stringResource(R.string.label_combat_style), value = styleLabel, valueColor = MaterialTheme.colorScheme.primary)
 
         // Weapon picker
         if (equippedWeapons.isNotEmpty()) {
@@ -261,7 +259,7 @@ internal fun BossInfoSheet(
                     Text(GameStrings.skillName(context, skill),
                         style = MaterialTheme.typography.bodySmall)
                     Text("+$xp ${stringResource(R.string.label_xp)}", style = MaterialTheme.typography.bodySmall,
-                        color = GoldPrimary, fontWeight = FontWeight.SemiBold)
+                        color = MaterialTheme.colorScheme.primary, fontWeight = FontWeight.SemiBold)
                 }
             }
         }

--- a/app/src/main/kotlin/com/fantasyidler/ui/screen/CarnivalScreen.kt
+++ b/app/src/main/kotlin/com/fantasyidler/ui/screen/CarnivalScreen.kt
@@ -68,7 +68,6 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import com.fantasyidler.R
 import com.fantasyidler.data.json.CarnivalPrize
 import com.fantasyidler.data.model.Skills
-import com.fantasyidler.ui.theme.GoldPrimary
 import com.fantasyidler.ui.viewmodel.ActiveGameState
 import com.fantasyidler.ui.viewmodel.AppraisalQuad
 import com.fantasyidler.ui.viewmodel.CarnivalViewModel
@@ -138,7 +137,7 @@ fun CarnivalScreen(
                         Text(
                             text  = stringResource(R.string.carnival_ticket_balance, state.ticketBalance),
                             style = MaterialTheme.typography.bodySmall,
-                            color = GoldPrimary,
+                            color = MaterialTheme.colorScheme.primary,
                         )
                     }
                 },
@@ -264,7 +263,7 @@ private fun IdleGamesTab(
                             Text(
                                 text  = stringResource(R.string.carnival_skill_level, GameStrings.skillName(context, game.skillKey), skillLevel),
                                 style = MaterialTheme.typography.bodySmall,
-                                color = GoldPrimary,
+                                color = MaterialTheme.colorScheme.primary,
                             )
                             Text(
                                 text  = stringResource(R.string.carnival_ticket_yield, myTickets),
@@ -422,7 +421,7 @@ private fun RingTossCard(gameState: ActiveGameState, difficulty: Difficulty, vie
                     stringResource(R.string.carnival_ring_hard_hint)
                 else
                     stringResource(R.string.carnival_ring_target_hint)
-                Text(hint, style = MaterialTheme.typography.bodySmall, color = GoldPrimary)
+                Text(hint, style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.primary)
                 Button(onClick = viewModel::startRingToss, modifier = Modifier.fillMaxWidth()) {
                     Text(stringResource(R.string.carnival_play))
                 }
@@ -457,7 +456,7 @@ private fun RingTossCard(gameState: ActiveGameState, difficulty: Difficulty, vie
                                 .align(Alignment.CenterStart)
                                 .padding(start = maxWidth * targetStart)
                                 .height(24.dp)
-                                .background(GoldPrimary.copy(alpha = 0.3f), RoundedCornerShape(4.dp))
+                                .background(MaterialTheme.colorScheme.primary.copy(alpha = 0.3f), RoundedCornerShape(4.dp))
                         )
                     }
                     Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.Center) {
@@ -465,7 +464,7 @@ private fun RingTossCard(gameState: ActiveGameState, difficulty: Difficulty, vie
                             stringResource(R.string.carnival_ring_hard_hint)
                         else
                             stringResource(R.string.carnival_ring_target_hint)
-                        Text(hint, style = MaterialTheme.typography.bodySmall, color = GoldPrimary)
+                        Text(hint, style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.primary)
                     }
                     Button(
                         onClick  = { haptic.performHapticFeedback(HapticFeedbackType.LongPress); viewModel.submitRingToss(position) },
@@ -520,14 +519,14 @@ private fun HammerStrikeCard(gameState: ActiveGameState, difficulty: Difficulty,
                         modifier   = Modifier.fillMaxWidth().height(28.dp).clip(RoundedCornerShape(4.dp)),
                         color      = when {
                             power >= perfectThreshold -> Color(0xFFF44336)
-                            power >= goodThreshold    -> GoldPrimary
+                            power >= goodThreshold    -> MaterialTheme.colorScheme.primary
                             else                      -> MaterialTheme.colorScheme.primary
                         },
                         trackColor = MaterialTheme.colorScheme.surfaceVariant,
                     )
                     Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceEvenly) {
                         Text(stringResource(R.string.carnival_hammer_miss_zone), style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
-                        Text(stringResource(R.string.carnival_hammer_good_zone), style = MaterialTheme.typography.bodySmall, color = GoldPrimary)
+                        Text(stringResource(R.string.carnival_hammer_good_zone), style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.primary)
                         Text(stringResource(R.string.carnival_hammer_perfect_zone), style = MaterialTheme.typography.bodySmall, color = Color(0xFFF44336))
                     }
                     Button(
@@ -761,7 +760,7 @@ private fun ShellGameCard(gameState: ActiveGameState, difficulty: Difficulty, vi
                         (0 until cupCount).forEach { i ->
                             Surface(
                                 shape  = RoundedCornerShape(8.dp),
-                                color  = if (i == gemPos) GoldPrimary else MaterialTheme.colorScheme.surface,
+                                color  = if (i == gemPos) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.surface,
                                 modifier = Modifier.size(56.dp),
                             ) {
                                 Box(contentAlignment = Alignment.Center) {
@@ -896,7 +895,7 @@ private fun HigherOrLowerCard(gameState: ActiveGameState, difficulty: Difficulty
                         text       = stringResource(R.string.carnival_higher_lower_current, current),
                         style      = MaterialTheme.typography.headlineMedium,
                         fontWeight = FontWeight.Bold,
-                        color      = GoldPrimary,
+                        color      = MaterialTheme.colorScheme.primary,
                     )
                     Text(
                         text  = stringResource(R.string.carnival_higher_lower_round, gameState.currentIdx + 1, totalRounds),
@@ -929,7 +928,7 @@ private fun HigherOrLowerCard(gameState: ActiveGameState, difficulty: Difficulty
                         text  = stringResource(R.string.carnival_higher_lower_last_card, gameState.lastNumber),
                         style = MaterialTheme.typography.headlineMedium,
                         fontWeight = FontWeight.Bold,
-                        color = GoldPrimary,
+                        color = MaterialTheme.colorScheme.primary,
                     )
                     Text(
                         text  = stringResource(R.string.carnival_higher_lower_result, gameState.totalCorrect, gameState.totalRounds, gameState.tickets),
@@ -1011,7 +1010,7 @@ private fun PrizeRow(
                     Text(
                         text  = statParts.joinToString("  "),
                         style = MaterialTheme.typography.bodySmall,
-                        color = GoldPrimary,
+                        color = MaterialTheme.colorScheme.primary,
                     )
                 }
                 val reqs = equipData.requirements
@@ -1037,7 +1036,7 @@ private fun PrizeRow(
             Text(
                 text       = stringResource(R.string.carnival_ticket_cost, prize.ticketCost),
                 style      = MaterialTheme.typography.bodyMedium,
-                color      = GoldPrimary,
+                color      = MaterialTheme.colorScheme.primary,
                 fontWeight = FontWeight.SemiBold,
             )
             Spacer(Modifier.height(4.dp))
@@ -1092,7 +1091,7 @@ private fun LampSkillPickerDialog(
                             Text(
                                 text  = stringResource(R.string.slayer_level_label, level),
                                 style = MaterialTheme.typography.bodySmall,
-                                color = GoldPrimary,
+                                color = MaterialTheme.colorScheme.primary,
                             )
                         }
                     }

--- a/app/src/main/kotlin/com/fantasyidler/ui/screen/CharacterSetupSheet.kt
+++ b/app/src/main/kotlin/com/fantasyidler/ui/screen/CharacterSetupSheet.kt
@@ -35,7 +35,6 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import com.fantasyidler.R
-import com.fantasyidler.ui.theme.GoldPrimary
 import com.fantasyidler.ui.theme.ScaledSheetContent
 
 internal val CHARACTER_GENDERS = listOf("Male", "Female", "Other")
@@ -181,7 +180,7 @@ fun CharacterSetupSheet(
                                     Text(
                                         text       = stringResource(R.string.character_title_none),
                                         fontWeight = if (equippedTitleId == null) FontWeight.SemiBold else FontWeight.Normal,
-                                        color      = if (equippedTitleId == null) GoldPrimary else MaterialTheme.colorScheme.onSurface,
+                                        color      = if (equippedTitleId == null) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onSurface,
                                     )
                                 },
                                 onClick = {
@@ -198,7 +197,7 @@ fun CharacterSetupSheet(
                                                 fontWeight = if (option.id == equippedTitleId) FontWeight.SemiBold else FontWeight.Normal,
                                                 color      = when {
                                                     !option.unlocked            -> MaterialTheme.colorScheme.onSurfaceVariant
-                                                    option.id == equippedTitleId -> GoldPrimary
+                                                    option.id == equippedTitleId -> MaterialTheme.colorScheme.primary
                                                     else                         -> MaterialTheme.colorScheme.onSurface
                                                 },
                                             )

--- a/app/src/main/kotlin/com/fantasyidler/ui/screen/ChurchScreen.kt
+++ b/app/src/main/kotlin/com/fantasyidler/ui/screen/ChurchScreen.kt
@@ -46,7 +46,6 @@ import com.fantasyidler.R
 import com.fantasyidler.data.json.BlessingData
 import com.fantasyidler.data.json.BlessingType
 import com.fantasyidler.repository.ChurchRepository
-import com.fantasyidler.ui.theme.GoldPrimary
 import com.fantasyidler.ui.viewmodel.ChurchViewModel
 import com.fantasyidler.util.formatDurationMs
 import kotlin.math.roundToInt
@@ -238,7 +237,7 @@ private fun ActiveBlessingBanner(
                 text       = name,
                 style      = MaterialTheme.typography.titleMedium,
                 fontWeight = FontWeight.Bold,
-                color      = GoldPrimary,
+                color      = MaterialTheme.colorScheme.primary,
             )
             Text(
                 text  = effectText,

--- a/app/src/main/kotlin/com/fantasyidler/ui/screen/CombatScreen.kt
+++ b/app/src/main/kotlin/com/fantasyidler/ui/screen/CombatScreen.kt
@@ -92,7 +92,6 @@ import com.fantasyidler.data.model.EquipSlot
 import com.fantasyidler.data.model.SessionFrame
 import com.fantasyidler.data.model.SkillSession
 import com.fantasyidler.data.model.Skills
-import com.fantasyidler.ui.theme.GoldPrimary
 import com.fantasyidler.ui.theme.ScaledSheetContent
 import com.fantasyidler.ui.theme.SuccessGreen
 import com.fantasyidler.ui.viewmodel.CombatViewModel
@@ -155,7 +154,7 @@ fun CombatScreen(
                             text       = "${stringResource(R.string.combat_level_label)} ${combatLevelFrom(state.skillLevels)}",
                             style      = MaterialTheme.typography.labelLarge,
                             fontWeight = FontWeight.Bold,
-                            color      = GoldPrimary,
+                            color      = MaterialTheme.colorScheme.primary,
                             modifier   = Modifier.padding(end = 16.dp),
                         )
                     }
@@ -826,7 +825,7 @@ private fun CombatSkillRow(
                         Text(
                             text  = stringResource(R.string.combat_prestige_bonus, prestigeLevel * 5),
                             style = MaterialTheme.typography.labelSmall,
-                            color = GoldPrimary,
+                            color = MaterialTheme.colorScheme.primary,
                         )
                     }
                 }
@@ -843,7 +842,7 @@ private fun CombatSkillRow(
                     .fillMaxWidth()
                     .height(4.dp)
                     .clip(RoundedCornerShape(2.dp)),
-                color            = GoldPrimary,
+                color            = MaterialTheme.colorScheme.primary,
                 trackColor       = MaterialTheme.colorScheme.surfaceVariant,
             )
         }
@@ -861,7 +860,7 @@ private fun CombatSkillRow(
                 Text(
                     text  = "★".repeat(prestigeLevel) + "☆".repeat((3 - prestigeLevel).coerceAtLeast(0)),
                     style = MaterialTheme.typography.labelMedium,
-                    color = GoldPrimary,
+                    color = MaterialTheme.colorScheme.primary,
                 )
                 when {
                     onPrestige != null && level >= 99 && prestigeLevel < 3 -> {
@@ -869,7 +868,7 @@ private fun CombatSkillRow(
                             Text(
                                 text  = stringResource(R.string.prestige),
                                 style = MaterialTheme.typography.labelSmall,
-                                color = GoldPrimary,
+                                color = MaterialTheme.colorScheme.primary,
                             )
                         }
                     }
@@ -951,7 +950,7 @@ private fun BossRow(
             text       = "Lv. ${boss.combatLevelRequired}",
             style      = MaterialTheme.typography.labelMedium,
             fontWeight = FontWeight.SemiBold,
-            color      = if (unlocked) GoldPrimary else dimColor,
+            color      = if (unlocked) MaterialTheme.colorScheme.primary else dimColor,
         )
     }
     HorizontalDivider(modifier = Modifier.padding(horizontal = 16.dp))
@@ -996,7 +995,7 @@ private fun TowerEntryRow(
                 text       = stringResource(R.string.tower_best_floor, bestFloor),
                 style      = MaterialTheme.typography.labelMedium,
                 fontWeight = FontWeight.SemiBold,
-                color      = GoldPrimary,
+                color      = MaterialTheme.colorScheme.primary,
             )
         }
     }
@@ -1082,7 +1081,7 @@ private fun DungeonRow(
         Text(
             text  = "Lv. ${dungeon.recommendedLevel}",
             style = MaterialTheme.typography.labelMedium,
-            color = if (unlocked) GoldPrimary else dimColor,
+            color = if (unlocked) MaterialTheme.colorScheme.primary else dimColor,
             fontWeight = FontWeight.SemiBold,
         )
     }

--- a/app/src/main/kotlin/com/fantasyidler/ui/screen/CombatSessionBanner.kt
+++ b/app/src/main/kotlin/com/fantasyidler/ui/screen/CombatSessionBanner.kt
@@ -81,8 +81,6 @@ import com.fantasyidler.data.model.EquipSlot
 import com.fantasyidler.data.model.SessionFrame
 import com.fantasyidler.data.model.SkillSession
 import com.fantasyidler.data.model.Skills
-import com.fantasyidler.ui.theme.GoldPrimary
-import com.fantasyidler.ui.theme.SuccessGreen
 import com.fantasyidler.ui.viewmodel.CombatViewModel
 import com.fantasyidler.ui.viewmodel.InventoryViewModel
 import com.fantasyidler.ui.viewmodel.combatLevelFrom
@@ -240,7 +238,7 @@ internal fun CombatSessionBanner(
                     else stringResource(R.string.label_session_in_progress),
             style = MaterialTheme.typography.headlineSmall,
             fontWeight = FontWeight.Bold,
-            color = if (isDone) GoldPrimary else MaterialTheme.colorScheme.onSurface,
+            color = if (isDone) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onSurface,
         )
         Spacer(Modifier.height(8.dp))
         Text(
@@ -255,7 +253,7 @@ internal fun CombatSessionBanner(
                              else stringResource(R.string.combat_run_progress, repeatIndex.coerceAtLeast(1), repeatTotal),
                 style      = MaterialTheme.typography.labelLarge,
                 fontWeight = FontWeight.SemiBold,
-                color      = GoldPrimary,
+                color      = MaterialTheme.colorScheme.primary,
             )
         }
         Spacer(Modifier.height(16.dp))
@@ -551,7 +549,7 @@ internal fun CombatSessionBanner(
                                         Text(
                                             text  = stringResource(R.string.combat_log_kill, entry.enemyName),
                                             style = MaterialTheme.typography.bodySmall,
-                                            color = GoldPrimary,
+                                            color = MaterialTheme.colorScheme.primary,
                                         )
                                     } else if (entry.isPlayer) {
                                         val color = if (entry.damage > 0) Color(0xFF4CAF50)

--- a/app/src/main/kotlin/com/fantasyidler/ui/screen/CraftingScreen.kt
+++ b/app/src/main/kotlin/com/fantasyidler/ui/screen/CraftingScreen.kt
@@ -66,7 +66,6 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import com.fantasyidler.R
 import com.fantasyidler.data.model.Skills
 import com.fantasyidler.simulator.XpTable
-import com.fantasyidler.ui.theme.GoldPrimary
 import com.fantasyidler.ui.viewmodel.CraftableRecipe
 import com.fantasyidler.ui.viewmodel.CraftingUiState
 import com.fantasyidler.ui.viewmodel.CraftingViewModel
@@ -270,7 +269,7 @@ private fun RecipeRow(
                     Text(
                         text  = "×$canMake",
                         style = MaterialTheme.typography.labelMedium,
-                        color = GoldPrimary,
+                        color = MaterialTheme.colorScheme.primary,
                         fontWeight = FontWeight.Bold,
                     )
                     Text(
@@ -430,7 +429,7 @@ private fun CraftSheet(
         Text(
             text     = projectedXpLabel(currentXp, totalXp.toLong()),
             style    = MaterialTheme.typography.bodySmall,
-            color    = GoldPrimary,
+            color    = MaterialTheme.colorScheme.primary,
             modifier = Modifier.align(Alignment.CenterHorizontally),
         )
         if (recipe.outputQty > 1) {

--- a/app/src/main/kotlin/com/fantasyidler/ui/screen/DungeonInfoSheet.kt
+++ b/app/src/main/kotlin/com/fantasyidler/ui/screen/DungeonInfoSheet.kt
@@ -87,8 +87,6 @@ import com.fantasyidler.data.model.EquipSlot
 import com.fantasyidler.data.model.SessionFrame
 import com.fantasyidler.data.model.SkillSession
 import com.fantasyidler.data.model.Skills
-import com.fantasyidler.ui.theme.GoldPrimary
-import com.fantasyidler.ui.theme.SuccessGreen
 import com.fantasyidler.ui.viewmodel.CombatViewModel
 import com.fantasyidler.ui.viewmodel.CombatViewModel.Companion.MAX_DUNGEON_REPEAT_COUNT
 import com.fantasyidler.ui.viewmodel.InventoryViewModel
@@ -206,9 +204,9 @@ internal fun DungeonInfoSheet(
         // Level and combat style rows
         StatRow(label = stringResource(R.string.combat_rec_level),
             value = dungeon.recommendedLevel.toString(),
-            valueColor = if (canEnter) GoldPrimary else MaterialTheme.colorScheme.error)
+            valueColor = if (canEnter) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.error)
         StatRow(label = stringResource(R.string.combat_your_level), value = combatLvl.toString())
-        StatRow(label = stringResource(R.string.label_combat_style), value = styleLabel, valueColor = GoldPrimary)
+        StatRow(label = stringResource(R.string.label_combat_style), value = styleLabel, valueColor = MaterialTheme.colorScheme.primary)
 
         Spacer(Modifier.height(12.dp))
 
@@ -287,7 +285,7 @@ internal fun DungeonInfoSheet(
                                          else GameStrings.itemName(context, key),
                             style      = MaterialTheme.typography.bodyMedium,
                             fontWeight = if (isSelected) FontWeight.SemiBold else FontWeight.Normal,
-                            color      = if (isSelected) GoldPrimary else MaterialTheme.colorScheme.onSurface,
+                            color      = if (isSelected) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onSurface,
                         )
                         if (key != null) {
                             val effectStr = potionEffects[key]?.entries
@@ -310,7 +308,7 @@ internal fun DungeonInfoSheet(
                     }
                     if (isSelected) {
                         Text("✓", style = MaterialTheme.typography.bodyMedium,
-                            color = GoldPrimary, fontWeight = FontWeight.Bold)
+                            color = MaterialTheme.colorScheme.primary, fontWeight = FontWeight.Bold)
                     }
                 }
             }

--- a/app/src/main/kotlin/com/fantasyidler/ui/screen/EquipmentComponents.kt
+++ b/app/src/main/kotlin/com/fantasyidler/ui/screen/EquipmentComponents.kt
@@ -75,7 +75,6 @@ import com.fantasyidler.data.json.SkillingDungeonData
 import com.fantasyidler.data.json.ConstructionRecipe
 import com.fantasyidler.data.json.ThievingNpcData
 import com.fantasyidler.data.model.EquipSlot
-import com.fantasyidler.ui.theme.GoldPrimary
 import com.fantasyidler.ui.viewmodel.Achievement
 import com.fantasyidler.ui.viewmodel.AchievementsViewModel
 import com.fantasyidler.ui.viewmodel.ArmoryViewModel
@@ -169,7 +168,7 @@ internal fun FoodRow(
             }
         } else {
             TextButton(onClick = onEquip) {
-                Text(stringResource(R.string.btn_equip), color = GoldPrimary)
+                Text(stringResource(R.string.btn_equip), color = MaterialTheme.colorScheme.primary)
             }
         }
     }
@@ -331,7 +330,7 @@ internal fun EquipPickerSheet(
                     Text(
                         text  = stringResource(R.string.btn_equip),
                         style = MaterialTheme.typography.labelMedium,
-                        color = GoldPrimary,
+                        color = MaterialTheme.colorScheme.primary,
                     )
                 }
                 HorizontalDivider(modifier = Modifier.padding(horizontal = 16.dp))

--- a/app/src/main/kotlin/com/fantasyidler/ui/screen/ExpeditionsScreen.kt
+++ b/app/src/main/kotlin/com/fantasyidler/ui/screen/ExpeditionsScreen.kt
@@ -30,7 +30,6 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.compose.ui.platform.LocalContext
 import com.fantasyidler.R
-import com.fantasyidler.ui.theme.GoldPrimary
 import com.fantasyidler.ui.viewmodel.ExpeditionsUiState
 import com.fantasyidler.ui.viewmodel.ExpeditionsViewModel
 import com.fantasyidler.ui.viewmodel.SkillingDungeonUiItem
@@ -150,7 +149,7 @@ private fun SkillingDungeonCard(
                 Text(
                     text = stringResource(R.string.expedition_lore_notes, item.notesFound, item.dungeon.noteThreshold),
                     style = MaterialTheme.typography.labelSmall,
-                    color = GoldPrimary,
+                    color = MaterialTheme.colorScheme.primary,
                 )
                 LinearProgressIndicator(
                     progress = { progress.coerceIn(0f, 1f) },
@@ -158,7 +157,7 @@ private fun SkillingDungeonCard(
                         .fillMaxWidth()
                         .padding(top = 4.dp)
                         .height(6.dp),
-                    color = GoldPrimary,
+                    color = MaterialTheme.colorScheme.primary,
                     trackColor = MaterialTheme.colorScheme.surfaceVariant,
                 )
                 if (item.notesFound >= item.dungeon.noteThreshold) {

--- a/app/src/main/kotlin/com/fantasyidler/ui/screen/FarmingScreen.kt
+++ b/app/src/main/kotlin/com/fantasyidler/ui/screen/FarmingScreen.kt
@@ -67,7 +67,6 @@ import com.fantasyidler.data.json.CropData
 import com.fantasyidler.data.model.FarmingPatch
 import com.fantasyidler.repository.FarmingRepository
 import com.fantasyidler.simulator.XpTable
-import com.fantasyidler.ui.theme.GoldPrimary
 import com.fantasyidler.ui.theme.ScaledSheetContent
 import com.fantasyidler.ui.viewmodel.FarmingUiState
 import com.fantasyidler.ui.viewmodel.FarmingViewModel
@@ -182,7 +181,7 @@ fun FarmingScreen(
                     Text(
                         text  = "+${result.xpGained.formatXp()} XP",
                         style = MaterialTheme.typography.bodyMedium,
-                        color = GoldPrimary,
+                        color = MaterialTheme.colorScheme.primary,
                         fontWeight = FontWeight.SemiBold,
                     )
                     if (result.itemsGained.isNotEmpty()) {
@@ -287,7 +286,7 @@ fun FarmingSheetContent(
                     Text(
                         text  = "+${result.xpGained.formatXp()} XP",
                         style = MaterialTheme.typography.bodyMedium,
-                        color = GoldPrimary,
+                        color = MaterialTheme.colorScheme.primary,
                         fontWeight = FontWeight.SemiBold,
                     )
                     if (result.itemsGained.isNotEmpty()) {
@@ -345,7 +344,7 @@ private fun FarmingXpBar(state: FarmingUiState) {
             LinearProgressIndicator(
                 progress = { progress },
                 modifier = Modifier.fillMaxWidth().height(6.dp).clip(RoundedCornerShape(3.dp)),
-                color    = GoldPrimary,
+                color    = MaterialTheme.colorScheme.primary,
             )
             Spacer(Modifier.height(4.dp))
             Text(
@@ -436,7 +435,7 @@ private fun PatchCard(
                         LinearProgressIndicator(
                             progress = { progress },
                             modifier = Modifier.fillMaxWidth().height(6.dp).clip(RoundedCornerShape(3.dp)),
-                            color    = GoldPrimary,
+                            color    = MaterialTheme.colorScheme.primary,
                         )
                         if (BuildConfig.DEBUG) {
                             TextButton(onClick = onClimb) {
@@ -455,14 +454,14 @@ private fun PatchCard(
                             Text(
                                 text  = "🌿 ${context.getString(R.string.farming_fertilizer_yield, pct)}",
                                 style = MaterialTheme.typography.labelSmall,
-                                color = GoldPrimary,
+                                color = MaterialTheme.colorScheme.primary,
                             )
                         }
                         Spacer(Modifier.height(4.dp))
                         LinearProgressIndicator(
                             progress = { progress },
                             modifier = Modifier.fillMaxWidth().height(6.dp).clip(RoundedCornerShape(3.dp)),
-                            color    = GoldPrimary,
+                            color    = MaterialTheme.colorScheme.primary,
                         )
                         Spacer(Modifier.height(4.dp))
                         Text(
@@ -492,7 +491,7 @@ private fun PatchCard(
                         Text(
                             text  = stringResource(R.string.farming_bean_ready),
                             style = MaterialTheme.typography.bodyMedium,
-                            color = GoldPrimary,
+                            color = MaterialTheme.colorScheme.primary,
                             fontWeight = FontWeight.SemiBold,
                         )
                         Spacer(Modifier.height(8.dp))
@@ -513,7 +512,7 @@ private fun PatchCard(
                         Text(
                             text  = stringResource(R.string.label_ready_to_harvest),
                             style = MaterialTheme.typography.bodySmall,
-                            color = GoldPrimary,
+                            color = MaterialTheme.colorScheme.primary,
                             fontWeight = FontWeight.SemiBold,
                         )
                         Spacer(Modifier.height(8.dp))
@@ -644,7 +643,7 @@ private fun PlantSheet(
                         Text(
                             text  = "Seeds: $seedCount  •  Owned: $ownedCount",
                             style = MaterialTheme.typography.labelSmall,
-                            color = if (enabled) GoldPrimary else MaterialTheme.colorScheme.error,
+                            color = if (enabled) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.error,
                         )
                     }
                     Spacer(Modifier.width(8.dp))

--- a/app/src/main/kotlin/com/fantasyidler/ui/screen/GuildDetailScreen.kt
+++ b/app/src/main/kotlin/com/fantasyidler/ui/screen/GuildDetailScreen.kt
@@ -57,7 +57,6 @@ import com.fantasyidler.data.json.GuildDailyTemplate
 import com.fantasyidler.data.json.GuildQuestData
 import com.fantasyidler.repository.GuildDailyWithProgress
 import com.fantasyidler.repository.GuildQuestWithProgress
-import com.fantasyidler.ui.theme.GoldPrimary
 import com.fantasyidler.ui.viewmodel.GuildDetailViewModel
 import com.fantasyidler.util.GameStrings
 import com.fantasyidler.util.dailyResetClockTime
@@ -222,7 +221,7 @@ private fun GuildProgressHeader(
             LinearProgressIndicator(
                 progress = { (dailiesCompleted.toFloat() / dailiesRequired.toFloat()).coerceIn(0f, 1f) },
                 modifier = Modifier.fillMaxWidth(),
-                color    = if (questGateBlocked) MaterialTheme.colorScheme.error else GoldPrimary,
+                color    = if (questGateBlocked) MaterialTheme.colorScheme.error else MaterialTheme.colorScheme.primary,
             )
             Spacer(Modifier.height(2.dp))
             Text(
@@ -244,7 +243,7 @@ private fun GuildProgressHeader(
                     Text(
                         text  = stringResource(R.string.guild_do_dailies_hint),
                         style = MaterialTheme.typography.labelSmall,
-                        color = GoldPrimary,
+                        color = MaterialTheme.colorScheme.primary,
                     )
                 }
             }
@@ -366,7 +365,7 @@ private fun GuildQuestRow(
             LinearProgressIndicator(
                 progress = { fraction },
                 modifier = Modifier.fillMaxWidth(),
-                color    = GoldPrimary,
+                color    = MaterialTheme.colorScheme.primary,
             )
             Spacer(Modifier.height(4.dp))
             Text(
@@ -472,7 +471,7 @@ private fun GuildDailyCard(
             LinearProgressIndicator(
                 progress = { fraction },
                 modifier = Modifier.fillMaxWidth(),
-                color    = GoldPrimary,
+                color    = MaterialTheme.colorScheme.primary,
             )
             Spacer(Modifier.height(4.dp))
             Text(

--- a/app/src/main/kotlin/com/fantasyidler/ui/screen/GuildHallScreen.kt
+++ b/app/src/main/kotlin/com/fantasyidler/ui/screen/GuildHallScreen.kt
@@ -48,7 +48,6 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.fantasyidler.BuildConfig
 import com.fantasyidler.R
-import com.fantasyidler.ui.theme.GoldPrimary
 import com.fantasyidler.ui.viewmodel.GuildHallViewModel
 import com.fantasyidler.ui.viewmodel.GuildSummary
 import com.fantasyidler.util.GameStrings
@@ -190,7 +189,7 @@ private fun GuildCard(
                     Text(
                         text  = stringResource(R.string.guild_dailies_available),
                         style = MaterialTheme.typography.labelSmall,
-                        color = GoldPrimary,
+                        color = MaterialTheme.colorScheme.primary,
                     )
                 }
                 if (summary.level < 10) {
@@ -198,7 +197,7 @@ private fun GuildCard(
                     LinearProgressIndicator(
                         progress = { (summary.dailiesCompletedThisTier.toFloat() / summary.dailiesRequiredThisTier.toFloat()).coerceIn(0f, 1f) },
                         modifier = Modifier.fillMaxWidth(),
-                        color    = GoldPrimary,
+                        color    = MaterialTheme.colorScheme.primary,
                     )
                     Spacer(Modifier.height(2.dp))
                     Text(

--- a/app/src/main/kotlin/com/fantasyidler/ui/screen/HomeCards.kt
+++ b/app/src/main/kotlin/com/fantasyidler/ui/screen/HomeCards.kt
@@ -81,7 +81,6 @@ import com.fantasyidler.data.model.SkillSession
 import com.fantasyidler.data.model.WorkerTier
 import com.fantasyidler.data.json.BlessingType
 import com.fantasyidler.repository.ChurchRepository
-import com.fantasyidler.ui.theme.GoldPrimary
 import com.fantasyidler.ui.viewmodel.HomeViewModel
 import com.fantasyidler.ui.viewmodel.SessionSummary
 import com.fantasyidler.ui.viewmodel.combatLevelFrom
@@ -204,7 +203,7 @@ internal fun HomeSessionCard(
                                  else stringResource(R.string.combat_run_progress, repeatIndex.coerceAtLeast(1), repeatTotal),
                     style      = MaterialTheme.typography.labelMedium,
                     fontWeight = FontWeight.SemiBold,
-                    color      = GoldPrimary,
+                    color      = MaterialTheme.colorScheme.primary,
                 )
             }
 
@@ -571,7 +570,7 @@ internal fun WorkerSessionCard(
                 Text(
                     text       = "$tierLabel · ${hiredWorker.dailyName}",
                     style      = MaterialTheme.typography.labelMedium,
-                    color      = GoldPrimary,
+                    color      = MaterialTheme.colorScheme.primary,
                     fontWeight = FontWeight.SemiBold,
                 )
             }

--- a/app/src/main/kotlin/com/fantasyidler/ui/screen/HomeScreen.kt
+++ b/app/src/main/kotlin/com/fantasyidler/ui/screen/HomeScreen.kt
@@ -87,7 +87,6 @@ import com.fantasyidler.data.model.SkillSession
 import com.fantasyidler.data.model.WorkerTier
 import com.fantasyidler.data.json.BlessingType
 import com.fantasyidler.repository.ChurchRepository
-import com.fantasyidler.ui.theme.GoldPrimary
 import com.fantasyidler.ui.theme.ScaledSheetContent
 import com.fantasyidler.ui.viewmodel.HomeViewModel
 import com.fantasyidler.ui.viewmodel.SessionSummary
@@ -193,7 +192,7 @@ fun HomeScreen(
                                         Text(
                                             text  = breakdown,
                                             style = MaterialTheme.typography.labelSmall,
-                                            color = GoldPrimary,
+                                            color = MaterialTheme.colorScheme.primary,
                                         )
                                     }
                                 }
@@ -217,7 +216,7 @@ fun HomeScreen(
                                     Text(
                                         text  = breakdown,
                                         style = MaterialTheme.typography.labelSmall,
-                                        color = GoldPrimary,
+                                        color = MaterialTheme.colorScheme.primary,
                                     )
                                 }
                             }
@@ -236,8 +235,8 @@ fun HomeScreen(
                             SummaryRow(
                                 label = if (isRare) "🌟 $item" else item,
                                 value = qty,
-                                labelColor = if (isRare) GoldPrimary else MaterialTheme.colorScheme.onSurface,
-                                valueColor = if (isRare) GoldPrimary else MaterialTheme.colorScheme.onSurfaceVariant,
+                                labelColor = if (isRare) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onSurface,
+                                valueColor = if (isRare) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onSurfaceVariant,
                                 fontWeight = if (isRare) FontWeight.Bold else FontWeight.Normal,
                             )
                         }
@@ -249,7 +248,7 @@ fun HomeScreen(
                         Text(
                             text  = stringResource(R.string.church_blessing_bonus, summary.coinBlessingBonus.formatCoins()),
                             style = MaterialTheme.typography.labelSmall,
-                            color = GoldPrimary,
+                            color = MaterialTheme.colorScheme.primary,
                         )
                     }
                     if (summary.foodConsumedLines.isNotEmpty()) {
@@ -284,7 +283,7 @@ fun HomeScreen(
                             Text(
                                 text = note,
                                 style = MaterialTheme.typography.bodySmall.copy(fontStyle = androidx.compose.ui.text.font.FontStyle.Italic),
-                                color = GoldPrimary,
+                                color = MaterialTheme.colorScheme.primary,
                                 modifier = Modifier.padding(vertical = 2.dp),
                             )
                         }
@@ -349,7 +348,7 @@ fun HomeScreen(
                                         Text(
                                             text  = breakdown,
                                             style = MaterialTheme.typography.labelSmall,
-                                            color = GoldPrimary,
+                                            color = MaterialTheme.colorScheme.primary,
                                         )
                                     }
                                 }
@@ -373,7 +372,7 @@ fun HomeScreen(
                                     Text(
                                         text  = breakdown,
                                         style = MaterialTheme.typography.labelSmall,
-                                        color = GoldPrimary,
+                                        color = MaterialTheme.colorScheme.primary,
                                     )
                                 }
                             }
@@ -392,8 +391,8 @@ fun HomeScreen(
                             SummaryRow(
                                 label = if (isRare) "🌟 $item" else item,
                                 value = qty,
-                                labelColor = if (isRare) GoldPrimary else MaterialTheme.colorScheme.onSurface,
-                                valueColor = if (isRare) GoldPrimary else MaterialTheme.colorScheme.onSurfaceVariant,
+                                labelColor = if (isRare) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onSurface,
+                                valueColor = if (isRare) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onSurfaceVariant,
                                 fontWeight = if (isRare) FontWeight.Bold else FontWeight.Normal,
                             )
                         }
@@ -405,7 +404,7 @@ fun HomeScreen(
                         Text(
                             text  = stringResource(R.string.church_blessing_bonus, summary.coinBlessingBonus.formatCoins()),
                             style = MaterialTheme.typography.labelSmall,
-                            color = GoldPrimary,
+                            color = MaterialTheme.colorScheme.primary,
                         )
                     }
                 }
@@ -615,7 +614,7 @@ fun HomeScreen(
                             StatInline(
                                 label      = stringResource(R.string.label_coins),
                                 value      = state.coins.formatCoins(),
-                                valueColor = GoldPrimary,
+                                valueColor = MaterialTheme.colorScheme.primary,
                             )
                         }
                         if (blessingActive) {
@@ -640,14 +639,14 @@ fun HomeScreen(
                                 Icon(
                                     imageVector        = Icons.Filled.Star,
                                     contentDescription = null,
-                                    tint               = GoldPrimary,
+                                    tint               = MaterialTheme.colorScheme.primary,
                                     modifier           = Modifier.size(12.dp),
                                 )
                                 Spacer(Modifier.width(4.dp))
                                 Text(
                                     text  = blessingText,
                                     style = MaterialTheme.typography.labelSmall,
-                                    color = GoldPrimary,
+                                    color = MaterialTheme.colorScheme.primary,
                                 )
                             }
                         }
@@ -674,7 +673,7 @@ fun HomeScreen(
 
             // ── Town grid ───────────────────────────────────────────────
             val churchTint = if (state.activeBlessingKey.isNotEmpty() && state.activeBlessingRemainingMs > 0)
-                GoldPrimary else MaterialTheme.colorScheme.onSurfaceVariant
+                MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onSurfaceVariant
             val townGridRows: @Composable () -> Unit = {
                 Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
                     Row(
@@ -769,7 +768,7 @@ fun HomeScreen(
                                     text  = if (eventComplete) stringResource(R.string.seasonal_event_complete)
                                             else stringResource(R.string.seasonal_event_token_progress, event.tokens, event.goal),
                                     style = MaterialTheme.typography.labelSmall,
-                                    color = if (eventComplete) GoldPrimary else MaterialTheme.colorScheme.onSurfaceVariant,
+                                    color = if (eventComplete) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onSurfaceVariant,
                                     fontWeight = if (eventComplete) FontWeight.Bold else FontWeight.Normal,
                                 )
                             }

--- a/app/src/main/kotlin/com/fantasyidler/ui/screen/InnScreen.kt
+++ b/app/src/main/kotlin/com/fantasyidler/ui/screen/InnScreen.kt
@@ -50,7 +50,6 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.fantasyidler.R
 import com.fantasyidler.data.model.WorkerTier
-import com.fantasyidler.ui.theme.GoldPrimary
 import com.fantasyidler.ui.viewmodel.DailyFoodItem
 import com.fantasyidler.ui.viewmodel.InnViewModel
 import androidx.compose.ui.platform.LocalContext
@@ -301,7 +300,7 @@ private fun FoodRow(
         Text(
             text  = stringResource(R.string.inn_hire_cost, food.price.toLong().formatCoins()),
             style = MaterialTheme.typography.bodyMedium,
-            color = GoldPrimary,
+            color = MaterialTheme.colorScheme.primary,
             fontWeight = FontWeight.SemiBold,
             modifier = Modifier.padding(horizontal = 12.dp),
         )
@@ -360,7 +359,7 @@ private fun BuyFoodDialog(
                     Text(
                         text       = stringResource(R.string.inn_buy_total, total.formatCoins()),
                         style      = MaterialTheme.typography.bodyMedium,
-                        color      = GoldPrimary,
+                        color      = MaterialTheme.colorScheme.primary,
                         fontWeight = FontWeight.SemiBold,
                     )
                 }
@@ -409,7 +408,7 @@ private fun TierCard(
                     Text(
                         text  = workerName,
                         style = MaterialTheme.typography.bodyMedium,
-                        color = GoldPrimary,
+                        color = MaterialTheme.colorScheme.primary,
                         fontWeight = FontWeight.SemiBold,
                     )
                 }
@@ -429,7 +428,7 @@ private fun TierCard(
                 Text(
                     text  = stringResource(R.string.inn_hire_cost, cost.formatCoins()),
                     style = MaterialTheme.typography.bodyMedium,
-                    color = GoldPrimary,
+                    color = MaterialTheme.colorScheme.primary,
                     fontWeight = FontWeight.SemiBold,
                 )
                 Button(

--- a/app/src/main/kotlin/com/fantasyidler/ui/screen/MercantileScreen.kt
+++ b/app/src/main/kotlin/com/fantasyidler/ui/screen/MercantileScreen.kt
@@ -43,7 +43,6 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import com.fantasyidler.R
 import com.fantasyidler.data.json.TradeRouteData
 import com.fantasyidler.util.GameStrings
-import com.fantasyidler.ui.theme.GoldPrimary
 import com.fantasyidler.ui.viewmodel.MercantileUiState
 import com.fantasyidler.ui.viewmodel.MercantileViewModel
 import com.fantasyidler.ui.viewmodel.xpProgressFraction
@@ -187,7 +186,7 @@ private fun MercantileStatsHeader(state: MercantileUiState) {
             Text(
                 text  = stringResource(R.string.mercantile_coins_label, state.coins.formatCoins()),
                 style = MaterialTheme.typography.bodySmall,
-                color = GoldPrimary,
+                color = MaterialTheme.colorScheme.primary,
             )
         }
     }

--- a/app/src/main/kotlin/com/fantasyidler/ui/screen/MonumentScreen.kt
+++ b/app/src/main/kotlin/com/fantasyidler/ui/screen/MonumentScreen.kt
@@ -45,7 +45,6 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.fantasyidler.R
 import com.fantasyidler.repository.MonumentRepository
-import com.fantasyidler.ui.theme.GoldPrimary
 import com.fantasyidler.ui.viewmodel.MonumentViewModel
 import com.fantasyidler.util.formatCoins
 
@@ -113,7 +112,7 @@ fun MonumentScreen(
                     Text(
                         text  = stringResource(R.string.monument_your_coins, state.coins.formatCoins()),
                         style = MaterialTheme.typography.labelMedium,
-                        color = GoldPrimary,
+                        color = MaterialTheme.colorScheme.primary,
                     )
                 }
             }
@@ -173,7 +172,7 @@ fun MonumentScreen(
                                 state.tier >= stage -> Text(
                                     text       = stringResource(R.string.monument_built),
                                     style      = MaterialTheme.typography.labelMedium,
-                                    color      = GoldPrimary,
+                                    color      = MaterialTheme.colorScheme.primary,
                                     fontWeight = FontWeight.Bold,
                                 )
                                 state.tier == stage - 1 -> Button(
@@ -207,14 +206,14 @@ fun MonumentScreen(
                         Text(
                             text       = stringResource(R.string.monument_flame_complete),
                             style      = MaterialTheme.typography.bodyMedium,
-                            color      = GoldPrimary,
+                            color      = MaterialTheme.colorScheme.primary,
                             fontWeight = FontWeight.Bold,
                         )
                     } else {
                         LinearProgressIndicator(
                             progress = { (state.fund.toFloat() / MonumentRepository.FLAME_GOAL).coerceIn(0f, 1f) },
                             modifier = Modifier.fillMaxWidth().height(8.dp).clip(RoundedCornerShape(4.dp)),
-                            color    = GoldPrimary,
+                            color    = MaterialTheme.colorScheme.primary,
                         )
                         Spacer(Modifier.height(4.dp))
                         Text(

--- a/app/src/main/kotlin/com/fantasyidler/ui/screen/OnboardingScreen.kt
+++ b/app/src/main/kotlin/com/fantasyidler/ui/screen/OnboardingScreen.kt
@@ -27,7 +27,6 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import com.fantasyidler.R
-import com.fantasyidler.ui.theme.GoldPrimary
 import kotlinx.coroutines.launch
 
 private data class OnboardingPage(val emoji: String, val title: String, val body: String)
@@ -90,7 +89,7 @@ fun OnboardingScreen(onComplete: () -> Unit) {
                         val selected = pagerState.currentPage == i
                         Surface(
                             shape    = CircleShape,
-                            color    = if (selected) GoldPrimary
+                            color    = if (selected) MaterialTheme.colorScheme.primary
                                        else MaterialTheme.colorScheme.onSurface.copy(alpha = 0.25f),
                             modifier = Modifier.size(if (selected) 10.dp else 7.dp),
                         ) {}

--- a/app/src/main/kotlin/com/fantasyidler/ui/screen/ProfileScreen.kt
+++ b/app/src/main/kotlin/com/fantasyidler/ui/screen/ProfileScreen.kt
@@ -81,7 +81,6 @@ import com.fantasyidler.BuildConfig
 import com.fantasyidler.R
 import com.fantasyidler.data.json.PetData
 import com.fantasyidler.data.json.SkillingDungeonData
-import com.fantasyidler.ui.theme.GoldPrimary
 import com.fantasyidler.ui.theme.ScaledSheetContent
 import com.fantasyidler.ui.viewmodel.Achievement
 import com.fantasyidler.ui.viewmodel.AchievementsViewModel
@@ -439,7 +438,7 @@ private fun TabsLayout(
 @Composable
 fun CoinsBanner(coins: Long) {
     Surface(
-        color    = GoldPrimary.copy(alpha = 0.15f),
+        color    = MaterialTheme.colorScheme.primary.copy(alpha = 0.15f),
         modifier = Modifier.fillMaxWidth(),
     ) {
         Row(
@@ -456,7 +455,7 @@ fun CoinsBanner(coins: Long) {
                 text       = coins.formatCoins(),
                 style      = MaterialTheme.typography.titleMedium,
                 fontWeight = FontWeight.Bold,
-                color      = GoldPrimary,
+                color      = MaterialTheme.colorScheme.primary,
             )
         }
     }
@@ -532,7 +531,7 @@ private fun SkillsTab(
 
 @Composable
 private fun CircularSkillProgress(level: Int, progressFraction: Float, modifier: Modifier = Modifier) {
-    val gold      = GoldPrimary
+    val gold      = MaterialTheme.colorScheme.primary
     val track     = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.15f)
     val onSurface = MaterialTheme.colorScheme.onSurface
     val textStyle = MaterialTheme.typography.labelMedium.copy(
@@ -658,7 +657,7 @@ private fun SkillUnlockSheet(
                 Text(
                     text  = stringResource(R.string.guild_level_label, level),
                     style = MaterialTheme.typography.bodySmall,
-                    color = GoldPrimary,
+                    color = MaterialTheme.colorScheme.primary,
                 )
             }
         }
@@ -674,7 +673,7 @@ private fun SkillUnlockSheet(
                 Text(
                     text     = stringResource(R.string.label_lv, milestone.level),
                     style    = MaterialTheme.typography.labelMedium,
-                    color    = if (unlocked) GoldPrimary
+                    color    = if (unlocked) MaterialTheme.colorScheme.primary
                                else MaterialTheme.colorScheme.onSurface.copy(alpha = 0.38f),
                     modifier = Modifier.width(44.dp),
                 )
@@ -688,7 +687,7 @@ private fun SkillUnlockSheet(
                 if (unlocked) {
                     Text(
                         text  = "✓",
-                        color = GoldPrimary,
+                        color = MaterialTheme.colorScheme.primary,
                         style = MaterialTheme.typography.labelSmall,
                     )
                 }
@@ -1058,7 +1057,7 @@ private fun AchievementsTab(
                         text       = "$unlockedCount / $totalCount",
                         style      = MaterialTheme.typography.labelLarge,
                         fontWeight = FontWeight.Bold,
-                        color      = GoldPrimary,
+                        color      = MaterialTheme.colorScheme.primary,
                     )
                 }
             }
@@ -1119,7 +1118,7 @@ private fun AchievementRow(ach: Achievement) {
             Text(
                 text  = "✓",
                 style = MaterialTheme.typography.titleMedium,
-                color = GoldPrimary,
+                color = MaterialTheme.colorScheme.primary,
                 fontWeight = FontWeight.Bold,
             )
         }
@@ -1211,7 +1210,7 @@ private fun PetRow(pet: PetData, owned: Boolean) {
         Text(
             text  = stringResource(R.string.format_xp_boost_percent, pet.boostPercent),
             style = MaterialTheme.typography.labelMedium,
-            color = (if (owned) GoldPrimary else MaterialTheme.colorScheme.onSurfaceVariant)
+            color = (if (owned) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onSurfaceVariant)
                 .copy(alpha = alpha),
         )
     }
@@ -1295,7 +1294,7 @@ private fun DungeonNotesCard(
                     Text(
                         text = "${index + 1}.",
                         style = MaterialTheme.typography.bodySmall,
-                        color = GoldPrimary,
+                        color = MaterialTheme.colorScheme.primary,
                         modifier = Modifier.width(20.dp),
                     )
                     Text(

--- a/app/src/main/kotlin/com/fantasyidler/ui/screen/QuestsScreen.kt
+++ b/app/src/main/kotlin/com/fantasyidler/ui/screen/QuestsScreen.kt
@@ -59,7 +59,6 @@ import com.fantasyidler.R
 import com.fantasyidler.data.json.DailyQuestTemplate
 import com.fantasyidler.data.json.QuestData
 import com.fantasyidler.repository.DailyQuestWithProgress
-import com.fantasyidler.ui.theme.GoldPrimary
 import com.fantasyidler.ui.viewmodel.QuestWithProgress
 import com.fantasyidler.ui.viewmodel.QuestsViewModel
 import com.fantasyidler.repository.WeeklyQuestWithProgress
@@ -390,7 +389,7 @@ private fun WeeklyQuestsContent(
                     Text(
                         text = stringResource(R.string.weekly_bonus_title),
                         style = MaterialTheme.typography.bodyLarge,
-                        color = GoldPrimary,
+                        color = MaterialTheme.colorScheme.primary,
                     )
                     Spacer(Modifier.height(8.dp))
                     Button(onClick = onClaimBonus, modifier = Modifier.fillMaxWidth()) {
@@ -501,7 +500,7 @@ private fun DailyQuestCard(
             LinearProgressIndicator(
                 progress = { fraction },
                 modifier = Modifier.fillMaxWidth(),
-                color    = GoldPrimary,
+                color    = MaterialTheme.colorScheme.primary,
             )
             Spacer(Modifier.height(4.dp))
             val displayProgress = quest.progress.coerceAtMost(quest.template.amount)
@@ -536,7 +535,7 @@ private fun DailyQuestCard(
             Text(
                 text  = stringResource(R.string.label_daily_reward),
                 style = MaterialTheme.typography.labelSmall,
-                color = GoldPrimary,
+                color = MaterialTheme.colorScheme.primary,
             )
             Spacer(Modifier.height(6.dp))
             Button(
@@ -598,7 +597,7 @@ private fun QuestRow(
             LinearProgressIndicator(
                 progress  = { questWithProgress.progressFraction },
                 modifier  = Modifier.fillMaxWidth(),
-                color     = GoldPrimary,
+                color     = MaterialTheme.colorScheme.primary,
             )
             Spacer(Modifier.height(4.dp))
             val displayProgress = questWithProgress.progress.coerceAtMost(quest.amount)
@@ -652,7 +651,7 @@ private fun QuestRow(
                 Text(
                     text  = rewardParts.joinToString(" · "),
                     style = MaterialTheme.typography.labelSmall,
-                    color = GoldPrimary,
+                    color = MaterialTheme.colorScheme.primary,
                 )
                 Spacer(Modifier.height(6.dp))
             }
@@ -702,7 +701,7 @@ private fun WeeklyQuestCard(
             LinearProgressIndicator(
                 progress = { fraction },
                 modifier = Modifier.fillMaxWidth(),
-                color    = GoldPrimary,
+                color    = MaterialTheme.colorScheme.primary,
             )
             Spacer(Modifier.height(4.dp))
             val displayProgress = quest.progress.coerceAtMost(quest.template.amount)

--- a/app/src/main/kotlin/com/fantasyidler/ui/screen/SeasonalEventScreen.kt
+++ b/app/src/main/kotlin/com/fantasyidler/ui/screen/SeasonalEventScreen.kt
@@ -66,7 +66,6 @@ import com.fantasyidler.data.json.NightMarketOfferData
 import com.fantasyidler.data.json.SeasonalMinigameConfig
 import com.fantasyidler.data.json.SeasonalRewardTierData
 import com.fantasyidler.repository.SeasonalBountyTaskWithProgress
-import com.fantasyidler.ui.theme.GoldPrimary
 import com.fantasyidler.ui.viewmodel.CraftingViewModel
 import com.fantasyidler.ui.viewmodel.SeasonalEventViewModel
 import com.fantasyidler.ui.viewmodel.SkillsViewModel
@@ -329,14 +328,14 @@ private fun RewardTierRow(
             Text(
                 text  = stringResource(R.string.seasonal_reward_tier_requirement, tier.tokens),
                 style = MaterialTheme.typography.labelSmall,
-                color = GoldPrimary,
+                color = MaterialTheme.colorScheme.primary,
             )
         }
         when {
             claimed || (!hasPayload && tokens >= tier.tokens) -> Text(
                 text       = stringResource(R.string.seasonal_reward_claimed),
                 style      = MaterialTheme.typography.labelMedium,
-                color      = GoldPrimary,
+                color      = MaterialTheme.colorScheme.primary,
                 fontWeight = FontWeight.Bold,
             )
             hasPayload && tokens >= tier.tokens -> Button(onClick = onClaim) { Text(stringResource(R.string.seasonal_claim)) }
@@ -368,7 +367,7 @@ private fun MarketOfferRow(
             Text(
                 text  = stringResource(R.string.seasonal_market_price, offer.coinCost.formatCoins()),
                 style = MaterialTheme.typography.labelSmall,
-                color = GoldPrimary,
+                color = MaterialTheme.colorScheme.primary,
             )
             val limit = offer.limit
             if (limit != null && !soldOut) {
@@ -423,7 +422,7 @@ private fun BountyTaskRow(
             Text(
                 text  = GameStrings.seasonalBountyHint(context, task.id, task.hint),
                 style = MaterialTheme.typography.labelSmall,
-                color = GoldPrimary,
+                color = MaterialTheme.colorScheme.primary,
             )
             Text(
                 text  = "${taskProgress.progress}/${task.amount}",
@@ -509,7 +508,7 @@ private fun BonfireRhythmGame(
     Text(
         text  = stringResource(R.string.seasonal_minigame_hint, config.hitsRequired, config.rounds),
         style = MaterialTheme.typography.bodySmall,
-        color = GoldPrimary,
+        color = MaterialTheme.colorScheme.primary,
     )
     Spacer(Modifier.height(8.dp))
 
@@ -534,7 +533,7 @@ private fun BonfireRhythmGame(
                         modifier = Modifier
                             .size(56.dp)
                             .clip(CircleShape)
-                            .background(if (isLit) GoldPrimary else MaterialTheme.colorScheme.surface)
+                            .background(if (isLit) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.surface)
                             .clickable(enabled = isPlaying) {
                                 if (litHole == index) {
                                     haptic.performHapticFeedback(HapticFeedbackType.LongPress)
@@ -555,7 +554,7 @@ private fun BonfireRhythmGame(
             text       = "$c",
             style      = MaterialTheme.typography.displayMedium,
             fontWeight = FontWeight.Bold,
-            color      = GoldPrimary,
+            color      = MaterialTheme.colorScheme.primary,
             textAlign  = TextAlign.Center,
             modifier   = Modifier.fillMaxWidth(),
         )
@@ -629,7 +628,7 @@ private fun LanternSequenceGame(
     Text(
         text  = stringResource(R.string.seasonal_minigame_sequence_hint, config.hitsRequired, config.rounds),
         style = MaterialTheme.typography.bodySmall,
-        color = GoldPrimary,
+        color = MaterialTheme.colorScheme.primary,
     )
     Spacer(Modifier.height(8.dp))
 
@@ -659,7 +658,7 @@ private fun LanternSequenceGame(
                         modifier = Modifier
                             .size(56.dp)
                             .clip(CircleShape)
-                            .background(if (isLit) GoldPrimary else MaterialTheme.colorScheme.surface)
+                            .background(if (isLit) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.surface)
                             .clickable(enabled = isPlaying && !showingSequence) {
                                 haptic.performHapticFeedback(HapticFeedbackType.LongPress)
                                 if (index == sequence.getOrNull(inputIndex)) {
@@ -692,7 +691,7 @@ private fun LanternSequenceGame(
             text       = "$c",
             style      = MaterialTheme.typography.displayMedium,
             fontWeight = FontWeight.Bold,
-            color      = GoldPrimary,
+            color      = MaterialTheme.colorScheme.primary,
             textAlign  = TextAlign.Center,
             modifier   = Modifier.fillMaxWidth(),
         )

--- a/app/src/main/kotlin/com/fantasyidler/ui/screen/SettingsScreen.kt
+++ b/app/src/main/kotlin/com/fantasyidler/ui/screen/SettingsScreen.kt
@@ -1,6 +1,5 @@
 package com.fantasyidler.ui.screen
 
-import android.content.Context
 import android.content.Intent
 import android.net.Uri
 import android.provider.DocumentsContract
@@ -67,6 +66,7 @@ import androidx.compose.ui.unit.dp
 import androidx.core.app.NotificationManagerCompat
 import com.fantasyidler.BuildConfig
 import com.fantasyidler.R
+import com.fantasyidler.util.GameStrings
 
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalLayoutApi::class)
 @Composable
@@ -78,6 +78,7 @@ fun SettingsScreen(
 ) {
     val context = LocalContext.current
 
+    val customThemes           by viewModel.customThemes.collectAsState()
     val themePreference        by viewModel.themePreference.collectAsState()
     val fontScale              by viewModel.fontScale.collectAsState()
     val profileLayout          by viewModel.profileLayout.collectAsState()
@@ -117,6 +118,19 @@ fun SettingsScreen(
         viewModel.importSave(jsonString) { success ->
             AppBannerCenter.enqueue(
                 if (success) context.getString(R.string.settings_imported_ok) else context.getString(R.string.settings_imported_fail)
+            )
+        }
+    }
+
+    val importThemeLauncher = rememberLauncherForActivityResult(
+        ActivityResultContracts.GetContent()
+    ) { uri ->
+        uri ?: return@rememberLauncherForActivityResult
+        val jsonString = context.contentResolver.openInputStream(uri)?.bufferedReader()?.readText()
+            ?: return@rememberLauncherForActivityResult
+        viewModel.importTheme(jsonString) { success ->
+            AppBannerCenter.enqueue(
+                if (success) context.getString(R.string.settings_theme_imported_ok) else context.getString(R.string.settings_theme_imported_fail)
             )
         }
     }
@@ -254,19 +268,40 @@ fun SettingsScreen(
                 subtitle = stringResource(R.string.settings_theme_desc),
             )
             FlowRow(horizontalArrangement = Arrangement.spacedBy(4.dp)) {
-                listOf(
-                    "dark"     to stringResource(R.string.settings_theme_dark),
-                    "midnight" to stringResource(R.string.settings_theme_midnight),
-                    "light"    to stringResource(R.string.settings_theme_light),
-                    "system"   to stringResource(R.string.settings_theme_system),
-                ).forEach { (key, label) ->
+                viewModel.officialThemes.forEach { theme ->
                     FilterChip(
-                        selected = themePreference == key,
-                        onClick  = { viewModel.setTheme(key) },
-                        label    = { Text(label, style = MaterialTheme.typography.labelSmall) },
+                        selected = themePreference == theme,
+                        onClick  = { viewModel.setTheme(theme) },
+                        label    = {Text(GameStrings.themeName(context, theme), style = MaterialTheme.typography.labelSmall) },
                     )
                 }
             }
+            if (customThemes.isNotEmpty()) {
+                FlowRow(horizontalArrangement = Arrangement.spacedBy(4.dp)) {
+                    customThemes.forEach { theme ->
+                        FilterChip(
+                            selected = themePreference == theme.name,
+                            onClick  = { viewModel.setTheme(theme.name) },
+                            label    = {Text(theme.displayName, style = MaterialTheme.typography.labelSmall) }
+                        )
+                    }
+                }
+                OutlinedButton(
+                    onClick = { viewModel.deleteTheme(themePreference) },
+                    enabled = themePreference in customThemes.map { it.name }
+                ) {
+                    Text(stringResource(R.string.settings_delete_theme_btn))
+                }
+            }
+            SettingsRow(
+                title    = stringResource(R.string.settings_import_theme),
+                subtitle = stringResource(R.string.settings_import_theme_desc),
+                trailing = {
+                    OutlinedButton(onClick = { importThemeLauncher.launch("*/*") }) {
+                        Text(stringResource(R.string.settings_import_btn))
+                    }
+                }
+            )
 
             SettingsRow(
                 title    = stringResource(R.string.settings_font_size),

--- a/app/src/main/kotlin/com/fantasyidler/ui/screen/ShopScreen.kt
+++ b/app/src/main/kotlin/com/fantasyidler/ui/screen/ShopScreen.kt
@@ -70,12 +70,10 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.fantasyidler.R
-import com.fantasyidler.ui.theme.GoldPrimary
 import com.fantasyidler.ui.viewmodel.BulkSellPreview
 import com.fantasyidler.ui.viewmodel.ShopEntry
 import com.fantasyidler.ui.viewmodel.ShopTransaction
 import com.fantasyidler.ui.viewmodel.ShopViewModel
-import com.fantasyidler.ui.theme.GoldPrimary
 import com.fantasyidler.ui.theme.ScaledSheetContent
 import com.fantasyidler.util.GameStrings
 import com.fantasyidler.util.formatCoins
@@ -160,7 +158,7 @@ fun ShopScreen(
                 Text(
                     text  = state.coins.formatCoins(),
                     style = MaterialTheme.typography.labelMedium,
-                    color = GoldPrimary,
+                    color = MaterialTheme.colorScheme.primary,
                     fontWeight = FontWeight.Bold,
                 )
             }
@@ -307,7 +305,7 @@ private fun BuyList(
                             text       = stringResource(R.string.shop_total_amount, discounted.toString()),
                             style      = MaterialTheme.typography.bodyMedium,
                             fontWeight = FontWeight.SemiBold,
-                            color      = if (canAfford) GoldPrimary else GoldPrimary.copy(alpha = 0.38f),
+                            color      = if (canAfford) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.primary.copy(alpha = 0.38f),
                         )
                         if (hasDiscount) {
                             Text(
@@ -436,7 +434,7 @@ private fun SellList(
                             text       = stringResource(R.string.shop_price_each, sellPrice.toString()),
                             style      = MaterialTheme.typography.bodyMedium,
                             fontWeight = FontWeight.SemiBold,
-                            color      = GoldPrimary.copy(alpha = lockedAlpha),
+                            color      = MaterialTheme.colorScheme.primary.copy(alpha = lockedAlpha),
                         )
                     }
                     HorizontalDivider(modifier = Modifier.padding(horizontal = 16.dp))
@@ -543,7 +541,7 @@ private fun TransactionSheet(
                 text       = stringResource(R.string.shop_total_amount, total.toString()),
                 style      = MaterialTheme.typography.titleMedium,
                 fontWeight = FontWeight.Bold,
-                color      = GoldPrimary,
+                color      = MaterialTheme.colorScheme.primary,
             )
         }
 
@@ -624,7 +622,7 @@ private fun BulkSellSheet(
                         text       = item.total.formatCoins(),
                         style      = MaterialTheme.typography.bodyMedium,
                         fontWeight = FontWeight.SemiBold,
-                        color      = GoldPrimary,
+                        color      = MaterialTheme.colorScheme.primary,
                     )
                 }
                 HorizontalDivider()
@@ -646,7 +644,7 @@ private fun BulkSellSheet(
                 text       = preview.totalCoins.formatCoins(),
                 style      = MaterialTheme.typography.titleMedium,
                 fontWeight = FontWeight.Bold,
-                color      = GoldPrimary,
+                color      = MaterialTheme.colorScheme.primary,
             )
         }
         Row(

--- a/app/src/main/kotlin/com/fantasyidler/ui/screen/SkillsScreen.kt
+++ b/app/src/main/kotlin/com/fantasyidler/ui/screen/SkillsScreen.kt
@@ -86,7 +86,6 @@ import com.fantasyidler.data.json.OreData
 import com.fantasyidler.data.json.ThievingNpcData
 import com.fantasyidler.data.json.TreeData
 import com.fantasyidler.data.model.Skills
-import com.fantasyidler.ui.theme.GoldPrimary
 import com.fantasyidler.ui.theme.ScaledSheetContent
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
@@ -525,7 +524,7 @@ private fun GuildDailySheetBanner(
                                             else                           -> "${quest.progress} / ${quest.amount}"
                                         },
                                         style = MaterialTheme.typography.labelMedium,
-                                        color = GoldPrimary,
+                                        color = MaterialTheme.colorScheme.primary,
                                     )
                                 }
                                 if (!quest.claimed && quest.progress < quest.amount && quest.canQueue()) {
@@ -533,7 +532,7 @@ private fun GuildDailySheetBanner(
                                         onQueueDaily(quest)
                                         showDialog = false
                                     }) {
-                                        Icon(Icons.Filled.Add, contentDescription = null, tint = GoldPrimary)
+                                        Icon(Icons.Filled.Add, contentDescription = null, tint = MaterialTheme.colorScheme.primary)
                                     }
                                 }
                             }
@@ -568,7 +567,7 @@ private fun GuildDailySheetBanner(
             Text(
                 text  = stringResource(R.string.nav_quests),
                 style = MaterialTheme.typography.labelMedium,
-                color = if (anyOpen) GoldPrimary else MaterialTheme.colorScheme.onSurfaceVariant,
+                color = if (anyOpen) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onSurfaceVariant,
             )
         }
         if (guildMaxed) {
@@ -868,7 +867,7 @@ internal fun SkillRow(
                         .size(44.dp)
                         .clip(CircleShape)
                         .background(
-                            if (isActive) GoldPrimary
+                            if (isActive) MaterialTheme.colorScheme.primary
                             else MaterialTheme.colorScheme.surfaceVariant
                         ),
                     contentAlignment = Alignment.Center,
@@ -905,7 +904,7 @@ internal fun SkillRow(
                 }
                 if (guildDailyOpen) {
                     Badge(
-                        containerColor = GoldPrimary,
+                        containerColor = MaterialTheme.colorScheme.primary,
                         modifier       = Modifier.align(Alignment.TopStart),
                     )
                 }
@@ -930,7 +929,7 @@ internal fun SkillRow(
                         Text(
                             text  = stringResource(R.string.label_training),
                             style = MaterialTheme.typography.labelSmall,
-                            color = GoldPrimary,
+                            color = MaterialTheme.colorScheme.primary,
                         )
                     } else {
                         val xpText = if (xpToNextLevel(xp) > 0L)
@@ -951,7 +950,7 @@ internal fun SkillRow(
                         .fillMaxWidth()
                         .height(4.dp)
                         .clip(RoundedCornerShape(2.dp)),
-                    color    = GoldPrimary,
+                    color    = MaterialTheme.colorScheme.primary,
                 )
                 if (toolEfficiency > 1.0f) {
                     Spacer(Modifier.height(2.dp))
@@ -984,7 +983,7 @@ internal fun SkillRow(
                 Text(
                     text  = "★".repeat(prestigeLevel) + "☆".repeat((3 - prestigeLevel).coerceAtLeast(0)),
                     style = MaterialTheme.typography.labelMedium,
-                    color = GoldPrimary,
+                    color = MaterialTheme.colorScheme.primary,
                 )
                 when {
                     onPrestige != null && level >= 99 && prestigeLevel < 3 -> {
@@ -992,7 +991,7 @@ internal fun SkillRow(
                             Text(
                                 text  = stringResource(R.string.prestige),
                                 style = MaterialTheme.typography.labelSmall,
-                                color = GoldPrimary,
+                                color = MaterialTheme.colorScheme.primary,
                             )
                         }
                     }

--- a/app/src/main/kotlin/com/fantasyidler/ui/screen/SlayerScreen.kt
+++ b/app/src/main/kotlin/com/fantasyidler/ui/screen/SlayerScreen.kt
@@ -52,7 +52,6 @@ import com.fantasyidler.R
 import com.fantasyidler.data.json.EquipmentData
 import com.fantasyidler.data.model.Skills
 import com.fantasyidler.data.model.SlayerTask
-import com.fantasyidler.ui.theme.GoldPrimary
 import com.fantasyidler.util.GameStrings
 import com.fantasyidler.ui.viewmodel.PendingLamp
 import com.fantasyidler.ui.viewmodel.SlayerViewModel
@@ -323,7 +322,7 @@ private fun SlayerSkillHeader(
                 Text(
                     text  = stringResource(R.string.slayer_level_label, level),
                     style = MaterialTheme.typography.bodyMedium,
-                    color = GoldPrimary,
+                    color = MaterialTheme.colorScheme.primary,
                     fontWeight = FontWeight.SemiBold,
                 )
             }
@@ -346,7 +345,7 @@ private fun SlayerSkillHeader(
                 Text(
                     text  = stringResource(R.string.slayer_points, slayerPoints),
                     style = MaterialTheme.typography.bodySmall,
-                    color = GoldPrimary,
+                    color = MaterialTheme.colorScheme.primary,
                     fontWeight = FontWeight.SemiBold,
                 )
             }
@@ -514,7 +513,7 @@ private fun ShopRow(
                     Text(
                         text  = statParts.joinToString("  "),
                         style = MaterialTheme.typography.bodySmall,
-                        color = GoldPrimary,
+                        color = MaterialTheme.colorScheme.primary,
                     )
                 }
                 val reqs = equipData.requirements
@@ -543,7 +542,7 @@ private fun ShopRow(
             Text(
                 text       = stringResource(R.string.slayer_shop_cost, item.cost),
                 style      = MaterialTheme.typography.bodyMedium,
-                color      = GoldPrimary,
+                color      = MaterialTheme.colorScheme.primary,
                 fontWeight = FontWeight.SemiBold,
             )
             Spacer(Modifier.height(4.dp))
@@ -596,7 +595,7 @@ private fun LampSkillPickerDialog(
                             Text(
                                 text  = stringResource(R.string.slayer_level_label, level),
                                 style = MaterialTheme.typography.bodySmall,
-                                color = GoldPrimary,
+                                color = MaterialTheme.colorScheme.primary,
                             )
                         }
                     }

--- a/app/src/main/kotlin/com/fantasyidler/ui/screen/TowerScreen.kt
+++ b/app/src/main/kotlin/com/fantasyidler/ui/screen/TowerScreen.kt
@@ -53,7 +53,6 @@ import com.fantasyidler.data.json.EquipmentData
 import com.fantasyidler.data.model.EquipSlot
 import com.fantasyidler.ui.viewmodel.TowerMilestone
 import com.fantasyidler.ui.viewmodel.TowerViewModel
-import com.fantasyidler.ui.theme.GoldPrimary
 import com.fantasyidler.util.GameStrings
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -202,7 +201,7 @@ private fun TowerHeaderCard(
                         Text(
                             text  = stringResource(R.string.tower_best_floor, bestFloor),
                             style = MaterialTheme.typography.bodyMedium,
-                            color = GoldPrimary,
+                            color = MaterialTheme.colorScheme.primary,
                         )
                     }
                 }
@@ -390,7 +389,7 @@ private fun MilestoneRow(
                 text       = stringResource(R.string.tower_floor_label, milestone.floor),
                 style      = MaterialTheme.typography.bodyMedium,
                 fontWeight = FontWeight.SemiBold,
-                color      = if (unlocked) GoldPrimary else dimColor,
+                color      = if (unlocked) MaterialTheme.colorScheme.primary else dimColor,
             )
             Text(
                 text  = milestone.description,

--- a/app/src/main/kotlin/com/fantasyidler/ui/screen/TownBuildingUpgrade.kt
+++ b/app/src/main/kotlin/com/fantasyidler/ui/screen/TownBuildingUpgrade.kt
@@ -21,7 +21,6 @@ import androidx.compose.ui.unit.dp
 import com.fantasyidler.R
 import com.fantasyidler.data.json.TownBuildingData
 import com.fantasyidler.repository.TownRepository
-import com.fantasyidler.ui.theme.GoldPrimary
 import com.fantasyidler.util.GameStrings
 import com.fantasyidler.util.formatCoins
 import kotlin.math.roundToInt
@@ -81,7 +80,7 @@ fun BuildingUpgradeCard(
             Text(
                 text       = tierText,
                 style      = MaterialTheme.typography.bodyMedium,
-                color      = if (isMaxed) GoldPrimary else MaterialTheme.colorScheme.onSurface,
+                color      = if (isMaxed) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onSurface,
                 fontWeight = if (isMaxed) FontWeight.SemiBold else FontWeight.Normal,
             )
 

--- a/app/src/main/kotlin/com/fantasyidler/ui/screen/WorkerSkillsScreen.kt
+++ b/app/src/main/kotlin/com/fantasyidler/ui/screen/WorkerSkillsScreen.kt
@@ -68,7 +68,6 @@ import com.fantasyidler.R
 import com.fantasyidler.data.model.Skills
 import com.fantasyidler.simulator.XpTable
 import com.fantasyidler.data.model.WorkerTier
-import com.fantasyidler.ui.theme.GoldPrimary
 import com.fantasyidler.ui.viewmodel.CraftableRecipe
 import com.fantasyidler.ui.viewmodel.SheetState
 import com.fantasyidler.ui.viewmodel.WorkerSkillsUiState
@@ -175,7 +174,7 @@ fun WorkerSkillsScreen(
                     Text(
                         text  = stringResource(R.string.inn_worker_tier, tierLabel),
                         style = MaterialTheme.typography.labelMedium,
-                        color = GoldPrimary,
+                        color = MaterialTheme.colorScheme.primary,
                         fontWeight = FontWeight.SemiBold,
                         modifier = Modifier.padding(horizontal = 16.dp, vertical = 6.dp),
                     )
@@ -659,7 +658,7 @@ private fun WorkerCraftRecipeRow(
             Text(
                 text  = stringResource(R.string.crafting_owned, ownedQty),
                 style = MaterialTheme.typography.labelSmall,
-                color = if (ownedQty > 0) GoldPrimary else dim,
+                color = if (ownedQty > 0) MaterialTheme.colorScheme.primary else dim,
             )
             recipe.outputCombatStyle?.let { style ->
 
@@ -715,7 +714,7 @@ private fun WorkerCraftRecipeRow(
                     Text(
                         text       = "×$canMake",
                         style      = MaterialTheme.typography.labelMedium,
-                        color      = GoldPrimary,
+                        color      = MaterialTheme.colorScheme.primary,
                         fontWeight = FontWeight.Bold,
                     )
                     Text(
@@ -843,7 +842,7 @@ private fun WorkerCraftQuantityContent(
         Text(
             text     = projectedXpLabel(state.skillXp[recipe.skillName] ?: 0L, totalXp.toLong()),
             style    = MaterialTheme.typography.bodySmall,
-            color    = GoldPrimary,
+            color    = MaterialTheme.colorScheme.primary,
             modifier = Modifier.align(Alignment.CenterHorizontally),
         )
         if (state.sessionDurationMs > 0) {
@@ -871,7 +870,7 @@ private fun WorkerCraftQuantityContent(
                         Text(
                             text       = if (ashKey == null) stringResource(R.string.catalyst_none) else GameStrings.itemName(context, ashKey),
                             style      = MaterialTheme.typography.bodyMedium,
-                            color      = if (selectedAsh == ashKey) GoldPrimary else MaterialTheme.colorScheme.onSurface,
+                            color      = if (selectedAsh == ashKey) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onSurface,
                             fontWeight = if (selectedAsh == ashKey) FontWeight.SemiBold else FontWeight.Normal,
                         )
                         if (ashKey != null) {
@@ -884,7 +883,7 @@ private fun WorkerCraftQuantityContent(
                     }
                 }
                 if (state.herbloreAshKey != null) {
-                    Text(stringResource(R.string.catalyst_enhanced_output), style = MaterialTheme.typography.labelSmall, color = GoldPrimary)
+                    Text(stringResource(R.string.catalyst_enhanced_output), style = MaterialTheme.typography.labelSmall, color = MaterialTheme.colorScheme.primary)
                 }
             }
         }

--- a/app/src/main/kotlin/com/fantasyidler/ui/screen/skills/AgilitySheet.kt
+++ b/app/src/main/kotlin/com/fantasyidler/ui/screen/skills/AgilitySheet.kt
@@ -81,7 +81,6 @@ import com.fantasyidler.data.json.OreData
 import com.fantasyidler.data.json.ThievingNpcData
 import com.fantasyidler.data.json.TreeData
 import com.fantasyidler.data.model.Skills
-import com.fantasyidler.ui.theme.GoldPrimary
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.Remove

--- a/app/src/main/kotlin/com/fantasyidler/ui/screen/skills/CraftSkillSheet.kt
+++ b/app/src/main/kotlin/com/fantasyidler/ui/screen/skills/CraftSkillSheet.kt
@@ -83,7 +83,6 @@ import com.fantasyidler.data.json.OreData
 import com.fantasyidler.data.json.ThievingNpcData
 import com.fantasyidler.data.json.TreeData
 import com.fantasyidler.data.model.Skills
-import com.fantasyidler.ui.theme.GoldPrimary
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.Remove
@@ -325,7 +324,7 @@ private fun CraftRecipeRow(
             Text(
                 text  = stringResource(R.string.crafting_owned, ownedQty),
                 style = MaterialTheme.typography.labelSmall,
-                color = if (ownedQty > 0) GoldPrimary else dim,
+                color = if (ownedQty > 0) MaterialTheme.colorScheme.primary else dim,
             )
             recipe.outputCombatStyle?.let { style ->
 
@@ -381,7 +380,7 @@ private fun CraftRecipeRow(
                     Text(
                         text       = "×$canMake",
                         style      = MaterialTheme.typography.labelMedium,
-                        color      = GoldPrimary,
+                        color      = MaterialTheme.colorScheme.primary,
                         fontWeight = FontWeight.Bold,
                     )
                     Text(
@@ -514,7 +513,7 @@ private fun CraftQuantityContent(
         Text(
             text       = projectedXpLabel(state.skillXp[recipe.skillName] ?: 0L, totalXp.toLong()),
             style      = MaterialTheme.typography.bodyMedium,
-            color      = GoldPrimary,
+            color      = MaterialTheme.colorScheme.primary,
             fontWeight = FontWeight.SemiBold,
         )
         val perItemMs = state.craftPerItemMs.takeIf { it > 0 } ?: (sessionDurationMs / 60)
@@ -543,7 +542,7 @@ private fun CraftQuantityContent(
                         Text(
                             text  = if (ashKey == null) stringResource(R.string.catalyst_none) else GameStrings.itemName(context, ashKey),
                             style = MaterialTheme.typography.bodyMedium,
-                            color = if (selectedAsh == ashKey) GoldPrimary else MaterialTheme.colorScheme.onSurface,
+                            color = if (selectedAsh == ashKey) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onSurface,
                             fontWeight = if (selectedAsh == ashKey) FontWeight.SemiBold else FontWeight.Normal,
                         )
                         if (ashKey != null) {
@@ -556,7 +555,7 @@ private fun CraftQuantityContent(
                     }
                 }
                 if (selectedAsh != null) {
-                    Text(stringResource(R.string.catalyst_enhanced_output), style = MaterialTheme.typography.labelSmall, color = GoldPrimary)
+                    Text(stringResource(R.string.catalyst_enhanced_output), style = MaterialTheme.typography.labelSmall, color = MaterialTheme.colorScheme.primary)
                 }
             }
         }

--- a/app/src/main/kotlin/com/fantasyidler/ui/screen/skills/FiremakingSheet.kt
+++ b/app/src/main/kotlin/com/fantasyidler/ui/screen/skills/FiremakingSheet.kt
@@ -82,7 +82,6 @@ import com.fantasyidler.data.json.OreData
 import com.fantasyidler.data.json.ThievingNpcData
 import com.fantasyidler.data.json.TreeData
 import com.fantasyidler.data.model.Skills
-import com.fantasyidler.ui.theme.GoldPrimary
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.Remove
@@ -252,7 +251,7 @@ internal fun FiremakingSheet(
             Text(
                 text       = projectedXpLabel(currentXp, totalXp.toLong()),
                 style      = MaterialTheme.typography.bodyMedium,
-                color      = GoldPrimary,
+                color      = MaterialTheme.colorScheme.primary,
                 fontWeight = FontWeight.SemiBold,
                 modifier   = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
             )

--- a/app/src/main/kotlin/com/fantasyidler/ui/screen/skills/GatheringSheets.kt
+++ b/app/src/main/kotlin/com/fantasyidler/ui/screen/skills/GatheringSheets.kt
@@ -82,7 +82,6 @@ import com.fantasyidler.data.json.OreData
 import com.fantasyidler.data.json.ThievingNpcData
 import com.fantasyidler.data.json.TreeData
 import com.fantasyidler.data.model.Skills
-import com.fantasyidler.ui.theme.GoldPrimary
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.Remove
@@ -403,7 +402,7 @@ internal fun ActivityRow(
             Text(
                 text  = if (hasActiveSession) stringResource(R.string.skills_add_to_queue) else stringResource(R.string.btn_start_session),
                 style = MaterialTheme.typography.labelMedium,
-                color = GoldPrimary,
+                color = MaterialTheme.colorScheme.primary,
             )
         }
     }

--- a/app/src/main/kotlin/com/fantasyidler/ui/screen/skills/PrayerSheet.kt
+++ b/app/src/main/kotlin/com/fantasyidler/ui/screen/skills/PrayerSheet.kt
@@ -82,7 +82,6 @@ import com.fantasyidler.data.json.OreData
 import com.fantasyidler.data.json.ThievingNpcData
 import com.fantasyidler.data.json.TreeData
 import com.fantasyidler.data.model.Skills
-import com.fantasyidler.ui.theme.GoldPrimary
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.Remove
@@ -209,7 +208,7 @@ internal fun PrayerSheet(
                                 color = MaterialTheme.colorScheme.onSurfaceVariant,
                             )
                         }
-                        Text(stringResource(R.string.btn_select), style = MaterialTheme.typography.labelMedium, color = GoldPrimary)
+                        Text(stringResource(R.string.btn_select), style = MaterialTheme.typography.labelMedium, color = MaterialTheme.colorScheme.primary)
                     }
                     HorizontalDivider(modifier = Modifier.padding(horizontal = 16.dp))
                 }
@@ -293,7 +292,7 @@ internal fun PrayerSheet(
             Text(
                 text     = projectedXpLabel(currentXp, (qty * selectedBone.xpPerBone).toLong()),
                 style    = MaterialTheme.typography.bodyMedium,
-                color    = GoldPrimary,
+                color    = MaterialTheme.colorScheme.primary,
                 fontWeight = FontWeight.SemiBold,
                 modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
             )

--- a/app/src/main/kotlin/com/fantasyidler/ui/screen/skills/RunecraftingSheet.kt
+++ b/app/src/main/kotlin/com/fantasyidler/ui/screen/skills/RunecraftingSheet.kt
@@ -82,7 +82,6 @@ import com.fantasyidler.data.json.OreData
 import com.fantasyidler.data.json.ThievingNpcData
 import com.fantasyidler.data.json.TreeData
 import com.fantasyidler.data.model.Skills
-import com.fantasyidler.ui.theme.GoldPrimary
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.Remove
@@ -210,7 +209,7 @@ internal fun RunecraftingSheet(
                         Text(
                             text  = stringResource(R.string.btn_select),
                             style = MaterialTheme.typography.labelMedium,
-                            color = GoldPrimary,
+                            color = MaterialTheme.colorScheme.primary,
                         )
                     }
                     HorizontalDivider(modifier = Modifier.padding(horizontal = 16.dp))
@@ -294,7 +293,7 @@ internal fun RunecraftingSheet(
             Text(
                 text       = projectedXpLabel(currentXp, (qty * selectedRune.xpPerRune).toLong()),
                 style      = MaterialTheme.typography.bodyMedium,
-                color      = GoldPrimary,
+                color      = MaterialTheme.colorScheme.primary,
                 fontWeight = FontWeight.SemiBold,
                 modifier   = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
             )
@@ -338,7 +337,7 @@ internal fun RunecraftingSheet(
                         Text(
                             text  = if (ashKey == null) stringResource(R.string.catalyst_none) else GameStrings.itemName(context, ashKey),
                             style = MaterialTheme.typography.bodyMedium,
-                            color = if (selectedAshKey == ashKey) GoldPrimary else MaterialTheme.colorScheme.onSurface,
+                            color = if (selectedAshKey == ashKey) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onSurface,
                             fontWeight = if (selectedAshKey == ashKey) FontWeight.SemiBold else FontWeight.Normal,
                         )
                         if (ashKey != null) Text(stringResource(R.string.catalyst_rune_bonus, totalRunes), style = MaterialTheme.typography.labelSmall, color = MaterialTheme.colorScheme.onSurfaceVariant)

--- a/app/src/main/kotlin/com/fantasyidler/ui/screen/skills/ThievingSheet.kt
+++ b/app/src/main/kotlin/com/fantasyidler/ui/screen/skills/ThievingSheet.kt
@@ -81,7 +81,6 @@ import com.fantasyidler.data.json.OreData
 import com.fantasyidler.data.json.ThievingNpcData
 import com.fantasyidler.data.json.TreeData
 import com.fantasyidler.data.model.Skills
-import com.fantasyidler.ui.theme.GoldPrimary
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.Remove

--- a/app/src/main/kotlin/com/fantasyidler/ui/theme/Color.kt
+++ b/app/src/main/kotlin/com/fantasyidler/ui/theme/Color.kt
@@ -2,53 +2,11 @@ package com.fantasyidler.ui.theme
 
 import androidx.compose.ui.graphics.Color
 
-// Primary — gold tones
-val GoldPrimary      = Color(0xFFC9A94D)
-val GoldContainer    = Color(0xFF3D2E00)
-val GoldOnContainer  = Color(0xFFFAD77B)
-
-// Secondary — earthy leather
-val BrownSecondary      = Color(0xFF8B5E3C)
-val BrownContainer      = Color(0xFF3E1F0A)
-val BrownOnContainer    = Color(0xFFD6A882)
-
-// Backgrounds & surfaces — dark fantasy blues
-val DarkBackground      = Color(0xFF1A1A2E)
-val DarkSurface         = Color(0xFF16213E)
-val DarkSurfaceVariant  = Color(0xFF0F3460)
-val DarkSurfaceHigh     = Color(0xFF1E2A4A)
-
-// Text
-val ParchmentText       = Color(0xFFE8DCC8)
-val ParchmentTextMuted  = Color(0xFFA89880)
-
-// Midnight theme — true-black AMOLED background, higher-contrast surfaces for warm display filters
-val MidnightBackground      = Color(0xFF000000)
-val MidnightSurface         = Color(0xFF111827)
-val MidnightSurfaceVariant  = Color(0xFF24344D)
-val MidnightTextMuted       = Color(0xFFC7BBA7)
-
-// Status
-val ErrorRed    = Color(0xFFCF6679)
+/** Semantic accents that are not Material colour-scheme roles. */
 val SuccessGreen = Color(0xFF4CAF50)
 val WarningAmber = Color(0xFFFFB300)
 
-// Light theme backgrounds & surfaces — warm parchment
-val LightBackground      = Color(0xFFF5EDD8)
-val LightSurface         = Color(0xFFFAF4E6)
-val LightSurfaceVariant  = Color(0xFFE5D5B0)
-
-// Light theme text — dark charcoal/brown
-val DarkText             = Color(0xFF1C1408)
-val DarkTextMuted        = Color(0xFF4A3820)
-
-// Light theme containers
-val GoldContainerLight      = Color(0xFFFFEFB0)
-val GoldOnContainerLight    = Color(0xFF2A1A00)
-val BrownContainerLight     = Color(0xFFF5DEC4)
-val BrownOnContainerLight   = Color(0xFF2A1208)
-
-// Equipment tier colours (used for level badges and item rarity)
+/** Equipment tier colours (level badges and item rarity). */
 val TierBronze  = Color(0xFFCD7F32)
 val TierIron    = Color(0xFF808080)
 val TierSteel   = Color(0xFF71A6D2)

--- a/app/src/main/kotlin/com/fantasyidler/ui/theme/Theme.kt
+++ b/app/src/main/kotlin/com/fantasyidler/ui/theme/Theme.kt
@@ -1,79 +1,14 @@
 package com.fantasyidler.ui.theme
 
-import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.material3.ColorScheme
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.darkColorScheme
-import androidx.compose.material3.lightColorScheme
 import androidx.compose.runtime.Composable
-
-private val DarkColorScheme = darkColorScheme(
-    primary              = GoldPrimary,
-    onPrimary            = DarkBackground,
-    primaryContainer     = GoldContainer,
-    onPrimaryContainer   = GoldOnContainer,
-    secondary            = BrownSecondary,
-    onSecondary          = ParchmentText,
-    secondaryContainer   = BrownContainer,
-    onSecondaryContainer = BrownOnContainer,
-    background           = DarkBackground,
-    onBackground         = ParchmentText,
-    surface              = DarkSurface,
-    onSurface            = ParchmentText,
-    surfaceVariant       = DarkSurfaceVariant,
-    onSurfaceVariant     = ParchmentTextMuted,
-    error                = ErrorRed,
-    onError              = ParchmentText,
-)
-
-private val MidnightColorScheme = darkColorScheme(
-    primary              = GoldPrimary,
-    onPrimary            = MidnightBackground,
-    primaryContainer     = GoldContainer,
-    onPrimaryContainer   = GoldOnContainer,
-    secondary            = BrownSecondary,
-    onSecondary          = ParchmentText,
-    secondaryContainer   = BrownContainer,
-    onSecondaryContainer = BrownOnContainer,
-    background           = MidnightBackground,
-    onBackground         = ParchmentText,
-    surface              = MidnightSurface,
-    onSurface            = ParchmentText,
-    surfaceVariant       = MidnightSurfaceVariant,
-    onSurfaceVariant     = MidnightTextMuted,
-    error                = ErrorRed,
-    onError              = ParchmentText,
-)
-
-private val LightColorScheme = lightColorScheme(
-    primary              = GoldPrimary,
-    onPrimary            = DarkText,
-    primaryContainer     = GoldContainerLight,
-    onPrimaryContainer   = GoldOnContainerLight,
-    secondary            = BrownSecondary,
-    onSecondary          = LightBackground,
-    secondaryContainer   = BrownContainerLight,
-    onSecondaryContainer = BrownOnContainerLight,
-    background           = LightBackground,
-    onBackground         = DarkText,
-    surface              = LightSurface,
-    onSurface            = DarkText,
-    surfaceVariant       = LightSurfaceVariant,
-    onSurfaceVariant     = DarkTextMuted,
-    error                = ErrorRed,
-    onError              = ParchmentText,
-)
 
 @Composable
 fun FantasyIdlerTheme(
-    themePreference: String = "dark",
+    colorScheme: ColorScheme,
     content: @Composable () -> Unit,
 ) {
-    val colorScheme = when (themePreference) {
-        "light"    -> LightColorScheme
-        "dark"     -> DarkColorScheme
-        "midnight" -> MidnightColorScheme
-        else       -> if (isSystemInDarkTheme()) DarkColorScheme else LightColorScheme
-    }
     MaterialTheme(
         colorScheme = colorScheme,
         typography  = AppTypography,

--- a/app/src/main/kotlin/com/fantasyidler/ui/theme/Type.kt
+++ b/app/src/main/kotlin/com/fantasyidler/ui/theme/Type.kt
@@ -11,7 +11,6 @@ val AppTypography = Typography(
         fontFamily = FontFamily.Default,
         fontWeight = FontWeight.Bold,
         fontSize = 36.sp,
-        color = GoldPrimary,
     ),
     headlineLarge = TextStyle(
         fontFamily = FontFamily.Default,

--- a/app/src/main/kotlin/com/fantasyidler/ui/viewmodel/SettingsViewModel.kt
+++ b/app/src/main/kotlin/com/fantasyidler/ui/viewmodel/SettingsViewModel.kt
@@ -3,8 +3,11 @@ package com.fantasyidler.ui.viewmodel
 import android.content.Context
 import android.content.Intent
 import android.net.Uri
+import androidx.compose.material3.ColorScheme
+import androidx.compose.material3.darkColorScheme
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.fantasyidler.data.model.CustomTheme
 import com.fantasyidler.data.model.PlayerFlags
 import com.fantasyidler.data.model.toExport
 import com.fantasyidler.data.model.toSkillSession
@@ -12,14 +15,16 @@ import com.fantasyidler.repository.BackupScheduler
 import com.fantasyidler.repository.FarmingRepository
 import com.fantasyidler.repository.GuildRepository
 import com.fantasyidler.repository.PlayerRepository
-import com.fantasyidler.repository.QueuedSessionStarter
 import com.fantasyidler.repository.QuestRepository
+import com.fantasyidler.repository.QueuedSessionStarter
 import com.fantasyidler.repository.SessionRepository
+import com.fantasyidler.repository.ThemeRepository
 import com.fantasyidler.repository.WorkerQueuedSessionStarter
 import dagger.hilt.android.lifecycle.HiltViewModel
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
@@ -37,8 +42,15 @@ class SettingsViewModel @Inject constructor(
     private val backupScheduler: BackupScheduler,
     private val guildRepo: GuildRepository,
     private val farmingRepo: FarmingRepository,
+    private val themeRepo: ThemeRepository,
     private val json: Json,
 ) : ViewModel() {
+
+    val officialThemes: List<String> = themeRepo.getOfficialThemes()
+
+    val customThemes: StateFlow<List<CustomTheme>> = themeRepo.observeCustomThemes()
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000),
+            emptyList())
 
     val themePreference: StateFlow<String> = playerRepo.playerFlow
         .map { player ->
@@ -47,6 +59,19 @@ class SettingsViewModel @Inject constructor(
             catch (_: Exception) { "dark" }
         }
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), "dark")
+
+    val colourScheme: StateFlow<ColorScheme> = combine(
+        playerRepo.playerFlow,
+        themeRepo.observeCustomThemes(),
+    ) { player, _ ->
+        val preference = if (player == null) {
+            "dark"
+        } else {
+            try { json.decodeFromString<PlayerFlags>(player.flags).themePreference }
+            catch (_: Exception) { "dark" }
+        }
+        themeRepo.getColourScheme(preference)
+    }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), darkColorScheme())
 
     val fontScale: StateFlow<Float> = playerRepo.playerFlow
         .map { player ->
@@ -199,6 +224,16 @@ class SettingsViewModel @Inject constructor(
         }
     }
 
+    fun deleteTheme(theme: String) {
+        viewModelScope.launch {
+            if (!themeRepo.deleteTheme(theme)) return@launch
+            val flags = playerRepo.getFlags()
+            if (flags.themePreference == theme) {
+                playerRepo.updateFlags(flags.copy(themePreference = "dark"))
+            }
+        }
+    }
+
     fun setFontScale(scale: Float) {
         viewModelScope.launch {
             val flags = playerRepo.getFlags()
@@ -291,6 +326,17 @@ class SettingsViewModel @Inject constructor(
                 sessionRepo.recoverActiveSession(queuedSessionStarter)
                 sessionRepo.recoverActiveWorkerSession(1, workerStarter)
                 sessionRepo.recoverActiveWorkerSession(2, workerStarter)
+                onDone(true)
+            } catch (_: Exception) {
+                onDone(false)
+            }
+        }
+    }
+
+    fun importTheme(jsonString: String, onDone: (success: Boolean) -> Unit) {
+        viewModelScope.launch {
+            try {
+                themeRepo.importTheme(jsonString)
                 onDone(true)
             } catch (_: Exception) {
                 onDone(false)

--- a/app/src/main/kotlin/com/fantasyidler/util/GameStrings.kt
+++ b/app/src/main/kotlin/com/fantasyidler/util/GameStrings.kt
@@ -214,6 +214,9 @@ object GameStrings {
             "pet" -> petDesc(context, prize)
             else -> fallback
         }
+
+    fun themeName(context: Context, theme: String): String =
+        context.stringByName("settings_theme_${theme}") ?: theme.toTitleCase()
 }
 
 // ---------------------------------------------------------------------------

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -373,6 +373,11 @@
     <string name="settings_font_normal">Normal</string>
     <string name="settings_font_large">Large</string>
     <string name="settings_font_huge">Huge</string>
+    <string name="settings_import_theme">Import themes</string>
+    <string name="settings_import_theme_desc">Import custom themes from a file</string>
+    <string name="settings_delete_theme_btn">Delete theme</string>
+    <string name="settings_theme_imported_ok">Theme file imported successfully</string>
+    <string name="settings_theme_imported_fail">Failed to import — invalid file</string>
     <string name="settings_language_desc">Override the app display language</string>
     <string name="settings_lang_english" translatable="false">English</string>
     <string name="settings_lang_deutsch" translatable="false">Deutsch</string>

--- a/app/src/test/kotlin/com/fantasyidler/ui/theme/ThemeContrastTest.kt
+++ b/app/src/test/kotlin/com/fantasyidler/ui/theme/ThemeContrastTest.kt
@@ -1,43 +1,133 @@
 package com.fantasyidler.ui.theme
 
 import androidx.compose.ui.graphics.Color
+import com.fantasyidler.data.json.ColourSchemeParameter
+import com.fantasyidler.data.json.ColourSchemeParameter.BACKGROUND
+import com.fantasyidler.data.json.ColourSchemeParameter.ON_BACKGROUND
+import com.fantasyidler.data.json.ColourSchemeParameter.ON_SURFACE
+import com.fantasyidler.data.json.ColourSchemeParameter.ON_SURFACE_VARIANT
+import com.fantasyidler.data.json.ColourSchemeParameter.SURFACE
+import com.fantasyidler.data.json.ColourSchemeParameter.SURFACE_VARIANT
+import com.fantasyidler.data.json.ThemeData
+import kotlinx.serialization.json.Json
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
+import java.io.File
 import kotlin.math.max
 import kotlin.math.min
 import kotlin.math.pow
 
+/**
+ * Contrast checks against the official theme definitions in
+ * `assets/data/official_themes.json`, so palette regressions are caught in the
+ * data that actually drives [com.fantasyidler.repository.ThemeRepository].
+ */
 class ThemeContrastTest {
+
+    private val json = Json { ignoreUnknownKeys = true }
+
+    private val themes: Map<String, ThemeData> by lazy {
+        json.decodeFromString(dataFile("official_themes.json").readText())
+    }
+
+    private val midnight: ThemeData get() = themes.getValue("midnight")
+    private val dark: ThemeData get() = themes.getValue("dark")
 
     @Test
     fun `midnight background and surface support enhanced contrast text`() {
-        assertContrastAtLeast(ParchmentText, MidnightBackground, 7.0)
-        assertContrastAtLeast(ParchmentText, MidnightSurface, 7.0)
+        assertContrastAtLeast(midnight.color(ON_BACKGROUND), midnight.color(BACKGROUND), 7.0)
+        assertContrastAtLeast(midnight.color(ON_SURFACE), midnight.color(SURFACE), 7.0)
     }
 
     @Test
     fun `midnight surface variant supports normal contrast muted text`() {
-        assertContrastAtLeast(MidnightTextMuted, MidnightSurfaceVariant, 4.5)
+        assertContrastAtLeast(
+            midnight.color(ON_SURFACE_VARIANT),
+            midnight.color(SURFACE_VARIANT),
+            4.5,
+        )
     }
 
     @Test
     fun `midnight containers remain visually distinct`() {
-        assertEquals(3, setOf(MidnightBackground, MidnightSurface, MidnightSurfaceVariant).size)
+        assertEquals(
+            3,
+            setOf(
+                midnight.color(BACKGROUND),
+                midnight.color(SURFACE),
+                midnight.color(SURFACE_VARIANT),
+            ).size,
+        )
     }
 
     @Test
     fun `midnight palette remains separate from dark palette`() {
-        assertNotEquals(DarkBackground, MidnightBackground)
-        assertNotEquals(DarkSurface, MidnightSurface)
-        assertNotEquals(DarkSurfaceVariant, MidnightSurfaceVariant)
-        assertNotEquals(ParchmentTextMuted, MidnightTextMuted)
+        assertNotEquals(dark.color(BACKGROUND), midnight.color(BACKGROUND))
+        assertNotEquals(dark.color(SURFACE), midnight.color(SURFACE))
+        assertNotEquals(dark.color(SURFACE_VARIANT), midnight.color(SURFACE_VARIANT))
+        assertNotEquals(dark.color(ON_SURFACE_VARIANT), midnight.color(ON_SURFACE_VARIANT))
     }
 
-    private fun assertContrastAtLeast(foreground: Color, background: Color, minimum: Double) {
+    @Test
+    fun `every official theme resolves core text roles to at least AA contrast`() {
+        for ((name, theme) in themes) {
+            assertContrastAtLeast(
+                theme.color(ON_BACKGROUND),
+                theme.color(BACKGROUND),
+                4.5,
+                label = "$name on_background/background",
+            )
+            assertContrastAtLeast(
+                theme.color(ON_SURFACE),
+                theme.color(SURFACE),
+                4.5,
+                label = "$name on_surface/surface",
+            )
+            assertContrastAtLeast(
+                theme.color(ON_SURFACE_VARIANT),
+                theme.color(SURFACE_VARIANT),
+                4.5,
+                label = "$name on_surface_variant/surface_variant",
+            )
+        }
+    }
+
+    private fun ThemeData.color(param: ColourSchemeParameter): Color {
+        val colourName = schemes[param]
+            ?: error("Theme is missing colour_scheme role '${param.name.lowercase()}'")
+        val hex = colours[colourName]
+            ?: error("Theme is missing colour '$colourName' for role '${param.name.lowercase()}'")
+        return Color(parseArgb(hex))
+    }
+
+    private fun parseArgb(raw: String): Long {
+        val cleaned = raw.trim()
+            .removePrefix("0x")
+            .removePrefix("0X")
+            .removePrefix("#")
+        return cleaned.toULong(16).toLong()
+    }
+
+    private fun dataFile(name: String): File =
+        listOf("src/main/assets/data/$name", "app/src/main/assets/data/$name")
+            .map(::File)
+            .firstOrNull(File::exists)
+            ?: error("Could not locate asset $name from ${File(".").absolutePath}")
+
+    private fun assertContrastAtLeast(
+        foreground: Color,
+        background: Color,
+        minimum: Double,
+        label: String = "",
+    ) {
         val ratio = contrastRatio(foreground, background)
-        assertTrue("Expected contrast of at least $minimum, but was $ratio", ratio >= minimum)
+        val detail = if (label.isEmpty()) "" else " ($label)"
+        assertTrue(
+            "Expected contrast of at least $minimum$detail, but was $ratio",
+            ratio >= minimum,
+        )
     }
 
     private fun contrastRatio(first: Color, second: Color): Double {


### PR DESCRIPTION
## Before submitting

- [x] I've tested any changes with the appropriate tests (eg. Unit tests, validation scripts)
- [x] I've pulled and merged the latest changes from the repository

## Summary

<!-- Short summary of the pull request and what it changes -->

This adds custom theming to the IdleFantasy app providing the ability to import custom files and also defines official themes in a dedicated JSON file

## Related issue(s) or discussion(s)

<!-- Prepend issues with "Fixes" if this should close the issue, e.g. Fixes #283, Relates to #284 -->

Discussed in #1316

## Changelog

<!-- Concise list of changes, e.g.
- Fix time-slot bug causing XP gains to not show in notification banner
- Added ellipsis for quests XP gains exceeding screen width
-->

- Define official themes in `official_themes.json` file
- Add database management for custom themes to be added
- Switch multiple references to GoldPrimary colour to use MaterialTheme.colorScheme.primary instead (SuccessGreen and some others left unchanged)
- Clean up code after changes in Theme.kt and Color.kt
- Add relevant settings strings to strings.xml
- Modify ThemeConstrastTest to use new official theme JSON files

## Anything else?

- Only thing that probably needs checking is that ThemeContrastTest currently fails the contrast check but only just. Could be worth fixing but will leave that up to you