### PR TITLE
Bugfix/limit player name

### DIFF
--- a/app/src/main/kotlin/com/fantasyidler/ui/screen/CharacterSetupSheet.kt
+++ b/app/src/main/kotlin/com/fantasyidler/ui/screen/CharacterSetupSheet.kt
@@ -41,6 +41,7 @@ import com.fantasyidler.ui.theme.ScaledSheetContent
 
 internal val CHARACTER_GENDERS = listOf("Male", "Female", "Other")
 internal val CHARACTER_RACES   = listOf("Human", "Elf", "Dwarf", "Orc", "Halfling", "Gnome")
+internal const val CHARACTER_NAME_MAX_LENGTH = 256
 
 /** A title option ready to render — display strings already resolved, whether static or seasonal. */
 data class TitleOption(
@@ -93,11 +94,16 @@ fun CharacterSetupSheet(
                 style = MaterialTheme.typography.titleLarge,
             )
 
+            val nameTooLong = draftName.length > CHARACTER_NAME_MAX_LENGTH
             OutlinedTextField(
                 value         = draftName,
                 onValueChange = { draftName = it },
                 label         = { Text(stringResource(R.string.character_name_label)) },
                 singleLine    = true,
+                isError       = nameTooLong,
+                supportingText = if (nameTooLong) {
+                    { Text(stringResource(R.string.character_name_too_long, CHARACTER_NAME_MAX_LENGTH)) }
+                } else null,
                 modifier      = Modifier.fillMaxWidth(),
             )
 
@@ -267,7 +273,7 @@ fun CharacterSetupSheet(
                     onClick  = {
                         val gender = if (draftGender == "Other" && customGenderText.isNotBlank())
                             customGenderText.trim() else draftGender
-                        onSave(draftName.trim(), gender, draftRace, draftIronman)
+                        onSave(draftName.trim().take(CHARACTER_NAME_MAX_LENGTH), gender, draftRace, draftIronman)
                     },
                     enabled  = draftName.isNotBlank(),
                 ) {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -716,6 +716,7 @@
     <string name="character_create_title">Create Your Character</string>
     <string name="character_edit_title">Edit Character</string>
     <string name="character_name_label">Character Name</string>
+    <string name="character_name_too_long">Only the first %1$d characters will be used.</string>
     <string name="character_gender">Gender</string>
     <string name="character_gender_male">Male</string>
     <string name="character_gender_female">Female</string>


### PR DESCRIPTION
## Before submitting

- [x] I've tested any changes with the appropriate tests (eg. Unit tests, validation scripts)
- [x] I've pulled and merged the latest changes from the repository

## Summary

<!-- Short summary of the pull request and what it changes -->

- if player name gets too big, they would not be able to use the profile page
- Decide to trim any name beyond 256 char (can be changed if you want) 
- Decided against adding ellipsis since it might hide the title that they added. 

## Related issue(s) or discussion(s)

<!-- Prepend issues with "Fixes" if this should close the issue, e.g. Fixes #283, Relates to #284 -->

**Demo**

https://github.com/user-attachments/assets/e2f3489b-baf0-408e-a218-097ba5d5e85e

## Changelog

<!-- Concise list of changes, e.g.
- Fix time-slot bug causing XP gains to not show in notification banner
- Added ellipsis for quests XP gains exceeding screen width
-->

- Limit Player character name to 256 to prevent issues with profile page.


## Anything else?

