### PR TITLE
feat: add warning for xp lamps

### DIFF
--- a/app/src/main/kotlin/com/fantasyidler/ui/components/LampSkillDialog.kt
+++ b/app/src/main/kotlin/com/fantasyidler/ui/components/LampSkillDialog.kt
@@ -1,0 +1,123 @@
+package com.fantasyidler.ui.components
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import com.fantasyidler.R
+import com.fantasyidler.data.model.Skills
+import com.fantasyidler.simulator.XpTable
+import com.fantasyidler.util.GameStrings
+
+@Composable
+fun LampSkillDialog(
+    skillLevels: Map<String, Int>,
+    skillXp: Map<String, Long>,
+    sessionXpGain: Long,
+    onSkillSelected: (String) -> Unit,
+    onDismiss: () -> Unit,
+) {
+    val context = LocalContext.current
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text(stringResource(R.string.slayer_lamp_pick_skill)) },
+        text = {
+            Column(
+                modifier            = Modifier.verticalScroll(rememberScrollState()),
+                verticalArrangement = Arrangement.spacedBy(4.dp),
+            ) {
+                Skills.ALL.forEach { skillKey ->
+                    val level = skillLevels[skillKey] ?: 1
+                    val xp    = skillXp[skillKey] ?: 0L
+                    val name  = GameStrings.skillName(context, skillKey)
+                    Surface(
+                        onClick  = { onSkillSelected(skillKey) },
+                        shape    = RoundedCornerShape(8.dp),
+                        color    = MaterialTheme.colorScheme.surface,
+                        modifier = Modifier.fillMaxWidth(),
+                    ) {
+                        Column(
+                            modifier            = Modifier.padding(horizontal = 12.dp, vertical = 10.dp),
+                            verticalArrangement = Arrangement.spacedBy(2.dp),
+                        ) {
+                            Row(
+                                modifier = Modifier.fillMaxWidth(),
+                                horizontalArrangement = Arrangement.SpaceBetween,
+                                verticalAlignment = Alignment.CenterVertically,
+                            ) {
+                                Text(name, style = MaterialTheme.typography.bodyMedium)
+                                Text(
+                                    text = stringResource(R.string.slayer_level_label, level),
+                                    style = MaterialTheme.typography.bodySmall,
+                                    color = MaterialTheme.colorScheme.primary,
+                                )
+                            }
+                            Row(
+                                modifier = Modifier.fillMaxWidth(),
+                                horizontalArrangement = Arrangement.SpaceBetween,
+                                verticalAlignment = Alignment.CenterVertically,
+                            ) {
+                                val endXp = xp + sessionXpGain
+                                val isOverMax = sessionXpGain > 0L && endXp > XpTable.xpForLevel(99)
+                                val xpLineText = remember(skillKey, skillXp, sessionXpGain) {
+                                    if (sessionXpGain <= 0L) null
+                                    else {
+                                        val levelBefore = XpTable.levelForXp(xp)
+                                        val levelAfter = XpTable.levelForXp(endXp)
+                                        val levelGain = levelAfter - levelBefore
+                                        val pct = (XpTable.progressFraction(endXp) * 100).toInt()
+                                        buildString {
+                                            append("→  Lv $levelAfter")
+                                            if (levelGain > 0) append(" (+$levelGain, $pct%)")
+                                            else append(" ($pct%)")
+                                        }
+                                    }
+                                }
+                                if (isOverMax) {
+                                    Text(
+                                        text = stringResource(R.string.slayer_lamp_max_level_warning),
+                                        style = MaterialTheme.typography.labelSmall,
+                                        color = MaterialTheme.colorScheme.error,
+                                    )
+                                } else {
+                                    Spacer(Modifier)
+                                }
+
+                                if (xpLineText != null) {
+                                    Text(
+                                        text = xpLineText,
+                                        style = MaterialTheme.typography.labelSmall,
+                                        color = MaterialTheme.colorScheme.onSecondaryContainer.copy(alpha = 0.7f),
+                                    )
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        confirmButton = {},
+        dismissButton = {
+            TextButton(onClick = onDismiss) {
+                Text(stringResource(R.string.btn_cancel))
+            }
+        },
+    )
+}

--- a/app/src/main/kotlin/com/fantasyidler/ui/screen/CarnivalScreen.kt
+++ b/app/src/main/kotlin/com/fantasyidler/ui/screen/CarnivalScreen.kt
@@ -23,7 +23,6 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
-import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -41,7 +40,6 @@ import androidx.compose.material3.Surface
 import androidx.compose.material3.Tab
 import androidx.compose.material3.TabRow
 import androidx.compose.material3.Text
-import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -68,6 +66,7 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import com.fantasyidler.R
 import com.fantasyidler.data.json.CarnivalPrize
 import com.fantasyidler.data.model.Skills
+import com.fantasyidler.ui.components.LampSkillDialog
 import com.fantasyidler.ui.viewmodel.ActiveGameState
 import com.fantasyidler.ui.viewmodel.AppraisalQuad
 import com.fantasyidler.ui.viewmodel.CarnivalViewModel
@@ -128,9 +127,10 @@ fun CarnivalScreen(
     state.pendingLampPrizeKey?.let { prizeKey ->
         val prize = viewModel.prizesMap[prizeKey]
         if (prize != null) {
-            LampSkillPickerDialog(
-                xpAmount        = prize.xpAmount,
+            LampSkillDialog(
                 skillLevels     = state.skillLevels,
+                skillXp         = state.skillXp,
+                sessionXpGain   = prize.xpAmount,
                 onSkillSelected = viewModel::redeemLamp,
                 onDismiss       = viewModel::dismissLampPicker,
             )
@@ -1068,52 +1068,3 @@ private fun PrizeRow(
     }
 }
 
-// ── Lamp skill picker ──────────────────────────────────────────────────────────
-
-@Composable
-private fun LampSkillPickerDialog(
-    xpAmount: Long,
-    skillLevels: Map<String, Int>,
-    onSkillSelected: (String) -> Unit,
-    onDismiss: () -> Unit,
-) {
-    val context = LocalContext.current
-    AlertDialog(
-        onDismissRequest = onDismiss,
-        title = { Text(stringResource(R.string.slayer_lamp_pick_skill)) },
-        text = {
-            Column(
-                modifier            = Modifier.verticalScroll(rememberScrollState()),
-                verticalArrangement = Arrangement.spacedBy(4.dp),
-            ) {
-                Skills.ALL.forEach { skillKey ->
-                    val level = skillLevels[skillKey] ?: 1
-                    val name  = GameStrings.skillName(context, skillKey)
-                    Surface(
-                        onClick  = { onSkillSelected(skillKey) },
-                        shape    = RoundedCornerShape(8.dp),
-                        color    = MaterialTheme.colorScheme.surface,
-                        modifier = Modifier.fillMaxWidth(),
-                    ) {
-                        Row(
-                            modifier              = Modifier
-                                .fillMaxWidth()
-                                .padding(horizontal = 12.dp, vertical = 10.dp),
-                            horizontalArrangement = Arrangement.SpaceBetween,
-                            verticalAlignment     = Alignment.CenterVertically,
-                        ) {
-                            Text(name, style = MaterialTheme.typography.bodyMedium)
-                            Text(
-                                text  = stringResource(R.string.slayer_level_label, level),
-                                style = MaterialTheme.typography.bodySmall,
-                                color = MaterialTheme.colorScheme.primary,
-                            )
-                        }
-                    }
-                }
-            }
-        },
-        confirmButton = {},
-        dismissButton = { TextButton(onClick = onDismiss) { Text(stringResource(R.string.btn_cancel)) } },
-    )
-}

--- a/app/src/main/kotlin/com/fantasyidler/ui/screen/SlayerScreen.kt
+++ b/app/src/main/kotlin/com/fantasyidler/ui/screen/SlayerScreen.kt
@@ -19,7 +19,6 @@ import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.WindowInsetsSides
 import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.safeDrawing
-import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.BottomSheetDefaults
 import androidx.compose.material3.Button
 import androidx.compose.material3.CircularProgressIndicator
@@ -50,10 +49,9 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.compose.ui.platform.LocalContext
 import com.fantasyidler.R
 import com.fantasyidler.data.json.EquipmentData
-import com.fantasyidler.data.model.Skills
 import com.fantasyidler.data.model.SlayerTask
 import com.fantasyidler.util.GameStrings
-import com.fantasyidler.ui.viewmodel.PendingLamp
+import com.fantasyidler.ui.components.LampSkillDialog
 import com.fantasyidler.ui.viewmodel.SlayerViewModel
 import com.fantasyidler.ui.viewmodel.xpProgressFraction
 import com.fantasyidler.ui.theme.ScaledSheetContent
@@ -284,11 +282,11 @@ fun SlayerScreen(
             )
         }
 
-        val pendingLamp = state.pendingLamp
-        if (pendingLamp != null) {
-            LampSkillPickerDialog(
-                pendingLamp     = pendingLamp,
+        state.pendingLamp?.let { pendingLamp ->
+            LampSkillDialog(
                 skillLevels     = state.skillLevels,
+                skillXp         = state.skillXp,
+                sessionXpGain   = pendingLamp.xpAmount,
                 onSkillSelected = viewModel::selectLampSkill,
                 onDismiss       = viewModel::dismissLampPicker,
             )
@@ -561,58 +559,6 @@ private fun ShopRow(
             }
         }
     }
-}
-
-@Composable
-private fun LampSkillPickerDialog(
-    pendingLamp: PendingLamp,
-    skillLevels: Map<String, Int>,
-    onSkillSelected: (String) -> Unit,
-    onDismiss: () -> Unit,
-) {
-    val context = LocalContext.current
-    AlertDialog(
-        onDismissRequest = onDismiss,
-        title = { Text(stringResource(R.string.slayer_lamp_pick_skill)) },
-        text = {
-            Column(
-                modifier            = Modifier.verticalScroll(rememberScrollState()),
-                verticalArrangement = Arrangement.spacedBy(4.dp),
-            ) {
-                Skills.ALL.forEach { skillKey ->
-                    val level = skillLevels[skillKey] ?: 1
-                    val name  = GameStrings.skillName(context, skillKey)
-                    Surface(
-                        onClick  = { onSkillSelected(skillKey) },
-                        shape    = RoundedCornerShape(8.dp),
-                        color    = MaterialTheme.colorScheme.surface,
-                        modifier = Modifier.fillMaxWidth(),
-                    ) {
-                        Row(
-                            modifier              = Modifier
-                                .fillMaxWidth()
-                                .padding(horizontal = 12.dp, vertical = 10.dp),
-                            horizontalArrangement = Arrangement.SpaceBetween,
-                            verticalAlignment     = Alignment.CenterVertically,
-                        ) {
-                            Text(name, style = MaterialTheme.typography.bodyMedium)
-                            Text(
-                                text  = stringResource(R.string.slayer_level_label, level),
-                                style = MaterialTheme.typography.bodySmall,
-                                color = MaterialTheme.colorScheme.primary,
-                            )
-                        }
-                    }
-                }
-            }
-        },
-        confirmButton = {},
-        dismissButton = {
-            TextButton(onClick = onDismiss) {
-                Text(stringResource(R.string.btn_cancel))
-            }
-        },
-    )
 }
 
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalLayoutApi::class)

--- a/app/src/main/kotlin/com/fantasyidler/ui/viewmodel/CarnivalViewModel.kt
+++ b/app/src/main/kotlin/com/fantasyidler/ui/viewmodel/CarnivalViewModel.kt
@@ -57,6 +57,7 @@ data class CarnivalUiState(
     val selectedTab: Int = 0,
     val tabInitialized: Boolean = false,
     val skillLevels: Map<String, Int> = emptyMap(),
+    val skillXp: Map<String, Long> = emptyMap(),
     val tierBonus: Float = 0f,
     val queueSize: Int = 0,
     val maxQueueSize: Int = 3,
@@ -165,6 +166,7 @@ class CarnivalViewModel @Inject constructor(
             val inventory: Map<String, Int> = json.decodeFromString(player.inventory)
             val flags: PlayerFlags = json.decodeFromString(player.flags)
             val levels: Map<String, Int> = json.decodeFromString(player.skillLevels)
+            val xpMap: Map<String, Long> = json.decodeFromString(player.skillXp)
             val pets: List<com.fantasyidler.data.model.OwnedPet> = try { json.decodeFromString(player.pets) } catch (_: Exception) { emptyList() }
             val ownedPetIds = pets.map { it.id }.toSet()
             val ownedPrizeKeys = prizes
@@ -179,6 +181,7 @@ class CarnivalViewModel @Inject constructor(
                 isLoading           = false,
                 ticketBalance       = inventory["carnival_ticket"] ?: 0,
                 skillLevels         = levels,
+                skillXp             = xpMap,
                 tierBonus           = townRepo.idleTicketBonusChance(flags),
                 queueSize           = flags.sessionQueue.size,
                 maxQueueSize        = playerRepo.maxQueueSize(flags),

--- a/app/src/main/kotlin/com/fantasyidler/ui/viewmodel/SlayerViewModel.kt
+++ b/app/src/main/kotlin/com/fantasyidler/ui/viewmodel/SlayerViewModel.kt
@@ -53,6 +53,7 @@ data class SlayerUiState(
     val unlockedDungeons: Set<String> = emptySet(),
     val inventory: Map<String, Int> = emptyMap(),
     val skillLevels: Map<String, Int> = emptyMap(),
+    val skillXp: Map<String, Long> = emptyMap(),
     val activeWeaponSlot: String? = null,
     /** Non-null when the player has tapped Buy on a lamp and needs to choose a skill. */
     val pendingLamp: PendingLamp? = null,
@@ -133,6 +134,7 @@ class SlayerViewModel @Inject constructor(
                 unlockedDungeons      = unlockedDungeons,
                 inventory             = inventory,
                 skillLevels           = levels,
+                skillXp               = xpMap,
                 activeWeaponSlot      = flags.activeWeaponSlot,
                 slayerEquippedWeapons = equippedWeapons,
                 foretelledTasks       = flags.foretelledTasks,

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1069,6 +1069,7 @@
     <string name="slayer_owned">Owned</string>
     <string name="slayer_lamp_purchased">+%1$s XP added to %2$s!</string>
     <string name="slayer_lamp_pick_skill">Choose a skill</string>
+    <string name="slayer_lamp_max_level_warning">⚠ XP will be wasted</string>
     <string name="slayer_lamp_small">XP Lamp (Small)</string>
     <string name="slayer_lamp_large">XP Lamp (Large)</string>
     <string name="slayer_lamp_small_desc">+10,000 XP to any skill</string>


### PR DESCRIPTION
## Before submitting

- [x] I've tested any changes with the appropriate tests (eg. Unit tests, validation scripts)
   - [ ] Waiting for #1373 to be merged to fix CI errors
- [x] I've pulled and merged the latest changes from the repository

## Summary

PR is based on an [idea on discord](https://discord.com/channels/1523043919548514314/1535434816043098152).

- Refactor both carnival and slayer lamps to use a single shared component
- Add warning if total xp gain from lamps is beyond the maximum Level 99
- Add a new label to tell you the new level and % 

**Screenshots**
<img width="310" height="782" alt="image" src="https://github.com/user-attachments/assets/0a8ef5e8-4cf0-4d92-92e4-e38b3bb19a5d" />


**Demo**

https://github.com/user-attachments/assets/32f5e22b-c41d-48cd-b2e9-224f0c8c7cec


## Related issue(s) or discussion(s)

#1373 - waiting for CI to be fixed before this can be merged.

## Changelog

- Add warnings to skills when xp gained from genie lamp is beyond max Level 99.


## Anything else?

- ❗ This is my first time adding a new text, From what I read from the documentation, I don't have to do anything else, but please update me if I need to do something specific or if the bot would handle all translations.