### PR TITLE
Add badge when prestige is available

### DIFF
--- a/app/src/main/kotlin/com/fantasyidler/data/model/PlayerModels.kt
+++ b/app/src/main/kotlin/com/fantasyidler/data/model/PlayerModels.kt
@@ -165,6 +165,8 @@ data class PlayerFlags(
     @SerialName("show_quest_dots") val showQuestDots: Boolean = true,
     /** Whether to abbreviate large item quantities/numbers (e.g. 2.46M vs 2,461,940). */
     @SerialName("compact_numbers") val compactNumbers: Boolean = false,
+    /** Nav bar badge dots for combat/skill prestige availability. */
+    @SerialName("show_prestige_notifications") val showPrestigeNotifications: Boolean = true,
     /** Shop: bulk and manual sells always leave one of each item for collectors. */
     @SerialName("shop_keep_one_of_each") val shopKeepOneOfEach: Boolean = false,
     /** Epoch ms when this character was created; 0 for pre-existing characters until backfilled

--- a/app/src/main/kotlin/com/fantasyidler/ui/navigation/AppNavigation.kt
+++ b/app/src/main/kotlin/com/fantasyidler/ui/navigation/AppNavigation.kt
@@ -68,6 +68,7 @@ import com.fantasyidler.ui.screen.SlayerScreen
 import com.fantasyidler.ui.screen.WorkerSkillsScreen
 import com.fantasyidler.ui.viewmodel.NavBadgeViewModel
 import com.fantasyidler.ui.viewmodel.OnboardingViewModel
+import com.fantasyidler.ui.viewmodel.SettingsViewModel
 
 @Composable
 fun AppNavigation(
@@ -80,6 +81,8 @@ fun AppNavigation(
     val questsClaimable by navBadgeVm.questsClaimableCount.collectAsState()
     val hasCombatPrestige by navBadgeVm.hasCombatPrestige.collectAsState()
     val hasSkillPrestige by navBadgeVm.hasSkillPrestige.collectAsState()
+    val settingsVm: SettingsViewModel = hiltViewModel()
+    val showPrestigeNotifications by settingsVm.showPrestigeNotifications.collectAsState()
 
     // Show onboarding as a full-screen overlay until complete.
     // null = still loading from DB; don't flash the overlay.
@@ -162,8 +165,8 @@ fun AppNavigation(
                                 }
                             } else {
                                 val showQuestBadge = screen is Screen.Quests && questsClaimable > 0
-                                val showCombatBadge = screen is Screen.Combat && hasCombatPrestige
-                                val showSkillBadge = screen is Screen.Skills && hasSkillPrestige
+                                val showCombatBadge = screen is Screen.Combat && hasCombatPrestige && showPrestigeNotifications
+                                val showSkillBadge = screen is Screen.Skills && hasSkillPrestige && showPrestigeNotifications
                                 if (showQuestBadge || showCombatBadge || showSkillBadge) {
                                     BadgedBox(badge = { Badge() }) {
                                         Icon(

--- a/app/src/main/kotlin/com/fantasyidler/ui/navigation/AppNavigation.kt
+++ b/app/src/main/kotlin/com/fantasyidler/ui/navigation/AppNavigation.kt
@@ -78,6 +78,8 @@ fun AppNavigation(
     val showOnboarding by onboardingVm.showOnboarding.collectAsState()
     val navBadgeVm: NavBadgeViewModel = hiltViewModel()
     val questsClaimable by navBadgeVm.questsClaimableCount.collectAsState()
+    val hasCombatPrestige by navBadgeVm.hasCombatPrestige.collectAsState()
+    val hasSkillPrestige by navBadgeVm.hasSkillPrestige.collectAsState()
 
     // Show onboarding as a full-screen overlay until complete.
     // null = still loading from DB; don't flash the overlay.
@@ -160,7 +162,9 @@ fun AppNavigation(
                                 }
                             } else {
                                 val showQuestBadge = screen is Screen.Quests && questsClaimable > 0
-                                if (showQuestBadge) {
+                                val showCombatBadge = screen is Screen.Combat && hasCombatPrestige
+                                val showSkillBadge = screen is Screen.Skills && hasSkillPrestige
+                                if (showQuestBadge || showCombatBadge || showSkillBadge) {
                                     BadgedBox(badge = { Badge() }) {
                                         Icon(
                                             imageVector        = if (selected) screen.selectedIcon else screen.icon,

--- a/app/src/main/kotlin/com/fantasyidler/ui/screen/CombatScreen.kt
+++ b/app/src/main/kotlin/com/fantasyidler/ui/screen/CombatScreen.kt
@@ -170,6 +170,13 @@ fun CombatScreen(
         }
 
         val combatSession = state.combatSession
+        val skillsPrestigeReadyCount = if (state.ironman) 0 else COMBAT_SKILLS.count { key ->
+            (state.skillLevels[key] ?: 1) >= 99 && (state.skillPrestige[key] ?: 0) < 3
+        }
+        val skillsTabLabel = if (skillsPrestigeReadyCount > 0)
+            stringResource(R.string.tab_label_with_count, stringResource(R.string.label_skills), skillsPrestigeReadyCount)
+        else
+            stringResource(R.string.label_skills)
         if (combatSession != null) {
             var savedPage by rememberSaveable { mutableIntStateOf(if (startOnGear) 2 else 0) }
             val pagerState = rememberPagerState(initialPage = savedPage, pageCount = { 4 })
@@ -198,7 +205,7 @@ fun CombatScreen(
                     Tab(
                         selected = pagerState.currentPage == 3,
                         onClick  = { scope.launch { pagerState.animateScrollToPage(3) } },
-                        text     = { Text(stringResource(R.string.label_skills)) },
+                        text     = { Text(skillsTabLabel) },
                     )
                 }
                 HorizontalPager(state = pagerState, modifier = Modifier.weight(1f)) { page ->
@@ -295,7 +302,7 @@ fun CombatScreen(
                     Tab(
                         selected = pagerState.currentPage == 2,
                         onClick  = { scope.launch { pagerState.animateScrollToPage(2) } },
-                        text     = { Text(stringResource(R.string.label_skills)) },
+                        text     = { Text(skillsTabLabel) },
                     )
                 }
                 HorizontalPager(state = pagerState, modifier = Modifier.weight(1f)) { page ->

--- a/app/src/main/kotlin/com/fantasyidler/ui/screen/SettingsScreen.kt
+++ b/app/src/main/kotlin/com/fantasyidler/ui/screen/SettingsScreen.kt
@@ -321,6 +321,17 @@ fun SettingsScreen(
                     )
                 }
             )
+            val showPrestigeNotifications by viewModel.showPrestigeNotifications.collectAsState()
+            SettingsRow(
+                title    = stringResource(R.string.settings_prestige_notifications),
+                subtitle = stringResource(R.string.settings_prestige_notifications_desc),
+                trailing = {
+                    Switch(
+                        checked         = showPrestigeNotifications,
+                        onCheckedChange = { viewModel.setShowPrestigeNotifications(it) },
+                    )
+                }
+            )
             val compactNumbers by viewModel.compactNumbers.collectAsState()
             SettingsRow(
                 title    = stringResource(R.string.settings_compact_numbers),

--- a/app/src/main/kotlin/com/fantasyidler/ui/screen/SkillsScreen.kt
+++ b/app/src/main/kotlin/com/fantasyidler/ui/screen/SkillsScreen.kt
@@ -122,6 +122,8 @@ import com.fantasyidler.ui.viewmodel.QuestCategory
 import com.fantasyidler.ui.viewmodel.QuestFillSuggestion
 import com.fantasyidler.ui.viewmodel.QuestIndicator
 
+private val NON_COMBAT_PRESTIGE_SKILLS = Skills.GATHERING + Skills.CRAFTING_SKILLS + Skills.SUPPORT + listOf(Skills.SLAYER)
+
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun SkillsScreen(
@@ -203,10 +205,20 @@ fun SkillsScreen(
         val scope = rememberCoroutineScope()
         Column(modifier = Modifier.fillMaxSize().padding(padding)) {
             TabRow(selectedTabIndex = pagerState.currentPage) {
+                val prestigeReadyCount = if (state.ironman) 0 else NON_COMBAT_PRESTIGE_SKILLS.count { key ->
+                    (state.skillLevels[key] ?: 1) >= 99 && (state.skillPrestige[key] ?: 0) < 3
+                }
                 Tab(
                     selected = pagerState.currentPage == 0,
                     onClick  = { scope.launch { pagerState.animateScrollToPage(0) } },
-                    text     = { Text(stringResource(R.string.nav_skills)) },
+                    text     = {
+                        Text(
+                            if (prestigeReadyCount > 0)
+                                stringResource(R.string.tab_label_with_count, stringResource(R.string.nav_skills), prestigeReadyCount)
+                            else
+                                stringResource(R.string.nav_skills)
+                        )
+                    },
                 )
                 Tab(
                     selected = pagerState.currentPage == 1,

--- a/app/src/main/kotlin/com/fantasyidler/ui/viewmodel/NavBadgeViewModel.kt
+++ b/app/src/main/kotlin/com/fantasyidler/ui/viewmodel/NavBadgeViewModel.kt
@@ -3,6 +3,7 @@ package com.fantasyidler.ui.viewmodel
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.fantasyidler.data.model.PlayerFlags
+import com.fantasyidler.data.model.Skills
 import com.fantasyidler.repository.DailyQuestRepository
 import com.fantasyidler.repository.GameDataRepository
 import com.fantasyidler.repository.PlayerRepository
@@ -12,6 +13,7 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.serialization.json.Json
 import javax.inject.Inject
@@ -46,4 +48,31 @@ class NavBadgeViewModel @Inject constructor(
             .count { it.progress >= it.template.amount && !it.claimed }
         regularCount + dailyCount + weeklyCount
     }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), 0)
+
+    private val skillsReadyToPrestige: StateFlow<Set<String>> = playerRepo.playerFlow
+        .map { player ->
+            if (player == null) return@map emptySet()
+            val flags: PlayerFlags = json.decodeFromString(player.flags)
+            if (flags.ironman) return@map emptySet()
+            val levels: Map<String, Int> = json.decodeFromString(player.skillLevels)
+            Skills.ALL.filterTo(mutableSetOf()) { skill ->
+                (levels[skill] ?: 1) >= 99 && (flags.skillPrestige[skill] ?: 0) < 3
+            }
+        }
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), emptySet())
+
+    val hasCombatPrestige: StateFlow<Boolean> = skillsReadyToPrestige
+        .map { ready -> COMBAT_PRESTIGE_SKILLS.any { it in ready } }
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), false)
+
+    val hasSkillPrestige: StateFlow<Boolean> = skillsReadyToPrestige
+        .map { ready -> ready.any { it !in COMBAT_PRESTIGE_SKILLS } }
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), false)
+
+    private companion object {
+        val COMBAT_PRESTIGE_SKILLS = setOf(
+            Skills.ATTACK, Skills.STRENGTH, Skills.DEFENSE,
+            Skills.RANGED, Skills.MAGIC, Skills.HITPOINTS,
+        )
+    }
 }

--- a/app/src/main/kotlin/com/fantasyidler/ui/viewmodel/SettingsViewModel.kt
+++ b/app/src/main/kotlin/com/fantasyidler/ui/viewmodel/SettingsViewModel.kt
@@ -124,6 +124,14 @@ class SettingsViewModel @Inject constructor(
         }
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), false)
 
+    val showPrestigeNotifications: StateFlow<Boolean> = playerRepo.playerFlow
+        .map { player ->
+            if (player == null) return@map true
+            try { json.decodeFromString<PlayerFlags>(player.flags).showPrestigeNotifications }
+            catch (_: Exception) { true }
+        }
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), true)
+
     val showJournalButton: StateFlow<Boolean> = playerRepo.playerFlow
         .map { player ->
             if (player == null) return@map true
@@ -205,6 +213,13 @@ class SettingsViewModel @Inject constructor(
         viewModelScope.launch {
             val flags = playerRepo.getFlags()
             playerRepo.updateFlags(flags.copy(compactNumbers = enabled))
+        }
+    }
+
+    fun setShowPrestigeNotifications(enabled: Boolean) {
+        viewModelScope.launch {
+            val flags = playerRepo.getFlags()
+            playerRepo.updateFlags(flags.copy(showPrestigeNotifications = enabled))
         }
     }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -149,6 +149,7 @@
     <string name="label_available_quests">Available</string>
     <string name="label_stats">Stats</string>
     <string name="label_skills">Skills</string>
+    <string name="tab_label_with_count">%1$s (%2$d)</string>
     <string name="label_shop">Shop</string>
     <string name="label_sell_items">Sell Items</string>
     <string name="label_total_level">Total Level</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -303,6 +303,8 @@
     <string name="settings_profile_layout_tabs">Tabs</string>
     <string name="settings_quest_dots">Quest dots on skills</string>
     <string name="settings_quest_dots_desc">Show a gold dot on skills that have an open quest</string>
+    <string name="settings_prestige_notifications">Prestige Notification Badges</string>
+    <string name="settings_prestige_notifications_desc">Show a notification badge on navigation when a skill is ready to prestige</string>
     <string name="settings_compact_numbers">Compact Numbers</string>
     <string name="settings_compact_numbers_desc">Abbreviate large item quantities (e.g. 2.46M instead of 2,461,940)</string>
     <string name="settings_home_screen">Home Screen</string>


### PR DESCRIPTION
## Before submitting

- [x] I've tested any changes with the appropriate tests (eg. Unit tests, validation scripts)
- [x] I've pulled and merged the latest changes from the repository

## Summary

<!-- Short summary of the pull request and what it changes -->
I was doing dungeons without knowing that my magic could be prestiged 😭. Added a badge notification so that no one would suffer the same fate. 

- Add navigation badge to combat navigation whenever a combat skill can prestige
- Add navigation badge to Skill navigation whenever a skill can prestige
- Added count of prestige-able skill on the top tabs for bth combat and Skills.
- This change does not affect iron man.

<img width="510" height="998" alt="image" src="https://github.com/user-attachments/assets/a8eacaac-dc44-40ae-a7e3-6d1ce5c3c64a" />


## Changelog

<!-- Concise list of changes, e.g.
- Fix time-slot bug causing XP gains to not show in notification banner
- Added ellipsis for quests XP gains exceeding screen width
-->

- Added notification badge to notify players when a skill is ready to prestige.


## Anything else?

