### PR TITLE
feat: prevents combat sessions to be created when queue is full

### DIFF
--- a/app/src/main/kotlin/com/fantasyidler/ui/screen/BossInfoSheet.kt
+++ b/app/src/main/kotlin/com/fantasyidler/ui/screen/BossInfoSheet.kt
@@ -1,6 +1,8 @@
 package com.fantasyidler.ui.screen
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -123,6 +125,7 @@ internal fun BossInfoSheet(
     potionEffects: Map<String, Map<String, Int>>,
     selectedPotionKey: String?,
     isStarting: Boolean,
+    isQueueFull: Boolean = false,
     repeatCount: Int,
     fullCoinKillsLeft: Int = PlayerRepository.BOSS_FULL_COIN_KILLS_PER_DAY,
     onWeaponSlotSelected: (String) -> Unit,
@@ -141,7 +144,7 @@ internal fun BossInfoSheet(
         else       -> "attack"
     }
     val styleLabel = GameStrings.skillName(context, combatStyle)
-    val canStart = canFight && !isStarting &&
+    val canStart = canFight && !isStarting && !isQueueFull &&
         (combatStyle != "magic" || selectedSpell != null)
 
     Column(
@@ -394,15 +397,29 @@ internal fun BossInfoSheet(
             OutlinedButton(onClick = onDismiss, modifier = Modifier.weight(1f)) {
                 Text(stringResource(R.string.btn_cancel))
             }
-            Button(
-                onClick  = onStart,
-                modifier = Modifier.weight(1f),
-                enabled  = canStart,
-            ) {
-                if (isStarting) CircularProgressIndicator(
-                    modifier    = Modifier.height(20.dp).width(20.dp),
-                    strokeWidth = 2.dp,
-                ) else Text(stringResource(R.string.btn_fight))
+            val queueFullMessage = stringResource(R.string.snackbar_queue_full)
+            Box(modifier = Modifier.weight(1f)) {
+                Button(
+                    onClick  = onStart,
+                    modifier = Modifier.fillMaxWidth(),
+                    enabled  = canStart,
+                ) {
+                    if (isStarting) CircularProgressIndicator(
+                        modifier    = Modifier.height(20.dp).width(20.dp),
+                        strokeWidth = 2.dp,
+                    ) else Text(stringResource(R.string.btn_fight))
+                }
+                if (isQueueFull) {
+                    Box(
+                        modifier = Modifier
+                            .matchParentSize()
+                            .clickable(
+                                interactionSource = remember { MutableInteractionSource() },
+                                indication        = null,
+                                onClick           = { AppBannerCenter.enqueue(queueFullMessage) },
+                            ),
+                    )
+                }
             }
         }
     }

--- a/app/src/main/kotlin/com/fantasyidler/ui/screen/CombatScreen.kt
+++ b/app/src/main/kotlin/com/fantasyidler/ui/screen/CombatScreen.kt
@@ -231,6 +231,7 @@ fun CombatScreen(
                             unlockedDungeons    = state.unlockedDungeons,
                             towerBestFloor      = state.towerBestFloor,
                             bossKillCounts      = state.bossKillCounts,
+                            isQueueFull         = state.isQueueFull,
                             onDungeon           = viewModel::selectDungeon,
                             onBoss              = viewModel::selectBoss,
                             onTower             = onNavigateToTower,
@@ -308,6 +309,7 @@ fun CombatScreen(
                             unlockedDungeons    = state.unlockedDungeons,
                             towerBestFloor      = state.towerBestFloor,
                             bossKillCounts      = state.bossKillCounts,
+                            isQueueFull         = state.isQueueFull,
                             onDungeon           = viewModel::selectDungeon,
                             onBoss              = viewModel::selectBoss,
                             onTower             = onNavigateToTower,
@@ -391,6 +393,7 @@ fun CombatScreen(
                 potionEffects        = viewModel.potionEffects,
                 selectedPotionKey    = state.selectedPotionKey,
                 isStarting           = state.startingSession,
+                isQueueFull          = state.isQueueFull,
                 repeatCount          = state.selectedBossRepeatCount,
                 fullCoinKillsLeft    = state.bossFullCoinKillsLeft,
                 onWeaponSlotSelected = viewModel::selectWeaponSlot,
@@ -423,6 +426,7 @@ fun CombatScreen(
                 potionEffects        = viewModel.potionEffects,
                 selectedPotionKey    = state.selectedPotionKey,
                 isStarting           = state.startingSession,
+                isQueueFull          = state.isQueueFull,
                 repeatCount          = state.selectedDungeonRepeatCount,
                 enemies              = viewModel.enemyMap,
                 onWeaponSlotSelected = viewModel::selectWeaponSlot,
@@ -471,6 +475,7 @@ private fun CombatSelectionList(
     unlockedDungeons: List<String> = emptyList(),
     towerBestFloor: Int = 0,
     bossKillCounts: Map<String, Int> = emptyMap(),
+    isQueueFull: Boolean = false,
     modifier: Modifier = Modifier,
     onDungeon: (DungeonData) -> Unit,
     onBoss: (BossData) -> Unit,
@@ -480,7 +485,7 @@ private fun CombatSelectionList(
 
     LazyColumn(modifier.fillMaxSize()) {
         item { CombatSectionHeader(stringResource(R.string.label_dungeons_tab)) }
-        item { TowerEntryRow(bestFloor = towerBestFloor, onTap = onTower) }
+        item { TowerEntryRow(bestFloor = towerBestFloor, isQueueFull = isQueueFull, onTap = onTower) }
         items(dungeons) { dungeon ->
             val unlocked = if (dungeon.loreUnlockOnly) {
                 unlockedDungeons.contains(dungeon.name)
@@ -490,6 +495,7 @@ private fun CombatSelectionList(
             DungeonRow(
                 dungeon        = dungeon,
                 unlocked       = unlocked,
+                isQueueFull     = isQueueFull,
                 survivalRating = survivalRatings[dungeon.name],
                 runCount       = dungeonRuns[dungeon.name] ?: 0,
                 lastRunStats   = dungeonLastRunStats[dungeon.name],
@@ -505,6 +511,7 @@ private fun CombatSelectionList(
                 unlocked = combatLvl >= boss.combatLevelRequired,
                 runCount = bossKillCounts[boss.id] ?: 0,
                 onTap    = { onBoss(boss) },
+                isQueueFull = isQueueFull,
             )
         }
         item { Spacer(Modifier.height(16.dp)) }
@@ -901,6 +908,7 @@ private fun CombatSectionHeader(title: String) {
 private fun BossRow(
     boss: BossData,
     unlocked: Boolean,
+    isQueueFull: Boolean,
     runCount: Int = 0,
     onTap: () -> Unit,
 ) {
@@ -947,12 +955,21 @@ private fun BossRow(
             }
         }
         Spacer(Modifier.width(12.dp))
-        Text(
-            text       = "Lv. ${boss.combatLevelRequired}",
-            style      = MaterialTheme.typography.labelMedium,
-            fontWeight = FontWeight.SemiBold,
-            color      = if (unlocked) MaterialTheme.colorScheme.primary else dimColor,
-        )
+        Column(horizontalAlignment = Alignment.End) {
+            Text(
+                text       = "Lv. ${boss.combatLevelRequired}",
+                style      = MaterialTheme.typography.labelMedium,
+                fontWeight = FontWeight.SemiBold,
+                color      = if (unlocked) MaterialTheme.colorScheme.primary else dimColor,
+            )
+            if (isQueueFull) {
+                Text(
+                    text = stringResource(R.string.snackbar_queue_full),
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.38f),
+                )
+            }
+        }
     }
     HorizontalDivider(modifier = Modifier.padding(horizontal = 16.dp))
 }
@@ -960,6 +977,7 @@ private fun BossRow(
 @Composable
 private fun TowerEntryRow(
     bestFloor: Int,
+    isQueueFull: Boolean,
     onTap: () -> Unit,
 ) {
     Row(
@@ -990,14 +1008,23 @@ private fun TowerEntryRow(
                 overflow = TextOverflow.Ellipsis,
             )
         }
-        if (bestFloor > 0) {
-            Spacer(Modifier.width(12.dp))
-            Text(
-                text       = stringResource(R.string.tower_best_floor, bestFloor),
-                style      = MaterialTheme.typography.labelMedium,
-                fontWeight = FontWeight.SemiBold,
-                color      = MaterialTheme.colorScheme.primary,
-            )
+        Spacer(Modifier.width(12.dp))
+        Column(horizontalAlignment = Alignment.End) {
+            if (bestFloor > 0) {
+                    Text(
+                        text       = stringResource(R.string.tower_best_floor, bestFloor),
+                        style      = MaterialTheme.typography.labelMedium,
+                        fontWeight = FontWeight.SemiBold,
+                        color      = MaterialTheme.colorScheme.primary,
+                    )
+            }
+            if (isQueueFull) {
+                Text(
+                    text  = stringResource(R.string.snackbar_queue_full),
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.38f),
+                )
+            }
         }
     }
     HorizontalDivider(modifier = Modifier.padding(horizontal = 16.dp))
@@ -1007,6 +1034,7 @@ private fun TowerEntryRow(
 private fun DungeonRow(
     dungeon: DungeonData,
     unlocked: Boolean,
+    isQueueFull: Boolean,
     survivalRating: CombatSimulator.SurvivalRating? = null,
     runCount: Int = 0,
     lastRunStats: com.fantasyidler.data.model.DungeonRunStats? = null,
@@ -1079,12 +1107,21 @@ private fun DungeonRow(
             }
         }
         Spacer(Modifier.width(12.dp))
-        Text(
-            text  = "Lv. ${dungeon.recommendedLevel}",
-            style = MaterialTheme.typography.labelMedium,
-            color = if (unlocked) MaterialTheme.colorScheme.primary else dimColor,
-            fontWeight = FontWeight.SemiBold,
-        )
+        Column(horizontalAlignment = Alignment.End) {
+            Text(
+                text = "Lv. ${dungeon.recommendedLevel}",
+                style = MaterialTheme.typography.labelMedium,
+                color = if (unlocked) MaterialTheme.colorScheme.primary else dimColor,
+                fontWeight = FontWeight.SemiBold,
+            )
+            if (isQueueFull) {
+                Text(
+                    text = stringResource(R.string.snackbar_queue_full),
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.38f),
+                )
+            }
+        }
     }
     HorizontalDivider(modifier = Modifier.padding(horizontal = 16.dp))
 }

--- a/app/src/main/kotlin/com/fantasyidler/ui/screen/DungeonInfoSheet.kt
+++ b/app/src/main/kotlin/com/fantasyidler/ui/screen/DungeonInfoSheet.kt
@@ -2,6 +2,7 @@ package com.fantasyidler.ui.screen
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -119,6 +120,7 @@ internal fun DungeonInfoSheet(
     potionEffects: Map<String, Map<String, Int>>,
     selectedPotionKey: String?,
     isStarting: Boolean,
+    isQueueFull: Boolean = false,
     repeatCount: Int,
     enemies: Map<String, EnemyData> = emptyMap(),
     onWeaponSlotSelected: (String) -> Unit,
@@ -177,7 +179,7 @@ internal fun DungeonInfoSheet(
         else       -> "attack"
     }
     val styleLabel = GameStrings.skillName(context, combatStyle)
-    val canStart   = canEnter && !isStarting &&
+    val canStart   = canEnter && !isStarting && !isQueueFull &&
         (combatStyle != "magic" || selectedSpell != null)
 
     Column(
@@ -359,16 +361,30 @@ internal fun DungeonInfoSheet(
             OutlinedButton(onClick = onDismiss, modifier = Modifier.weight(1f)) {
                 Text(stringResource(R.string.btn_cancel))
             }
-            Button(
-                onClick  = onStart,
-                modifier = Modifier.weight(1f),
-                enabled  = canStart,
-            ) {
-                if (isStarting) CircularProgressIndicator(
-                    modifier  = Modifier.height(20.dp).width(20.dp),
-                    strokeWidth = 2.dp,
-                )
-                else Text(stringResource(R.string.btn_enter_dungeon))
+            val queueFullMessage = stringResource(R.string.snackbar_queue_full)
+            Box(modifier = Modifier.weight(1f)) {
+                Button(
+                    onClick  = onStart,
+                    modifier = Modifier.fillMaxWidth(),
+                    enabled  = canStart,
+                ) {
+                    if (isStarting) CircularProgressIndicator(
+                        modifier  = Modifier.height(20.dp).width(20.dp),
+                        strokeWidth = 2.dp,
+                    )
+                    else Text(stringResource(R.string.btn_enter_dungeon))
+                }
+                if (isQueueFull) {
+                    Box(
+                        modifier = Modifier
+                            .matchParentSize()
+                            .clickable(
+                                interactionSource = remember { MutableInteractionSource() },
+                                indication        = null,
+                                onClick           = { AppBannerCenter.enqueue(queueFullMessage) },
+                            ),
+                    )
+                }
             }
         }
     }

--- a/app/src/main/kotlin/com/fantasyidler/ui/screen/SlayerScreen.kt
+++ b/app/src/main/kotlin/com/fantasyidler/ui/screen/SlayerScreen.kt
@@ -1,6 +1,9 @@
 package com.fantasyidler.ui.screen
 
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -40,6 +43,7 @@ import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
@@ -159,12 +163,27 @@ fun SlayerScreen(
             if (currentTask != null) {
                 TaskCard(task = currentTask, dungeons = state.taskDungeons)
                 if (state.taskDungeons.isNotEmpty() && !state.taskIsStuck) {
-                    OutlinedButton(
-                        onClick  = viewModel::queueTaskDungeon,
-                        enabled  = state.queueSize < state.maxQueueSize,
-                        modifier = Modifier.fillMaxWidth(),
-                    ) {
-                        Text(stringResource(R.string.slayer_add_dungeon_to_queue))
+                    val isQueueFull = state.queueSize >= state.maxQueueSize
+                    val queueFullMessage = stringResource(R.string.snackbar_queue_full)
+                    Box(modifier = Modifier.fillMaxWidth()) {
+                        OutlinedButton(
+                            onClick  = viewModel::queueTaskDungeon,
+                            enabled  = !isQueueFull,
+                            modifier = Modifier.fillMaxWidth(),
+                        ) {
+                            Text(stringResource(R.string.slayer_add_dungeon_to_queue))
+                        }
+                        if (isQueueFull) {
+                            Box(
+                                modifier = Modifier
+                                    .matchParentSize()
+                                    .clickable(
+                                        interactionSource = remember { MutableInteractionSource() },
+                                        indication        = null,
+                                        onClick           = { AppBannerCenter.enqueue(queueFullMessage) },
+                                    ),
+                            )
+                        }
                     }
                 }
                 if (state.taskIsStuck) {

--- a/app/src/main/kotlin/com/fantasyidler/ui/screen/TowerScreen.kt
+++ b/app/src/main/kotlin/com/fantasyidler/ui/screen/TowerScreen.kt
@@ -1,5 +1,7 @@
 package com.fantasyidler.ui.screen
 
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -40,6 +42,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
@@ -109,6 +112,7 @@ fun TowerScreen(
                     hasSession           = state.towerSession != null,
                     sessionDone          = state.towerSession?.completed == true,
                     startingSession      = state.startingSession,
+                    isQueueFull          = state.isQueueFull,
                     equippedWeapons      = state.equippedWeapons,
                     selectedWeaponSlot   = state.selectedWeaponSlot,
                     onWeaponSlotSelected = viewModel::selectWeaponSlot,
@@ -159,6 +163,7 @@ private fun TowerHeaderCard(
     hasSession:           Boolean,
     sessionDone:          Boolean,
     startingSession:      Boolean,
+    isQueueFull:          Boolean,
     equippedWeapons:      Map<String, EquipmentData>,
     selectedWeaponSlot:   String?,
     onWeaponSlotSelected: (String) -> Unit,
@@ -348,12 +353,28 @@ private fun TowerHeaderCard(
                     Text(stringResource(R.string.tower_collect_prompt))
                 }
 
-                else        -> Button(
-                    onClick  = onStart,
-                    enabled  = !startingSession,
-                    modifier = Modifier.fillMaxWidth(),
-                ) {
-                    Text(stringResource(R.string.tower_start_btn, nextFloorToQueue))
+                else        -> {
+                    val queueFullMessage = stringResource(R.string.snackbar_queue_full)
+                    Box(modifier = Modifier.fillMaxWidth()) {
+                        Button(
+                            onClick  = onStart,
+                            enabled  = !startingSession && !isQueueFull,
+                            modifier = Modifier.fillMaxWidth(),
+                        ) {
+                            Text(stringResource(R.string.tower_start_btn, nextFloorToQueue))
+                        }
+                        if (isQueueFull) {
+                            Box(
+                                modifier = Modifier
+                                    .matchParentSize()
+                                    .clickable(
+                                        interactionSource = remember { MutableInteractionSource() },
+                                        indication        = null,
+                                        onClick           = { AppBannerCenter.enqueue(queueFullMessage) },
+                                    ),
+                            )
+                        }
+                    }
                 }
             }
 

--- a/app/src/main/kotlin/com/fantasyidler/ui/viewmodel/CombatViewModel.kt
+++ b/app/src/main/kotlin/com/fantasyidler/ui/viewmodel/CombatViewModel.kt
@@ -106,6 +106,7 @@ data class CombatUiState(
     val bossFullCoinKillsLeft: Int = PlayerRepository.BOSS_FULL_COIN_KILLS_PER_DAY,
     /** True once the Grand Monument's Eternal Flame is lit (unlocks monument-gated bosses). */
     val monumentComplete: Boolean = false,
+    val isQueueFull: Boolean = false,
 )
 
 // ---------------------------------------------------------------------------
@@ -253,6 +254,7 @@ class CombatViewModel @Inject constructor(
                 activeDungeonRepeatTotal = flags.activeDungeonRepeatTotal,
                 bossFullCoinKillsLeft   = playerRepo.bossFullCoinKillsLeft(flags, extra.selectedBoss?.id ?: ""),
                 monumentComplete        = flags.monumentTier >= 5,
+                isQueueFull             = flags.sessionQueue.size >= playerRepo.maxQueueSize(flags),
             )
         }
     }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), CombatUiState())

--- a/app/src/main/kotlin/com/fantasyidler/ui/viewmodel/TowerViewModel.kt
+++ b/app/src/main/kotlin/com/fantasyidler/ui/viewmodel/TowerViewModel.kt
@@ -60,6 +60,7 @@ data class TowerUiState(
     val availableSpells: List<SpellData> = emptyList(),
     val selectedPotionKey: String? = null,
     val availablePotions: Map<String, Int> = emptyMap(),
+    val isQueueFull: Boolean = false,
 )
 
 data class TowerMilestone(
@@ -197,6 +198,7 @@ class TowerViewModel @Inject constructor(
                 availableSpells     = gameData.spells.values.filter { it.magicLevelRequired <= magicLevel }.sortedBy { it.magicLevelRequired },
                 selectedPotionKey   = extra.selectedPotionKey ?: flags.activePotionKey?.takeIf { (inventory[it] ?: 0) > 0 },
                 availablePotions    = inventory.filterKeys { it in gameData.potionEffects },
+                isQueueFull         = flags.sessionQueue.size >= playerRepo.maxQueueSize(flags),
             )
         }
     }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), TowerUiState())


### PR DESCRIPTION
## Before submitting

- [x] I've tested any changes with the appropriate tests (eg. Unit tests, validation scripts)
- [x] I've pulled and merged the latest changes from the repository

## Summary

Fix Indicator when queue is full in various places. (it currently works for Carnival and somewhat for the seasonable event, but not others)
- [x] Fix in Dungeons
- [x] Fix infinite Tower
- [x] Fix in Bosses
- [x] Fix in Slayer

**Demo**

https://github.com/user-attachments/assets/d8dcd115-1569-42aa-bd6b-8e402526be38


## Related issue(s) or discussion(s)

<!-- Prepend issues with "Fixes" if this should close the issue, e.g. Fixes #283, Relates to #284 -->


## Changelog

<!-- Concise list of changes, e.g.
- Fix time-slot bug causing XP gains to not show in notification banner
- Added ellipsis for quests XP gains exceeding screen width
-->

- Prevent combat sessions from being added when queue is full.


## Anything else?

- There is a bug with Sheets and the AppBanner (something to do with the Z index), but it's something to fix another time.