### PR TITLE
Improve skills with owned quantity

### DIFF
--- a/app/lint-baseline.xml
+++ b/app/lint-baseline.xml
@@ -5932,17 +5932,6 @@
 
     <issue
         id="MissingTranslation"
-        message="&quot;skills_bone_qty&quot; is not translated in &quot;cs&quot; (Czech) or &quot;ga&quot; (Irish)"
-        errorLine1="    &lt;string name=&quot;skills_bone_qty&quot;>%1$d XP each  •  %2$d in inventory&lt;/string>"
-        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~">
-        <location
-            file="src/main/res/values/strings.xml"
-            line="586"
-            column="13"/>
-    </issue>
-
-    <issue
-        id="MissingTranslation"
         message="&quot;skills_bone_selected&quot; is not translated in &quot;cs&quot; (Czech)"
         errorLine1="    &lt;string name=&quot;skills_bone_selected&quot;>%1$d XP each  •  %2$d available&lt;/string>"
         errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~">

--- a/app/src/main/kotlin/com/fantasyidler/ui/screen/SkillsScreen.kt
+++ b/app/src/main/kotlin/com/fantasyidler/ui/screen/SkillsScreen.kt
@@ -152,6 +152,10 @@ fun SkillsScreen(
                     ).forEach { (category, labelRes) ->
                         Text("${category.emoji}  ${stringResource(labelRes)}")
                     }
+                    Row(verticalAlignment = Alignment.CenterVertically) {
+                        Text("●  ", color = MaterialTheme.colorScheme.primary)
+                        Text(stringResource(R.string.quest_legend_gold_dot))
+                    }
                     Spacer(Modifier.height(4.dp))
                     Text(
                         text  = stringResource(R.string.quest_legend_notes),
@@ -313,6 +317,7 @@ fun SkillActivitySheet(
                         petBoostPct       = state.petBoosts[Skills.MINING] ?: 0,
                         xpBonusMult       = state.xpBonusMult,
                         activeQuests      = state.activeQuests,
+                        inventory         = state.inventory,
                         onSelect          = { oreKey -> viewModel.startMiningSession(oreKey) },
                     )
                     is SheetState.Woodcutting -> WoodcuttingSheet(
@@ -327,6 +332,7 @@ fun SkillActivitySheet(
                         petBoostPct       = state.petBoosts[Skills.WOODCUTTING] ?: 0,
                         xpBonusMult       = state.xpBonusMult,
                         activeQuests      = state.activeQuests,
+                        inventory         = state.inventory,
                         onSelect          = { treeKey -> viewModel.startWoodcuttingSession(treeKey) },
                     )
                     is SheetState.Fishing -> FishingSheet(
@@ -341,6 +347,7 @@ fun SkillActivitySheet(
                         petBoostPct       = state.petBoosts[Skills.FISHING] ?: 0,
                         xpBonusMult       = state.xpBonusMult,
                         activeQuests      = state.activeQuests,
+                        inventory         = state.inventory,
                         onSelect          = { fishKey -> viewModel.startFishingSession(fishKey) },
                     )
                     is SheetState.Agility -> AgilitySheet(

--- a/app/src/main/kotlin/com/fantasyidler/ui/screen/WorkerSkillsScreen.kt
+++ b/app/src/main/kotlin/com/fantasyidler/ui/screen/WorkerSkillsScreen.kt
@@ -283,6 +283,7 @@ fun WorkerSkillsScreen(
                     sessionDurationMs = state.gatheringDurationMs,
                     currentXp         = state.skillXp[Skills.MINING] ?: 0L,
                     efficiency        = state.miningEfficiency,
+                    inventory         = state.inventory,
                     onSelect          = { viewModel.startMiningSession(it) },
                 )
                 is SheetState.Woodcutting -> WoodcuttingSheet(
@@ -293,6 +294,7 @@ fun WorkerSkillsScreen(
                     sessionDurationMs = state.gatheringDurationMs,
                     currentXp         = state.skillXp[Skills.WOODCUTTING] ?: 0L,
                     efficiency        = state.woodcuttingEfficiency,
+                    inventory         = state.inventory,
                     onSelect          = { viewModel.startWoodcuttingSession(it) },
                 )
                 is SheetState.Fishing -> FishingSheet(
@@ -303,6 +305,7 @@ fun WorkerSkillsScreen(
                     sessionDurationMs = state.gatheringDurationMs,
                     currentXp         = state.skillXp[Skills.FISHING] ?: 0L,
                     efficiency        = state.fishingEfficiency,
+                    inventory         = state.inventory,
                     onSelect          = { viewModel.startFishingSession(it) },
                 )
                 is SheetState.Agility -> AgilitySheet(

--- a/app/src/main/kotlin/com/fantasyidler/ui/screen/skills/FiremakingSheet.kt
+++ b/app/src/main/kotlin/com/fantasyidler/ui/screen/skills/FiremakingSheet.kt
@@ -145,6 +145,7 @@ internal fun FiremakingSheet(
     // the host's onDismissRequest interception covers the older popup-based sheet.
     BackHandler(enabled = selectedKey != null) { selectedKey = null }
     val selectedLog = selectedKey?.let { availableLogs[it] }
+    val dim = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.38f)
 
     Column(
         modifier = Modifier
@@ -196,9 +197,14 @@ internal fun FiremakingSheet(
                                 }
                                 val ashOwned = inventory[ashKey] ?: 0
                                 Text(
-                                    text  = stringResource(R.string.firemaking_burns_to, ashName) + "  •  ${log.xpPerLog} XP  •  " + stringResource(R.string.firemaking_ashes_owned, ashOwned),
+                                    text  = stringResource(R.string.firemaking_burns_to, ashName) + "  •  ${log.xpPerLog} XP",
                                     style = MaterialTheme.typography.bodySmall,
                                     color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = rowAlpha),
+                                )
+                                Text(
+                                    text  = stringResource(R.string.firemaking_ashes_owned, ashOwned),
+                                    style = MaterialTheme.typography.labelSmall,
+                                    color = if (ashOwned > 0) MaterialTheme.colorScheme.primary else dim,
                                 )
                             }
                             Text(
@@ -234,9 +240,15 @@ internal fun FiremakingSheet(
                 modifier = Modifier.padding(horizontal = 16.dp),
             )
             Text(
-                text     = "${maxQty} ${stringResource(R.string.firemaking_logs_in_inventory)}  •  " + stringResource(R.string.firemaking_ashes_owned, ashOwned),
+                text     = "${maxQty} ${stringResource(R.string.firemaking_logs_in_inventory)}",
                 style    = MaterialTheme.typography.bodySmall,
                 color    = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.padding(horizontal = 16.dp, vertical = 4.dp),
+            )
+            Text(
+                text     = stringResource(R.string.firemaking_ashes_owned, ashOwned),
+                style    = MaterialTheme.typography.labelSmall,
+                color    = if (ashOwned > 0) MaterialTheme.colorScheme.primary else dim,
                 modifier = Modifier.padding(horizontal = 16.dp, vertical = 4.dp),
             )
             Spacer(Modifier.height(12.dp))

--- a/app/src/main/kotlin/com/fantasyidler/ui/screen/skills/GatheringSheets.kt
+++ b/app/src/main/kotlin/com/fantasyidler/ui/screen/skills/GatheringSheets.kt
@@ -125,6 +125,7 @@ internal fun MiningSheet(
     petBoostPct: Int = 0,
     xpBonusMult: Float = 1f,
     activeQuests: Map<String, List<QuestIndicator>> = emptyMap(),
+    inventory: Map<String, Int> = emptyMap(),
     onSelect: (String) -> Unit,
 ) {
     val context = LocalContext.current
@@ -170,6 +171,7 @@ internal fun MiningSheet(
                         hasActiveSession = hasActiveSession,
                         isQueueFull      = isQueueFull,
                         questIndicators  = activeQuests["${Skills.MINING}:$key"] ?: emptyList(),
+                        ownedQty         = inventory[key] ?: 0,
                         onClick          = { selectedKey = key },
                     )
                 }
@@ -202,6 +204,7 @@ internal fun WoodcuttingSheet(
     petBoostPct: Int = 0,
     xpBonusMult: Float = 1f,
     activeQuests: Map<String, List<QuestIndicator>> = emptyMap(),
+    inventory: Map<String, Int> = emptyMap(),
     onSelect: (String) -> Unit,
 ) {
     val context = LocalContext.current
@@ -241,6 +244,7 @@ internal fun WoodcuttingSheet(
                         hasActiveSession = hasActiveSession,
                         isQueueFull      = isQueueFull,
                         questIndicators  = activeQuests["${Skills.WOODCUTTING}:${tree.logName}"] ?: emptyList(),
+                        ownedQty         = inventory[tree.logName] ?: 0,
                         onClick          = { selectedKey = key },
                     )
                 }
@@ -273,6 +277,7 @@ internal fun FishingSheet(
     petBoostPct: Int = 0,
     xpBonusMult: Float = 1f,
     activeQuests: Map<String, List<QuestIndicator>> = emptyMap(),
+    inventory: Map<String, Int> = emptyMap(),
     onSelect: (String) -> Unit,
 ) {
     val context = LocalContext.current
@@ -312,6 +317,7 @@ internal fun FishingSheet(
                         hasActiveSession = hasActiveSession,
                         isQueueFull      = isQueueFull,
                         questIndicators  = activeQuests["${Skills.FISHING}:$key"] ?: emptyList(),
+                        ownedQty         = inventory[key] ?: 0,
                         onClick          = { selectedKey = key },
                     )
                 }
@@ -366,8 +372,10 @@ internal fun ActivityRow(
     hasActiveSession: Boolean,
     isQueueFull: Boolean,
     questIndicators: List<QuestIndicator> = emptyList(),
+    ownedQty: Int? = null,
     onClick: () -> Unit,
 ) {
+    val dim = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.38f)
     Row(
         modifier = Modifier
             .fillMaxWidth()
@@ -388,6 +396,13 @@ internal fun ActivityRow(
                 style = MaterialTheme.typography.bodySmall,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
             )
+            if (ownedQty != null) {
+                Text(
+                    text  = stringResource(R.string.crafting_owned, ownedQty),
+                    style = MaterialTheme.typography.labelSmall,
+                    color = if (ownedQty > 0) MaterialTheme.colorScheme.primary else dim,
+                )
+            }
             if (projectedLabel != null) {
                 Text(
                     text  = projectedLabel,

--- a/app/src/main/kotlin/com/fantasyidler/ui/screen/skills/PrayerSheet.kt
+++ b/app/src/main/kotlin/com/fantasyidler/ui/screen/skills/PrayerSheet.kt
@@ -146,6 +146,7 @@ internal fun PrayerSheet(
     // the host's onDismissRequest interception covers the older popup-based sheet.
     BackHandler(enabled = selectedKey != null) { selectedKey = null }
     val selectedBone = selectedKey?.let { availableBones[it] }
+    val dim = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.38f)
 
     Column(
         modifier = Modifier
@@ -216,11 +217,19 @@ internal fun PrayerSheet(
                                     QuestIndicatorIcons(questIndicators)
                                 }
                             }
-                            Text(
-                                text  = stringResource(R.string.skills_bone_qty, bone.xpPerBone.toInt(), qty),
-                                style = MaterialTheme.typography.bodySmall,
-                                color = MaterialTheme.colorScheme.onSurfaceVariant,
-                            )
+                            Row(verticalAlignment = Alignment.CenterVertically) {
+                                Text(
+                                    text  = stringResource(R.string.skills_xp_each, bone.xpPerBone.toInt()),
+                                    style = MaterialTheme.typography.bodySmall,
+                                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                )
+                                Spacer(Modifier.width(8.dp))
+                                Text(
+                                    text  = stringResource(R.string.crafting_owned, qty),
+                                    style = MaterialTheme.typography.labelSmall,
+                                    color = if (qty > 0) MaterialTheme.colorScheme.primary else dim,
+                                )
+                            }
                         }
                         Text(stringResource(R.string.btn_select), style = MaterialTheme.typography.labelMedium, color = MaterialTheme.colorScheme.primary)
                     }

--- a/app/src/main/kotlin/com/fantasyidler/ui/screen/skills/PrayerSheet.kt
+++ b/app/src/main/kotlin/com/fantasyidler/ui/screen/skills/PrayerSheet.kt
@@ -217,19 +217,16 @@ internal fun PrayerSheet(
                                     QuestIndicatorIcons(questIndicators)
                                 }
                             }
-                            Row(verticalAlignment = Alignment.CenterVertically) {
-                                Text(
-                                    text  = stringResource(R.string.skills_xp_each, bone.xpPerBone.toInt()),
-                                    style = MaterialTheme.typography.bodySmall,
-                                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                                )
-                                Spacer(Modifier.width(8.dp))
-                                Text(
-                                    text  = stringResource(R.string.crafting_owned, qty),
-                                    style = MaterialTheme.typography.labelSmall,
-                                    color = if (qty > 0) MaterialTheme.colorScheme.primary else dim,
-                                )
-                            }
+                            Text(
+                                text  = stringResource(R.string.skills_xp_each, bone.xpPerBone.toInt()),
+                                style = MaterialTheme.typography.bodySmall,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            )
+                            Text(
+                                text  = stringResource(R.string.crafting_owned, qty),
+                                style = MaterialTheme.typography.labelSmall,
+                                color = if (qty > 0) MaterialTheme.colorScheme.primary else dim,
+                            )
                         }
                         Text(stringResource(R.string.btn_select), style = MaterialTheme.typography.labelMedium, color = MaterialTheme.colorScheme.primary)
                     }

--- a/app/src/main/kotlin/com/fantasyidler/ui/screen/skills/RunecraftingSheet.kt
+++ b/app/src/main/kotlin/com/fantasyidler/ui/screen/skills/RunecraftingSheet.kt
@@ -145,6 +145,7 @@ internal fun RunecraftingSheet(
     BackHandler(enabled = selectedKey != null) { selectedKey = null }
     val selectedRune = selectedKey?.let { sheet.availableRunes[it] }
     var selectedAshKey by remember { mutableStateOf<String?>(null) }
+    val dim = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.38f)
 
     Column(
         modifier = Modifier
@@ -216,9 +217,14 @@ internal fun RunecraftingSheet(
                             }
                             val runeOwned = inventory[key] ?: 0
                             Text(
-                                text  = stringResource(R.string.skills_rune_desc, rune.xpPerRune.toInt(), rune.levelRequired) + "  •  " + stringResource(R.string.crafting_owned, runeOwned),
+                                text  = stringResource(R.string.skills_rune_desc, rune.xpPerRune.toInt(), rune.levelRequired),
                                 style = MaterialTheme.typography.bodySmall,
                                 color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            )
+                            Text(
+                                text  = stringResource(R.string.crafting_owned, runeOwned),
+                                style = MaterialTheme.typography.labelSmall,
+                                color = if (runeOwned > 0) MaterialTheme.colorScheme.primary else dim,
                             )
                         }
                         Text(
@@ -249,9 +255,15 @@ internal fun RunecraftingSheet(
             )
             val ownedRune = selectedKey?.let { inventory[it] } ?: 0
             Text(
-                text     = stringResource(R.string.skills_rune_selected, selectedRune.xpPerRune.toInt(), inventoryMax) + "  •  " + stringResource(R.string.crafting_owned, ownedRune),
+                text     = stringResource(R.string.skills_rune_selected, selectedRune.xpPerRune.toInt(), inventoryMax),
                 style    = MaterialTheme.typography.bodySmall,
                 color    = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.padding(horizontal = 16.dp, vertical = 4.dp),
+            )
+            Text(
+                text     = stringResource(R.string.crafting_owned, ownedRune),
+                style    = MaterialTheme.typography.labelSmall,
+                color    = if (ownedRune > 0) MaterialTheme.colorScheme.primary else dim,
                 modifier = Modifier.padding(horizontal = 16.dp, vertical = 4.dp),
             )
             Spacer(Modifier.height(12.dp))

--- a/app/src/main/res/value-es-rES/strings.xml
+++ b/app/src/main/res/value-es-rES/strings.xml
@@ -615,9 +615,8 @@
     <!-- Translator note: %1$d = prayer level -->
     <string name="skills_prayer_desc">Level %1$d  •  Entierra huesos o esparce cenizas para la oración. XP</string>
     <string name="skills_no_bones">No hay huesos ni cenizas en el inventario.</string>
-    <!-- Translator note: %1$d = XP per bone, %2$d = quantity in inventory -->
-    <string name="skills_bone_qty">%1$d XP cada  •  %2$d en inventario</string>
     <!-- Translator note: %1$d = XP per bone, %2$d = quantity available -->
+    <string name="skills_xp_each">%1$d XP cada</string>
     <string name="skills_bone_selected">%1$d XP cada  •  %2$d disponible</string>
     <!-- Translator note: %1$d = total XP -->
     <string name="skills_xp_total">+%1$d XP total</string> <!-- untranslated -->
@@ -658,6 +657,7 @@
     <string name="quest_legend_guild_daily">Guild daily</string> <!-- untranslated -->
     <string name="quest_legend_guild">Guild quest</string> <!-- untranslated -->
     <string name="quest_legend_quest">Quest</string> <!-- untranslated -->
+    <string name="quest_legend_gold_dot">Gold dot on skill icon: has an open daily, weekly, or guild daily quest.</string> <!-- untranslated -->
     <string name="quest_legend_notes">Dimmed icons can\'t be completed yet (missing level or materials). A small raised number means several quests of that type want the same thing.</string> <!-- untranslated -->
     <!-- Translator note: %1$d = quantity -->
     <string name="shop_qty_in_inv">×%1$d en inventario</string>

--- a/app/src/main/res/value-es-rES/strings.xml
+++ b/app/src/main/res/value-es-rES/strings.xml
@@ -657,7 +657,6 @@
     <string name="quest_legend_guild_daily">Guild daily</string> <!-- untranslated -->
     <string name="quest_legend_guild">Guild quest</string> <!-- untranslated -->
     <string name="quest_legend_quest">Quest</string> <!-- untranslated -->
-    <string name="quest_legend_gold_dot">Gold dot on skill icon: has an open daily, weekly, or guild daily quest.</string> <!-- untranslated -->
     <string name="quest_legend_notes">Dimmed icons can\'t be completed yet (missing level or materials). A small raised number means several quests of that type want the same thing.</string> <!-- untranslated -->
     <!-- Translator note: %1$d = quantity -->
     <string name="shop_qty_in_inv">×%1$d en inventario</string>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -615,9 +615,8 @@
     <!-- Translator note: %1$d = prayer level -->
     <string name="skills_prayer_desc">Level %1$d  •  Bury bones or scatter ashes for Prayer XP</string> <!-- untranslated -->
     <string name="skills_no_bones">No bones or ashes in inventory</string> <!-- untranslated -->
-    <!-- Translator note: %1$d = XP per bone, %2$d = quantity in inventory -->
-    <string name="skills_bone_qty">%1$d XP each  •  %2$d in inventory</string> <!-- untranslated -->
     <!-- Translator note: %1$d = XP per bone, %2$d = quantity available -->
+    <string name="skills_xp_each">%1$d XP each</string> <!-- untranslated -->
     <string name="skills_bone_selected">%1$d XP each  •  %2$d available</string> <!-- untranslated -->
     <!-- Translator note: %1$d = total XP -->
     <string name="skills_xp_total">+%1$d XP total</string> <!-- untranslated -->
@@ -658,6 +657,7 @@
     <string name="quest_legend_guild_daily">Guild daily</string> <!-- untranslated -->
     <string name="quest_legend_guild">Guild quest</string> <!-- untranslated -->
     <string name="quest_legend_quest">Quest</string> <!-- untranslated -->
+    <string name="quest_legend_gold_dot">Gold dot on skill icon: has an open daily, weekly, or guild daily quest.</string> <!-- untranslated -->
     <string name="quest_legend_notes">Dimmed icons can\'t be completed yet (missing level or materials). A small raised number means several quests of that type want the same thing.</string> <!-- untranslated -->
     <!-- Translator note: %1$d = quantity -->
     <string name="shop_qty_in_inv">×%1$d in inventory</string> <!-- untranslated -->

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -616,7 +616,6 @@
     <string name="skills_prayer_desc">Level %1$d  •  Bury bones or scatter ashes for Prayer XP</string> <!-- untranslated -->
     <string name="skills_no_bones">No bones or ashes in inventory</string> <!-- untranslated -->
     <!-- Translator note: %1$d = XP per bone, %2$d = quantity available -->
-    <string name="skills_xp_each">%1$d XP each</string> <!-- untranslated -->
     <string name="skills_bone_selected">%1$d XP each  •  %2$d available</string> <!-- untranslated -->
     <!-- Translator note: %1$d = total XP -->
     <string name="skills_xp_total">+%1$d XP total</string> <!-- untranslated -->
@@ -657,7 +656,6 @@
     <string name="quest_legend_guild_daily">Guild daily</string> <!-- untranslated -->
     <string name="quest_legend_guild">Guild quest</string> <!-- untranslated -->
     <string name="quest_legend_quest">Quest</string> <!-- untranslated -->
-    <string name="quest_legend_gold_dot">Gold dot on skill icon: has an open daily, weekly, or guild daily quest.</string> <!-- untranslated -->
     <string name="quest_legend_notes">Dimmed icons can\'t be completed yet (missing level or materials). A small raised number means several quests of that type want the same thing.</string> <!-- untranslated -->
     <!-- Translator note: %1$d = quantity -->
     <string name="shop_qty_in_inv">×%1$d in inventory</string> <!-- untranslated -->

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -657,7 +657,6 @@
     <string name="quest_legend_guild_daily">Gilden-Tagesquest</string>
     <string name="quest_legend_guild">Gildenquest</string>
     <string name="quest_legend_quest">Quest</string> <!-- untranslated -->
-    <string name="quest_legend_gold_dot">Gold dot on skill icon: has an open daily, weekly, or guild daily quest.</string>
     <string name="quest_legend_notes">Abgeblendete Symbole können noch nicht abgeschlossen werden (Level oder Materialien fehlen). Eine kleine hochgestellte Zahl bedeutet, dass mehrere Quests dieses Typs dasselbe Ziel haben.</string>
     <!-- Translator note: %1$d = quantity -->
     <string name="shop_qty_in_inv">×%1$d im Inventar</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -615,9 +615,8 @@
     <!-- Translator note: %1$d = prayer level -->
     <string name="skills_prayer_desc">Level %1$d  •  Knochen vergraben oder Asche verstreuen für Gebets-EP</string>
     <string name="skills_no_bones">Keine Knochen oder Asche im Inventar</string>
-    <!-- Translator note: %1$d = XP per bone, %2$d = quantity in inventory -->
-    <string name="skills_bone_qty">%1$d EP je  •  %2$d im Inventar</string>
     <!-- Translator note: %1$d = XP per bone, %2$d = quantity available -->
+    <string name="skills_xp_each">%1$d EP je</string>
     <string name="skills_bone_selected">%1$d EP je  •  %2$d verfügbar</string>
     <!-- Translator note: %1$d = total XP -->
     <string name="skills_xp_total">+%1$d EP gesamt</string>
@@ -658,6 +657,7 @@
     <string name="quest_legend_guild_daily">Gilden-Tagesquest</string>
     <string name="quest_legend_guild">Gildenquest</string>
     <string name="quest_legend_quest">Quest</string> <!-- untranslated -->
+    <string name="quest_legend_gold_dot">Gold dot on skill icon: has an open daily, weekly, or guild daily quest.</string>
     <string name="quest_legend_notes">Abgeblendete Symbole können noch nicht abgeschlossen werden (Level oder Materialien fehlen). Eine kleine hochgestellte Zahl bedeutet, dass mehrere Quests dieses Typs dasselbe Ziel haben.</string>
     <!-- Translator note: %1$d = quantity -->
     <string name="shop_qty_in_inv">×%1$d im Inventar</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -657,7 +657,6 @@
     <string name="quest_legend_guild_daily">Diaria del gremio</string>
     <string name="quest_legend_guild">Misión del gremio</string>
     <string name="quest_legend_quest">Misión</string>
-    <string name="quest_legend_gold_dot">Gold dot on skill icon: has an open daily, weekly, or guild daily quest.</string>
     <string name="quest_legend_notes">Los iconos atenuados aún no se pueden completar (falta nivel o materiales). Un pequeño número elevado indica que varias misiones de ese tipo piden lo mismo.</string>
     <!-- Translator note: %1$d = quantity -->
     <string name="shop_qty_in_inv">×%1$d en inventario</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -615,9 +615,8 @@
     <!-- Translator note: %1$d = prayer level -->
     <string name="skills_prayer_desc">Level %1$d  •  Entierra huesos o esparce cenizas para la oración. XP</string>
     <string name="skills_no_bones">No hay huesos ni cenizas en el inventario.</string>
-    <!-- Translator note: %1$d = XP per bone, %2$d = quantity in inventory -->
-    <string name="skills_bone_qty">%1$d XP cada  •  %2$d en inventario</string>
     <!-- Translator note: %1$d = XP per bone, %2$d = quantity available -->
+    <string name="skills_xp_each">%1$d XP cada</string>
     <string name="skills_bone_selected">%1$d XP cada  •  %2$d disponible</string>
     <!-- Translator note: %1$d = total XP -->
     <string name="skills_xp_total">+%1$d XP total</string> <!-- untranslated -->
@@ -658,6 +657,7 @@
     <string name="quest_legend_guild_daily">Diaria del gremio</string>
     <string name="quest_legend_guild">Misión del gremio</string>
     <string name="quest_legend_quest">Misión</string>
+    <string name="quest_legend_gold_dot">Gold dot on skill icon: has an open daily, weekly, or guild daily quest.</string>
     <string name="quest_legend_notes">Los iconos atenuados aún no se pueden completar (falta nivel o materiales). Un pequeño número elevado indica que varias misiones de ese tipo piden lo mismo.</string>
     <!-- Translator note: %1$d = quantity -->
     <string name="shop_qty_in_inv">×%1$d en inventario</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -658,7 +658,6 @@
     <string name="quest_legend_guild_daily">Quotidienne de guilde</string>
     <string name="quest_legend_guild">Quête de guilde</string>
     <string name="quest_legend_quest">Quête</string>
-    <string name="quest_legend_gold_dot">Gold dot on skill icon: has an open daily, weekly, or guild daily quest.</string>
     <string name="quest_legend_notes">Les icônes estompées ne peuvent pas encore être terminées (niveau ou matériaux manquants). Un petit chiffre en exposant indique que plusieurs quêtes de ce type visent la même chose.</string>
     <!-- Translator note: %1$d = quantity -->
     <string name="shop_qty_in_inv">×%1$d dans l\'inventaire</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -616,9 +616,8 @@
     <!-- Translator note: %1$d = prayer level -->
     <string name="skills_prayer_desc">Niv. %1$d  •  Enterrez des os ou dispersez des cendres pour XP en Prière</string>
     <string name="skills_no_bones">Aucun os ou cendres dans l\'inventaire</string>
-    <!-- Translator note: %1$d = XP per bone, %2$d = quantity in inventory -->
-    <string name="skills_bone_qty">%1$d XP par os  •  %2$d dans l\'inventaire</string>
     <!-- Translator note: %1$d = XP per bone, %2$d = quantity available -->
+    <string name="skills_xp_each">%1$d XP par os</string>
     <string name="skills_bone_selected">%1$d XP par os  •  %2$d disponibles</string>
     <!-- Translator note: %1$d = total XP -->
     <string name="skills_xp_total">+%1$d XP au total</string>
@@ -659,6 +658,7 @@
     <string name="quest_legend_guild_daily">Quotidienne de guilde</string>
     <string name="quest_legend_guild">Quête de guilde</string>
     <string name="quest_legend_quest">Quête</string>
+    <string name="quest_legend_gold_dot">Gold dot on skill icon: has an open daily, weekly, or guild daily quest.</string>
     <string name="quest_legend_notes">Les icônes estompées ne peuvent pas encore être terminées (niveau ou matériaux manquants). Un petit chiffre en exposant indique que plusieurs quêtes de ce type visent la même chose.</string>
     <!-- Translator note: %1$d = quantity -->
     <string name="shop_qty_in_inv">×%1$d dans l\'inventaire</string>

--- a/app/src/main/res/values-ga/strings.xml
+++ b/app/src/main/res/values-ga/strings.xml
@@ -644,7 +644,6 @@
     <string name="skills_prayer_desc">Level %1$d  •  Bury bones or scatter ashes for Prayer XP</string> <!-- untranslated -->
     <string name="skills_no_bones">No bones or ashes in inventory</string> <!-- untranslated -->
     <!-- Translator note: %1$d = XP per bone, %2$d = quantity available -->
-    <string name="skills_xp_each">%1$d XP each</string> <!-- untranslated -->
     <string name="skills_bone_selected">%1$d taithí gach aon  •  %2$d ar fáill</string>
     <!-- Translator note: %1$d = total XP -->
     <string name="skills_xp_total">+%1$d taithí iomlán</string>
@@ -685,7 +684,6 @@
     <string name="quest_legend_guild_daily">Guild daily</string> <!-- untranslated -->
     <string name="quest_legend_guild">Guild quest</string> <!-- untranslated -->
     <string name="quest_legend_quest">Quest</string> <!-- untranslated -->
-    <string name="quest_legend_gold_dot">Gold dot on skill icon: has an open daily, weekly, or guild daily quest.</string> <!-- untranslated -->
     <string name="quest_legend_notes">Dimmed icons can\'t be completed yet (missing level or materials). A small raised number means several quests of that type want the same thing.</string> <!-- untranslated -->
     <!-- Translator note: %1$d = quantity -->
     <string name="shop_qty_in_inv">×%1$d in inventory</string> <!-- untranslated -->

--- a/app/src/main/res/values-ga/strings.xml
+++ b/app/src/main/res/values-ga/strings.xml
@@ -643,9 +643,8 @@
     <!-- Translator note: %1$d = prayer level -->
     <string name="skills_prayer_desc">Level %1$d  •  Bury bones or scatter ashes for Prayer XP</string> <!-- untranslated -->
     <string name="skills_no_bones">No bones or ashes in inventory</string> <!-- untranslated -->
-    <!-- Translator note: %1$d = XP per bone, %2$d = quantity in inventory -->
-    <string name="skills_bone_qty">%1$d XP each  •  %2$d in inventory</string> <!-- untranslated -->
     <!-- Translator note: %1$d = XP per bone, %2$d = quantity available -->
+    <string name="skills_xp_each">%1$d XP each</string> <!-- untranslated -->
     <string name="skills_bone_selected">%1$d taithí gach aon  •  %2$d ar fáill</string>
     <!-- Translator note: %1$d = total XP -->
     <string name="skills_xp_total">+%1$d taithí iomlán</string>
@@ -686,6 +685,7 @@
     <string name="quest_legend_guild_daily">Guild daily</string> <!-- untranslated -->
     <string name="quest_legend_guild">Guild quest</string> <!-- untranslated -->
     <string name="quest_legend_quest">Quest</string> <!-- untranslated -->
+    <string name="quest_legend_gold_dot">Gold dot on skill icon: has an open daily, weekly, or guild daily quest.</string> <!-- untranslated -->
     <string name="quest_legend_notes">Dimmed icons can\'t be completed yet (missing level or materials). A small raised number means several quests of that type want the same thing.</string> <!-- untranslated -->
     <!-- Translator note: %1$d = quantity -->
     <string name="shop_qty_in_inv">×%1$d in inventory</string> <!-- untranslated -->

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -608,7 +608,6 @@
     <string name="skills_prayer_desc">Level %1$d  •  Bury bones or scatter ashes for Prayer XP</string> <!-- untranslated -->
     <string name="skills_no_bones">Tidak ada tulang atau abu di inventaris.</string>
     <!-- Translator note: %1$d = XP per bone, %2$d = quantity available -->
-    <string name="skills_xp_each">%1$d XP each</string> <!-- untranslated -->
     <string name="skills_bone_selected">%1$d XP each  •  %2$d available</string> <!-- untranslated -->
     <!-- Translator note: %1$d = total XP -->
     <string name="skills_xp_total">+%1$d XP total</string> <!-- untranslated -->
@@ -649,7 +648,6 @@
     <string name="quest_legend_guild_daily">Harian guild</string>
     <string name="quest_legend_guild">Quest guild</string>
     <string name="quest_legend_quest">Quest</string> <!-- untranslated -->
-    <string name="quest_legend_gold_dot">Gold dot on skill icon: has an open daily, weekly, or guild daily quest.</string> <!-- untranslated -->
     <string name="quest_legend_notes">Ikon redup belum bisa diselesaikan (level atau bahan kurang). Angka kecil di atas berarti beberapa quest jenis itu menginginkan hal yang sama.</string>
     <!-- Translator note: %1$d = quantity -->
     <string name="shop_qty_in_inv">×%1$d di inventaris</string>

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -607,9 +607,8 @@
     <!-- Translator note: %1$d = prayer level -->
     <string name="skills_prayer_desc">Level %1$d  •  Bury bones or scatter ashes for Prayer XP</string> <!-- untranslated -->
     <string name="skills_no_bones">Tidak ada tulang atau abu di inventaris.</string>
-    <!-- Translator note: %1$d = XP per bone, %2$d = quantity in inventory -->
-    <string name="skills_bone_qty">%1$d XP each  •  %2$d in inventory</string> <!-- untranslated -->
     <!-- Translator note: %1$d = XP per bone, %2$d = quantity available -->
+    <string name="skills_xp_each">%1$d XP each</string> <!-- untranslated -->
     <string name="skills_bone_selected">%1$d XP each  •  %2$d available</string> <!-- untranslated -->
     <!-- Translator note: %1$d = total XP -->
     <string name="skills_xp_total">+%1$d XP total</string> <!-- untranslated -->
@@ -650,6 +649,7 @@
     <string name="quest_legend_guild_daily">Harian guild</string>
     <string name="quest_legend_guild">Quest guild</string>
     <string name="quest_legend_quest">Quest</string> <!-- untranslated -->
+    <string name="quest_legend_gold_dot">Gold dot on skill icon: has an open daily, weekly, or guild daily quest.</string> <!-- untranslated -->
     <string name="quest_legend_notes">Ikon redup belum bisa diselesaikan (level atau bahan kurang). Angka kecil di atas berarti beberapa quest jenis itu menginginkan hal yang sama.</string>
     <!-- Translator note: %1$d = quantity -->
     <string name="shop_qty_in_inv">×%1$d di inventaris</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -657,7 +657,6 @@
     <string name="quest_legend_guild_daily">Giornaliera di gilda</string>
     <string name="quest_legend_guild">Missione di gilda</string>
     <string name="quest_legend_quest">Missione</string>
-    <string name="quest_legend_gold_dot">Gold dot on skill icon: has an open daily, weekly, or guild daily quest.</string>
     <string name="quest_legend_notes">Le icone attenuate non possono ancora essere completate (livello o materiali mancanti). Un piccolo numero in apice indica che più missioni di quel tipo richiedono la stessa cosa.</string>
     <!-- Translator note: %1$d = quantity -->
     <string name="shop_qty_in_inv">Hai ×%1$d</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -615,9 +615,8 @@
     <!-- Translator note: %1$d = prayer level -->
     <string name="skills_prayer_desc">Level %1$d  •  Seppellisci ossa o disperdi ceneri per XP Preghiera</string>
     <string name="skills_no_bones">Non hai ossa o ceneri con te</string>
-    <!-- Translator note: %1$d = XP per bone, %2$d = quantity in inventory -->
-    <string name="skills_bone_qty">%1$d XP ciascuno  •  ne hai %2$d</string>
     <!-- Translator note: %1$d = XP per bone, %2$d = quantity available -->
+    <string name="skills_xp_each">%1$d XP ciascuno</string>
     <string name="skills_bone_selected">%1$d XP ciascuno  •  %2$d disponibili</string>
     <!-- Translator note: %1$d = total XP -->
     <string name="skills_xp_total">+%1$d XP totali</string>
@@ -658,6 +657,7 @@
     <string name="quest_legend_guild_daily">Giornaliera di gilda</string>
     <string name="quest_legend_guild">Missione di gilda</string>
     <string name="quest_legend_quest">Missione</string>
+    <string name="quest_legend_gold_dot">Gold dot on skill icon: has an open daily, weekly, or guild daily quest.</string>
     <string name="quest_legend_notes">Le icone attenuate non possono ancora essere completate (livello o materiali mancanti). Un piccolo numero in apice indica che più missioni di quel tipo richiedono la stessa cosa.</string>
     <!-- Translator note: %1$d = quantity -->
     <string name="shop_qty_in_inv">Hai ×%1$d</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -615,9 +615,8 @@
     <!-- Translator note: %1$d = prayer level -->
     <string name="skills_prayer_desc">レベル %1$d  •  骨を埋葬するか灰を撒いて祈り経験値を獲得</string>
     <string name="skills_no_bones">インベントリに骨や灰がありません</string>
-    <!-- Translator note: %1$d = XP per bone, %2$d = quantity in inventory -->
-    <string name="skills_bone_qty">各 %1$d XP  •  所持数: %2$d</string>
     <!-- Translator note: %1$d = XP per bone, %2$d = quantity available -->
+    <string name="skills_xp_each">各 %1$d XP</string>
     <string name="skills_bone_selected">各 %1$d XP  •  使用可能: %2$d</string>
     <!-- Translator note: %1$d = total XP -->
     <string name="skills_xp_total">累計 +%1$d XP</string>
@@ -658,6 +657,7 @@
     <string name="quest_legend_guild_daily">ギルドデイリー</string>
     <string name="quest_legend_guild">ギルドクエスト</string>
     <string name="quest_legend_quest">クエスト</string>
+    <string name="quest_legend_gold_dot">Gold dot on skill icon: has an open daily, weekly, or guild daily quest.</string>
     <string name="quest_legend_notes">薄いアイコンはまだ達成できません（レベルや素材が不足）。小さな上付き数字は、同じ対象を求めるクエストがその種類に複数あることを示します。</string>
     <!-- Translator note: %1$d = quantity -->
     <string name="shop_qty_in_inv">インベントリ所持数: ×%1$d</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -657,7 +657,6 @@
     <string name="quest_legend_guild_daily">ギルドデイリー</string>
     <string name="quest_legend_guild">ギルドクエスト</string>
     <string name="quest_legend_quest">クエスト</string>
-    <string name="quest_legend_gold_dot">Gold dot on skill icon: has an open daily, weekly, or guild daily quest.</string>
     <string name="quest_legend_notes">薄いアイコンはまだ達成できません（レベルや素材が不足）。小さな上付き数字は、同じ対象を求めるクエストがその種類に複数あることを示します。</string>
     <!-- Translator note: %1$d = quantity -->
     <string name="shop_qty_in_inv">インベントリ所持数: ×%1$d</string>

--- a/app/src/main/res/values-lt/strings.xml
+++ b/app/src/main/res/values-lt/strings.xml
@@ -615,9 +615,8 @@
     <!-- Translator note: %1$d = prayer level -->
     <string name="skills_prayer_desc">Level %1$d  •  Bury bones or scatter ashes for Prayer XP</string> <!-- untranslated -->
     <string name="skills_no_bones">No bones or ashes in inventory</string> <!-- untranslated -->
-    <!-- Translator note: %1$d = XP per bone, %2$d = quantity in inventory -->
-    <string name="skills_bone_qty">%1$d XP each  •  %2$d in inventory</string> <!-- untranslated -->
     <!-- Translator note: %1$d = XP per bone, %2$d = quantity available -->
+    <string name="skills_xp_each">%1$d XP each</string> <!-- untranslated -->
     <string name="skills_bone_selected">%1$d XP each  •  %2$d available</string> <!-- untranslated -->
     <!-- Translator note: %1$d = total XP -->
     <string name="skills_xp_total">+%1$d XP total</string> <!-- untranslated -->
@@ -658,6 +657,7 @@
     <string name="quest_legend_guild_daily">Guild daily</string> <!-- untranslated -->
     <string name="quest_legend_guild">Guild quest</string> <!-- untranslated -->
     <string name="quest_legend_quest">Quest</string> <!-- untranslated -->
+    <string name="quest_legend_gold_dot">Gold dot on skill icon: has an open daily, weekly, or guild daily quest.</string> <!-- untranslated -->
     <string name="quest_legend_notes">Dimmed icons can\'t be completed yet (missing level or materials). A small raised number means several quests of that type want the same thing.</string> <!-- untranslated -->
     <!-- Translator note: %1$d = quantity -->
     <string name="shop_qty_in_inv">×%1$d in inventory</string> <!-- untranslated -->

--- a/app/src/main/res/values-lt/strings.xml
+++ b/app/src/main/res/values-lt/strings.xml
@@ -616,7 +616,6 @@
     <string name="skills_prayer_desc">Level %1$d  •  Bury bones or scatter ashes for Prayer XP</string> <!-- untranslated -->
     <string name="skills_no_bones">No bones or ashes in inventory</string> <!-- untranslated -->
     <!-- Translator note: %1$d = XP per bone, %2$d = quantity available -->
-    <string name="skills_xp_each">%1$d XP each</string> <!-- untranslated -->
     <string name="skills_bone_selected">%1$d XP each  •  %2$d available</string> <!-- untranslated -->
     <!-- Translator note: %1$d = total XP -->
     <string name="skills_xp_total">+%1$d XP total</string> <!-- untranslated -->
@@ -657,7 +656,6 @@
     <string name="quest_legend_guild_daily">Guild daily</string> <!-- untranslated -->
     <string name="quest_legend_guild">Guild quest</string> <!-- untranslated -->
     <string name="quest_legend_quest">Quest</string> <!-- untranslated -->
-    <string name="quest_legend_gold_dot">Gold dot on skill icon: has an open daily, weekly, or guild daily quest.</string> <!-- untranslated -->
     <string name="quest_legend_notes">Dimmed icons can\'t be completed yet (missing level or materials). A small raised number means several quests of that type want the same thing.</string> <!-- untranslated -->
     <!-- Translator note: %1$d = quantity -->
     <string name="shop_qty_in_inv">×%1$d in inventory</string> <!-- untranslated -->

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -615,9 +615,8 @@
     <!-- Translator note: %1$d = prayer level -->
     <string name="skills_prayer_desc">Lvl %1$d  •  Begraaf botten of verstrooi as voor Gebeds XP</string>
     <string name="skills_no_bones">Geen botten of as in inventaris</string>
-    <!-- Translator note: %1$d = XP per bone, %2$d = quantity in inventory -->
-    <string name="skills_bone_qty">%1$d XP per stuk  •  %2$d in inventaris</string>
     <!-- Translator note: %1$d = XP per bone, %2$d = quantity available -->
+    <string name="skills_xp_each">%1$d XP per stuk</string>
     <string name="skills_bone_selected">%1$d XP per stuk  •  %2$d beschikbaar</string>
     <!-- Translator note: %1$d = total XP -->
     <string name="skills_xp_total">+%1$d XP totaal</string>
@@ -658,6 +657,7 @@
     <string name="quest_legend_guild_daily">Dagelijkse gildequest</string>
     <string name="quest_legend_guild">Gildequest</string>
     <string name="quest_legend_quest">Quest</string> <!-- untranslated -->
+    <string name="quest_legend_gold_dot">Gold dot on skill icon: has an open daily, weekly, or guild daily quest.</string>
     <string name="quest_legend_notes">Gedimde pictogrammen kunnen nog niet voltooid worden (level of materialen ontbreken). Een klein verhoogd cijfer betekent dat meerdere quests van dat type hetzelfde willen.</string>
     <!-- Translator note: %1$d = quantity -->
     <string name="shop_qty_in_inv">×%1$d in inventaris</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -657,7 +657,6 @@
     <string name="quest_legend_guild_daily">Dagelijkse gildequest</string>
     <string name="quest_legend_guild">Gildequest</string>
     <string name="quest_legend_quest">Quest</string> <!-- untranslated -->
-    <string name="quest_legend_gold_dot">Gold dot on skill icon: has an open daily, weekly, or guild daily quest.</string>
     <string name="quest_legend_notes">Gedimde pictogrammen kunnen nog niet voltooid worden (level of materialen ontbreken). Een klein verhoogd cijfer betekent dat meerdere quests van dat type hetzelfde willen.</string>
     <!-- Translator note: %1$d = quantity -->
     <string name="shop_qty_in_inv">×%1$d in inventaris</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -673,7 +673,6 @@
     <string name="quest_legend_guild_daily">Dzienne gildii</string>
     <string name="quest_legend_guild">Zadanie gildii</string>
     <string name="quest_legend_quest">Zadanie</string>
-    <string name="quest_legend_gold_dot">Gold dot on skill icon: has an open daily, weekly, or guild daily quest.</string>
     <string name="quest_legend_notes">Przyciemnione ikony nie mogą być jeszcze ukończone (brak poziomu lub materiałów). Mała podniesiona cyfra oznacza, że kilka zadań tego typu dotyczy tego samego.</string>
     <!-- Translator note: %1$d = quantity -->
     <string name="shop_qty_in_inv">×%1$d w ekwipunku</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -631,9 +631,8 @@
     <!-- Translator note: %1$d = prayer level -->
     <string name="skills_prayer_desc">Poziom %1$d  •  Zakop kości lub rozsyp popioły, by zdobyć XP Modlitwy</string>
     <string name="skills_no_bones">Brak kości lub popiołów w ekwipunku</string>
-    <!-- Translator note: %1$d = XP per bone, %2$d = quantity in inventory -->
-    <string name="skills_bone_qty">%1$d XP każda  •  %2$d w ekwipunku</string>
     <!-- Translator note: %1$d = XP per bone, %2$d = quantity available -->
+    <string name="skills_xp_each">%1$d XP każda</string>
     <string name="skills_bone_selected">%1$d XP każda  •  %2$d dostępnych</string>
     <!-- Translator note: %1$d = total XP -->
     <string name="skills_xp_total">+%1$d XP łącznie</string>
@@ -674,6 +673,7 @@
     <string name="quest_legend_guild_daily">Dzienne gildii</string>
     <string name="quest_legend_guild">Zadanie gildii</string>
     <string name="quest_legend_quest">Zadanie</string>
+    <string name="quest_legend_gold_dot">Gold dot on skill icon: has an open daily, weekly, or guild daily quest.</string>
     <string name="quest_legend_notes">Przyciemnione ikony nie mogą być jeszcze ukończone (brak poziomu lub materiałów). Mała podniesiona cyfra oznacza, że kilka zadań tego typu dotyczy tego samego.</string>
     <!-- Translator note: %1$d = quantity -->
     <string name="shop_qty_in_inv">×%1$d w ekwipunku</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -615,9 +615,8 @@
     <!-- Translator note: %1$d = prayer level -->
     <string name="skills_prayer_desc">Nível %1$d  •  Enterre ossos ou espalhe cinzas para ganhar XP de Oração</string>
     <string name="skills_no_bones">Nenhum osso ou cinza no inventário</string>
-    <!-- Translator note: %1$d = XP per bone, %2$d = quantity in inventory -->
-    <string name="skills_bone_qty">%1$d XP cada  •  %2$d no inventário</string>
     <!-- Translator note: %1$d = XP per bone, %2$d = quantity available -->
+    <string name="skills_xp_each">%1$d XP cada</string>
     <string name="skills_bone_selected">%1$d XP cada  •  %2$d disponíveis</string>
     <!-- Translator note: %1$d = total XP -->
     <string name="skills_xp_total">+%1$d XP no total</string>
@@ -658,6 +657,7 @@
     <string name="quest_legend_guild_daily">Diária da guilda</string>
     <string name="quest_legend_guild">Missão da guilda</string>
     <string name="quest_legend_quest">Missão</string>
+    <string name="quest_legend_gold_dot">Gold dot on skill icon: has an open daily, weekly, or guild daily quest.</string>
     <string name="quest_legend_notes">Ícones esmaecidos ainda não podem ser concluídos (falta nível ou materiais). Um pequeno número elevado indica que várias missões desse tipo pedem a mesma coisa.</string>
     <!-- Translator note: %1$d = quantity -->
     <string name="shop_qty_in_inv">×%1$d no inventário</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -657,7 +657,6 @@
     <string name="quest_legend_guild_daily">Diária da guilda</string>
     <string name="quest_legend_guild">Missão da guilda</string>
     <string name="quest_legend_quest">Missão</string>
-    <string name="quest_legend_gold_dot">Gold dot on skill icon: has an open daily, weekly, or guild daily quest.</string>
     <string name="quest_legend_notes">Ícones esmaecidos ainda não podem ser concluídos (falta nível ou materiais). Um pequeno número elevado indica que várias missões desse tipo pedem a mesma coisa.</string>
     <!-- Translator note: %1$d = quantity -->
     <string name="shop_qty_in_inv">×%1$d no inventário</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -673,7 +673,6 @@
     <string name="quest_legend_guild_daily">Ежедневное задание гильдии</string>
     <string name="quest_legend_guild">Задание гильдии</string>
     <string name="quest_legend_quest">Задание</string>
-    <string name="quest_legend_gold_dot">Gold dot on skill icon: has an open daily, weekly, or guild daily quest.</string>
     <string name="quest_legend_notes">Тусклые значки пока нельзя выполнить (не хватает уровня или материалов). Маленькая надстрочная цифра означает, что несколько заданий этого типа требуют одного и того же.</string>
     <!-- Translator note: %1$d = quantity -->
     <string name="shop_qty_in_inv">×%1$d в инвентаре</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -631,9 +631,8 @@
     <!-- Translator note: %1$d = prayer level -->
     <string name="skills_prayer_desc">Уровень %1$d  •  Захороните кости или рассейте прах для опыта молитвы</string>
     <string name="skills_no_bones">Нет костей или праха в инвентаре</string>
-    <!-- Translator note: %1$d = XP per bone, %2$d = quantity in inventory -->
-    <string name="skills_bone_qty">%1$d опыта за шт.  •  %2$d в инвентаре</string>
     <!-- Translator note: %1$d = XP per bone, %2$d = quantity available -->
+    <string name="skills_xp_each">%1$d опыта за шт.</string>
     <string name="skills_bone_selected">%1$d опыта за шт.  •  %2$d доступно</string>
     <!-- Translator note: %1$d = total XP -->
     <string name="skills_xp_total">+%1$d опыта всего</string>
@@ -674,6 +673,7 @@
     <string name="quest_legend_guild_daily">Ежедневное задание гильдии</string>
     <string name="quest_legend_guild">Задание гильдии</string>
     <string name="quest_legend_quest">Задание</string>
+    <string name="quest_legend_gold_dot">Gold dot on skill icon: has an open daily, weekly, or guild daily quest.</string>
     <string name="quest_legend_notes">Тусклые значки пока нельзя выполнить (не хватает уровня или материалов). Маленькая надстрочная цифра означает, что несколько заданий этого типа требуют одного и того же.</string>
     <!-- Translator note: %1$d = quantity -->
     <string name="shop_qty_in_inv">×%1$d в инвентаре</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -657,7 +657,6 @@
     <string name="quest_legend_guild_daily">Lonca günlük görevi</string>
     <string name="quest_legend_guild">Lonca görevi</string>
     <string name="quest_legend_quest">Görev</string>
-    <string name="quest_legend_gold_dot">Gold dot on skill icon: has an open daily, weekly, or guild daily quest.</string>
     <string name="quest_legend_notes">Soluk simgeler henüz tamamlanamaz (seviye veya malzeme eksik). Küçük üst simge sayı, aynı hedefi isteyen birden fazla görev olduğunu gösterir.</string>
     <!-- Translator note: %1$d = quantity -->
     <string name="shop_qty_in_inv">Envanterde ×%1$d adet</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -615,9 +615,8 @@
     <!-- Translator note: %1$d = prayer level -->
     <string name="skills_prayer_desc">Seviye %1$d  •  Dua XP\'si için kemikleri göm veya külleri saç</string>
     <string name="skills_no_bones">Envanterde kemik veya kül yok</string>
-    <!-- Translator note: %1$d = XP per bone, %2$d = quantity in inventory -->
-    <string name="skills_bone_qty">Tanesi %1$d XP  •  Envanterde %2$d adet</string>
     <!-- Translator note: %1$d = XP per bone, %2$d = quantity available -->
+    <string name="skills_xp_each">Tanesi %1$d XP</string>
     <string name="skills_bone_selected">Tanesi %1$d XP  •  %2$d adet mevcut</string>
     <!-- Translator note: %1$d = total XP -->
     <string name="skills_xp_total">Toplam +%1$d XP</string>
@@ -658,6 +657,7 @@
     <string name="quest_legend_guild_daily">Lonca günlük görevi</string>
     <string name="quest_legend_guild">Lonca görevi</string>
     <string name="quest_legend_quest">Görev</string>
+    <string name="quest_legend_gold_dot">Gold dot on skill icon: has an open daily, weekly, or guild daily quest.</string>
     <string name="quest_legend_notes">Soluk simgeler henüz tamamlanamaz (seviye veya malzeme eksik). Küçük üst simge sayı, aynı hedefi isteyen birden fazla görev olduğunu gösterir.</string>
     <!-- Translator note: %1$d = quantity -->
     <string name="shop_qty_in_inv">Envanterde ×%1$d adet</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -615,9 +615,8 @@
     <!-- Translator note: %1$d = prayer level -->
     <string name="skills_prayer_desc">Level %1$d  •  Bury bones or scatter ashes for Prayer XP</string> <!-- untranslated -->
     <string name="skills_no_bones">No bones or ashes in inventory</string> <!-- untranslated -->
-    <!-- Translator note: %1$d = XP per bone, %2$d = quantity in inventory -->
-    <string name="skills_bone_qty">%1$d XP each  •  %2$d in inventory</string> <!-- untranslated -->
     <!-- Translator note: %1$d = XP per bone, %2$d = quantity available -->
+    <string name="skills_xp_each">%1$d XP each</string> <!-- untranslated -->
     <string name="skills_bone_selected">%1$d XP each  •  %2$d available</string> <!-- untranslated -->
     <!-- Translator note: %1$d = total XP -->
     <string name="skills_xp_total">+%1$d XP total</string> <!-- untranslated -->
@@ -658,6 +657,7 @@
     <string name="quest_legend_guild_daily">Guild daily</string> <!-- untranslated -->
     <string name="quest_legend_guild">Guild quest</string> <!-- untranslated -->
     <string name="quest_legend_quest">Quest</string> <!-- untranslated -->
+    <string name="quest_legend_gold_dot">Gold dot on skill icon: has an open daily, weekly, or guild daily quest.</string> <!-- untranslated -->
     <string name="quest_legend_notes">Dimmed icons can\'t be completed yet (missing level or materials). A small raised number means several quests of that type want the same thing.</string> <!-- untranslated -->
     <!-- Translator note: %1$d = quantity -->
     <string name="shop_qty_in_inv">×%1$d in inventory</string> <!-- untranslated -->

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -616,7 +616,6 @@
     <string name="skills_prayer_desc">Level %1$d  •  Bury bones or scatter ashes for Prayer XP</string> <!-- untranslated -->
     <string name="skills_no_bones">No bones or ashes in inventory</string> <!-- untranslated -->
     <!-- Translator note: %1$d = XP per bone, %2$d = quantity available -->
-    <string name="skills_xp_each">%1$d XP each</string> <!-- untranslated -->
     <string name="skills_bone_selected">%1$d XP each  •  %2$d available</string> <!-- untranslated -->
     <!-- Translator note: %1$d = total XP -->
     <string name="skills_xp_total">+%1$d XP total</string> <!-- untranslated -->
@@ -657,7 +656,6 @@
     <string name="quest_legend_guild_daily">Guild daily</string> <!-- untranslated -->
     <string name="quest_legend_guild">Guild quest</string> <!-- untranslated -->
     <string name="quest_legend_quest">Quest</string> <!-- untranslated -->
-    <string name="quest_legend_gold_dot">Gold dot on skill icon: has an open daily, weekly, or guild daily quest.</string> <!-- untranslated -->
     <string name="quest_legend_notes">Dimmed icons can\'t be completed yet (missing level or materials). A small raised number means several quests of that type want the same thing.</string> <!-- untranslated -->
     <!-- Translator note: %1$d = quantity -->
     <string name="shop_qty_in_inv">×%1$d in inventory</string> <!-- untranslated -->

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -657,7 +657,7 @@
     <string name="quest_legend_guild_daily">Guild daily</string>
     <string name="quest_legend_guild">Guild quest</string>
     <string name="quest_legend_quest">Quest</string>
-    <string name="quest_legend_gold_dot">Gold dot on skill icon: has an open daily, weekly, or guild daily quest.</string>
+    <string name="quest_legend_gold_dot">Timed quest is available.</string>
     <string name="quest_legend_notes">Dimmed icons can\'t be completed yet (missing level or materials). A small raised number means several quests of that type want the same thing.</string>
     <!-- Translator note: %1$d = quantity -->
     <string name="shop_qty_in_inv">×%1$d in inventory</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -615,8 +615,7 @@
     <!-- Translator note: %1$d = prayer level -->
     <string name="skills_prayer_desc">Level %1$d  •  Bury bones or scatter ashes for Prayer XP</string>
     <string name="skills_no_bones">No bones or ashes in inventory</string>
-    <!-- Translator note: %1$d = XP per bone, %2$d = quantity in inventory -->
-    <string name="skills_bone_qty">%1$d XP each  •  %2$d in inventory</string>
+    <string name="skills_xp_each">%1$d XP each</string>
     <!-- Translator note: %1$d = XP per bone, %2$d = quantity available -->
     <string name="skills_bone_selected">%1$d XP each  •  %2$d available</string>
     <!-- Translator note: %1$d = total XP -->
@@ -658,6 +657,7 @@
     <string name="quest_legend_guild_daily">Guild daily</string>
     <string name="quest_legend_guild">Guild quest</string>
     <string name="quest_legend_quest">Quest</string>
+    <string name="quest_legend_gold_dot">Gold dot on skill icon: has an open daily, weekly, or guild daily quest.</string>
     <string name="quest_legend_notes">Dimmed icons can\'t be completed yet (missing level or materials). A small raised number means several quests of that type want the same thing.</string>
     <!-- Translator note: %1$d = quantity -->
     <string name="shop_qty_in_inv">×%1$d in inventory</string>


### PR DESCRIPTION
## Before submitting

- [x] I've tested any changes with the appropriate tests (eg. Unit tests, validation scripts)
- [x] I've pulled and merged the latest changes from the repository

## Summary

Add "Owned: N" count to all skill-sheet rows (Mining, Fishing, Woodcutting, Firemaking, Runecrafting, Prayer) and explain the gold dot on skill icons in the Skills tab legend.

## Related issue(s) or discussion(s)

N/A

## Changelog

- Add "Owned: N" quantity display to Mining, Fishing, Woodcutting, Firemaking, Runecrafting, and Prayer skill sheet rows
- Explain gold dot icon indicator in Skills tab legend
- Update localization strings across 14 supported locales

## Anything else?

N/A