### PR TITLE
bugfix: disable slayer foretell next task when no active slayer task

### DIFF
--- a/app/src/main/kotlin/com/fantasyidler/ui/screen/SlayerScreen.kt
+++ b/app/src/main/kotlin/com/fantasyidler/ui/screen/SlayerScreen.kt
@@ -241,6 +241,7 @@ fun SlayerScreen(
                 inventory            = state.inventory,
                 queueSize            = state.queueSize,
                 maxQueueSize         = state.maxQueueSize,
+                hasActiveTask        = state.activeTask != null,
                 onForetell           = viewModel::foretellTask,
                 onQueueTask          = viewModel::queueForetelledTaskDungeon,
             )
@@ -418,6 +419,7 @@ private fun ForetellSection(
     inventory: Map<String, Int>,
     queueSize: Int,
     maxQueueSize: Int,
+    hasActiveTask: Boolean,
     onForetell: () -> Unit,
     onQueueTask: (SlayerTask) -> Unit,
 ) {
@@ -473,6 +475,7 @@ private fun ForetellSection(
             if (foretelledTasks.size < 3) {
                 Button(
                     onClick  = onForetell,
+                    enabled  = hasActiveTask,
                     modifier = Modifier.fillMaxWidth(),
                 ) {
                     Text(stringResource(R.string.slayer_foretell_btn, nextCostUnits))


### PR DESCRIPTION
## Before submitting

- [x] I've tested any changes with the appropriate tests (eg. Unit tests, validation scripts)
   - [ ] Waiting for #1373 to be merged to fix CI errors
- [x] I've pulled and merged the latest changes from the repository

## Summary
🐛 Bug found: Users should not be able to spend bones to get the next slayer task when there are no active task. This just disables it for now so they don't waste bones. Honestly, we can merge these 2 buttons into one, but could be something for the future, I might look into improving the Slayer UI, just wanted to clear this bug first. 

- Disable button to foretell next task when there is no active task.

## Demo
When there is still active slayer task
<img width="501" height="813" alt="image" src="https://github.com/user-attachments/assets/e08308a1-544e-42ac-8e17-f8c27e7b1122" />

When there is no active slayer task
<img width="546" height="739" alt="image" src="https://github.com/user-attachments/assets/7f2b377f-5b4a-4b13-9014-a90699f6eaca" />


## Changelog

- Disable foretell next slayer task button when there is no active task.


## Anything else?

