### PR TITLE
Add Compact Numbers setting and improve shop number formatting

### DIFF
--- a/app/src/main/kotlin/com/fantasyidler/data/model/PlayerModels.kt
+++ b/app/src/main/kotlin/com/fantasyidler/data/model/PlayerModels.kt
@@ -163,6 +163,8 @@ data class PlayerFlags(
     @SerialName("show_session_end_time") val showSessionEndTime: Boolean = true,
     /** Gold quest dots on the Skills tab icons; some players prefer them off (discussion #1386). */
     @SerialName("show_quest_dots") val showQuestDots: Boolean = true,
+    /** Whether to abbreviate large item quantities/numbers (e.g. 2.46M vs 2,461,940). */
+    @SerialName("compact_numbers") val compactNumbers: Boolean = false,
     /** Epoch ms when this character was created; 0 for pre-existing characters until backfilled
      *  from their oldest quest completion (sessions are deleted on collect, so quest timestamps
      *  are the oldest surviving record). */

--- a/app/src/main/kotlin/com/fantasyidler/ui/screen/SettingsScreen.kt
+++ b/app/src/main/kotlin/com/fantasyidler/ui/screen/SettingsScreen.kt
@@ -321,6 +321,17 @@ fun SettingsScreen(
                     )
                 }
             )
+            val compactNumbers by viewModel.compactNumbers.collectAsState()
+            SettingsRow(
+                title    = stringResource(R.string.settings_compact_numbers),
+                subtitle = stringResource(R.string.settings_compact_numbers_desc),
+                trailing = {
+                    Switch(
+                        checked         = compactNumbers,
+                        onCheckedChange = { viewModel.setCompactNumbers(it) },
+                    )
+                }
+            )
             SettingsRow(
                 title    = stringResource(R.string.settings_profile_layout),
                 subtitle = stringResource(R.string.settings_profile_layout_desc),

--- a/app/src/main/kotlin/com/fantasyidler/ui/screen/ShopScreen.kt
+++ b/app/src/main/kotlin/com/fantasyidler/ui/screen/ShopScreen.kt
@@ -77,6 +77,7 @@ import com.fantasyidler.ui.viewmodel.ShopViewModel
 import com.fantasyidler.ui.theme.ScaledSheetContent
 import com.fantasyidler.util.GameStrings
 import com.fantasyidler.util.formatCoins
+import com.fantasyidler.util.formatQuantity
 
 private fun localizedCategory(context: android.content.Context, raw: String): String {
     val resId = when (raw) {
@@ -180,6 +181,7 @@ fun ShopScreen(
                         equipped           = state.equipped,
                         lockedItems        = state.lockedItems,
                         context            = context,
+                        compactNumbers     = state.compactNumbers,
                         priceFor           = viewModel::sellPriceFor,
                         categoryFor        = viewModel::sellCategoryFor,
                         onSell             = { key -> viewModel.openSell(key, GameStrings.itemName(context, key)) },
@@ -192,6 +194,7 @@ fun ShopScreen(
                         coins              = state.coins,
                         xpBoostActive      = state.xpBoostActive,
                         inventory          = state.inventory,
+                        compactNumbers     = state.compactNumbers,
                         discountedPriceFor = viewModel::discountedPrice,
                         onBuy              = viewModel::openBuy,
                     )
@@ -230,9 +233,10 @@ fun ShopScreen(
         ) {
             ScaledSheetContent {
             BulkSellSheet(
-                preview   = preview,
-                onConfirm = viewModel::confirmBulkSell,
-                onDismiss = viewModel::dismissBulkSell,
+                preview        = preview,
+                compactNumbers = state.compactNumbers,
+                onConfirm      = viewModel::confirmBulkSell,
+                onDismiss      = viewModel::dismissBulkSell,
             )
             }
         }
@@ -249,6 +253,7 @@ private fun BuyList(
     coins: Long,
     xpBoostActive: Boolean,
     inventory: Map<String, Int>,
+    compactNumbers: Boolean = false,
     discountedPriceFor: (ShopEntry) -> Int,
     onBuy: (ShopEntry) -> Unit,
 ) {
@@ -304,7 +309,7 @@ private fun BuyList(
                         }
                         if (!isXpBoost) {
                             Text(
-                                text  = stringResource(R.string.shop_qty_in_inv, owned),
+                                text  = stringResource(R.string.shop_qty_in_inv, owned.formatQuantity(compactNumbers)),
                                 style = MaterialTheme.typography.labelSmall,
                                 color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.7f),
                             )
@@ -312,14 +317,14 @@ private fun BuyList(
                     }
                     Column(horizontalAlignment = Alignment.End) {
                         Text(
-                            text       = stringResource(R.string.shop_total_amount, discounted.toString()),
+                            text       = stringResource(R.string.shop_total_amount, discounted.toLong().formatCoins()),
                             style      = MaterialTheme.typography.bodyMedium,
                             fontWeight = FontWeight.SemiBold,
                             color      = if (canAfford) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.primary.copy(alpha = 0.38f),
                         )
                         if (hasDiscount) {
                             Text(
-                                text           = stringResource(R.string.shop_total_amount, entry.price.toString()),
+                                text           = stringResource(R.string.shop_total_amount, entry.price.toLong().formatCoins()),
                                 style          = MaterialTheme.typography.bodySmall,
                                 textDecoration = TextDecoration.LineThrough,
                                 color          = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.6f),
@@ -347,6 +352,7 @@ private fun SellList(
     equipped: Map<String, String?>,
     lockedItems: Set<String>,
     context: android.content.Context,
+    compactNumbers: Boolean = false,
     priceFor: (String) -> Int,
     categoryFor: (String) -> String,
     onSell: (String) -> Unit,
@@ -435,13 +441,13 @@ private fun SellList(
                                 }
                             }
                             Text(
-                                text  = stringResource(R.string.shop_qty_in_inv, qty),
+                                text  = stringResource(R.string.shop_qty_in_inv, qty.formatQuantity(compactNumbers)),
                                 style = MaterialTheme.typography.bodySmall,
                                 color = MaterialTheme.colorScheme.onSurfaceVariant,
                             )
                         }
                         Text(
-                            text       = stringResource(R.string.shop_price_each, sellPrice.toString()),
+                            text       = stringResource(R.string.shop_price_each, sellPrice.toLong().formatCoins()),
                             style      = MaterialTheme.typography.bodyMedium,
                             fontWeight = FontWeight.SemiBold,
                             color      = MaterialTheme.colorScheme.primary.copy(alpha = lockedAlpha),
@@ -491,7 +497,7 @@ private fun TransactionSheet(
         )
         Spacer(Modifier.height(4.dp))
         Text(
-            text  = stringResource(R.string.shop_price_each_long, transaction.priceEach.toString()),
+            text  = stringResource(R.string.shop_price_each_long, transaction.priceEach.toLong().formatCoins()),
             style = MaterialTheme.typography.bodySmall,
             color = MaterialTheme.colorScheme.onSurfaceVariant,
         )
@@ -548,7 +554,7 @@ private fun TransactionSheet(
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
             )
             Text(
-                text       = stringResource(R.string.shop_total_amount, total.toString()),
+                text       = stringResource(R.string.shop_total_amount, total.formatCoins()),
                 style      = MaterialTheme.typography.titleMedium,
                 fontWeight = FontWeight.Bold,
                 color      = MaterialTheme.colorScheme.primary,
@@ -592,6 +598,7 @@ private fun TransactionSheet(
 @Composable
 private fun BulkSellSheet(
     preview: BulkSellPreview,
+    compactNumbers: Boolean = false,
     onConfirm: () -> Unit,
     onDismiss: () -> Unit,
 ) {
@@ -623,7 +630,7 @@ private fun BulkSellSheet(
                         modifier = Modifier.weight(1f),
                     )
                     Text(
-                        text  = "×${item.qty}",
+                        text  = "×${item.qty.formatQuantity(compactNumbers)}",
                         style = MaterialTheme.typography.bodyMedium,
                         color = MaterialTheme.colorScheme.onSurfaceVariant,
                         modifier = Modifier.padding(horizontal = 12.dp),

--- a/app/src/main/kotlin/com/fantasyidler/ui/viewmodel/SettingsViewModel.kt
+++ b/app/src/main/kotlin/com/fantasyidler/ui/viewmodel/SettingsViewModel.kt
@@ -116,6 +116,14 @@ class SettingsViewModel @Inject constructor(
         }
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), true)
 
+    val compactNumbers: StateFlow<Boolean> = playerRepo.playerFlow
+        .map { player ->
+            if (player == null) return@map false
+            try { json.decodeFromString<PlayerFlags>(player.flags).compactNumbers }
+            catch (_: Exception) { false }
+        }
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), false)
+
     val showJournalButton: StateFlow<Boolean> = playerRepo.playerFlow
         .map { player ->
             if (player == null) return@map true
@@ -190,6 +198,13 @@ class SettingsViewModel @Inject constructor(
         viewModelScope.launch {
             val flags = playerRepo.getFlags()
             playerRepo.updateFlags(flags.copy(showQuestDots = enabled))
+        }
+    }
+
+    fun setCompactNumbers(enabled: Boolean) {
+        viewModelScope.launch {
+            val flags = playerRepo.getFlags()
+            playerRepo.updateFlags(flags.copy(compactNumbers = enabled))
         }
     }
 

--- a/app/src/main/kotlin/com/fantasyidler/ui/viewmodel/ShopViewModel.kt
+++ b/app/src/main/kotlin/com/fantasyidler/ui/viewmodel/ShopViewModel.kt
@@ -91,6 +91,7 @@ data class ShopUiState(
     val skillPrestige: Map<String, Int> = emptyMap(),
     /** Ironman characters can only sell — every buy path is blocked. */
     val ironman: Boolean = false,
+    val compactNumbers: Boolean = false,
 ) {
     val xpBoostActive: Boolean get() = xpBoostExpiresAt > System.currentTimeMillis()
 }
@@ -131,6 +132,7 @@ class ShopViewModel @Inject constructor(
                 townBuildingTiers = flags.townBuildingTiers,
                 skillPrestige     = flags.skillPrestige,
                 ironman           = flags.ironman,
+                compactNumbers    = flags.compactNumbers,
             )
         }
     }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), ShopUiState())

--- a/app/src/main/kotlin/com/fantasyidler/util/Extensions.kt
+++ b/app/src/main/kotlin/com/fantasyidler/util/Extensions.kt
@@ -29,11 +29,31 @@ fun Long.formatCoins(): String = when {
     else               -> toString()
 }
 
+/** Format an Int coin amount with thousands separators. */
+fun Int.formatCoins(): String = toLong().formatCoins()
+
 /** Abbreviated coin format for compact UI (e.g. 50000 → "50k"). */
 fun Long.formatCoinsBrief(): String = when {
     this >= 1_000_000L -> "%.1fM".format(this / 1_000_000.0)
     this >= 1_000L     -> "${this / 1000}k"
     else               -> toString()
+}
+
+/** Format an integer quantity as a readable string, respecting the [compact] setting. */
+fun Int.formatQuantity(compact: Boolean = false): String = toLong().formatQuantity(compact)
+
+/** Format a Long quantity as a readable string, respecting the [compact] setting. */
+fun Long.formatQuantity(compact: Boolean = false): String = when {
+    compact && this >= 1_000_000L -> {
+        val formatted = "%.2f".format(this / 1_000_000.0).trimEnd('0').trimEnd('.', ',')
+        "${formatted}M"
+    }
+    compact && this >= 1_000L -> {
+        val formatted = "%.1f".format(this / 1_000.0).trimEnd('0').trimEnd('.', ',')
+        "${formatted}k"
+    }
+    this >= 1_000L || this <= -1_000L -> "%,d".format(this)
+    else -> toString()
 }
 
 /** Formats an epoch-ms timestamp as a clock time, respecting the device's 12/24-hour preference. */

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -277,6 +277,8 @@
     <string name="settings_profile_layout_tabs">Tabs</string> <!-- untranslated -->
     <string name="settings_quest_dots">Quest dots on skills</string> <!-- untranslated -->
     <string name="settings_quest_dots_desc">Show a gold dot on skills that have an open quest</string> <!-- untranslated -->
+    <string name="settings_compact_numbers">Compact Numbers</string> <!-- untranslated -->
+    <string name="settings_compact_numbers_desc">Abbreviate large item quantities (e.g. 2.46M instead of 2,461,940)</string> <!-- untranslated -->
     <string name="settings_home_screen">Home Screen</string> <!-- untranslated -->
     <string name="settings_home_screen_desc">Choose what appears on the home screen</string> <!-- untranslated -->
     <string name="settings_recent_activity">Recent Activity Log</string> <!-- untranslated -->
@@ -666,7 +668,7 @@
     <string name="quest_legend_gold_dot">Timed quest is available.</string> <!-- untranslated -->
     <string name="quest_legend_notes">Dimmed icons can\'t be completed yet (missing level or materials). A small raised number means several quests of that type want the same thing.</string> <!-- untranslated -->
     <!-- Translator note: %1$d = quantity -->
-    <string name="shop_qty_in_inv">×%1$d in inventory</string> <!-- untranslated -->
+    <string name="shop_qty_in_inv">×%1$s in inventory</string> <!-- untranslated -->
     <!-- Translator note: %1$s = formatted coin amount -->
     <string name="shop_price_each">%1$s coins ea.</string> <!-- untranslated -->
     <!-- Translator note: %1$s = item name -->

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -277,6 +277,8 @@
     <string name="settings_profile_layout_tabs">Reiter</string>
     <string name="settings_quest_dots">Quest dots on skills</string> <!-- untranslated -->
     <string name="settings_quest_dots_desc">Show a gold dot on skills that have an open quest</string> <!-- untranslated -->
+    <string name="settings_compact_numbers">Compact Numbers</string> <!-- untranslated -->
+    <string name="settings_compact_numbers_desc">Abbreviate large item quantities (e.g. 2.46M instead of 2,461,940)</string> <!-- untranslated -->
     <string name="settings_home_screen">Startbildschirm</string>
     <string name="settings_home_screen_desc">Wählt aus, was auf dem Startbildschirm angezeigt wird</string>
     <string name="settings_recent_activity">Protokoll der letzten Aktivitäten</string>
@@ -666,7 +668,7 @@
     <string name="quest_legend_gold_dot">Timed quest is available.</string> <!-- untranslated -->
     <string name="quest_legend_notes">Abgeblendete Symbole können noch nicht abgeschlossen werden (Level oder Materialien fehlen). Eine kleine hochgestellte Zahl bedeutet, dass mehrere Quests dieses Typs dasselbe Ziel haben.</string>
     <!-- Translator note: %1$d = quantity -->
-    <string name="shop_qty_in_inv">×%1$d im Inventar</string>
+    <string name="shop_qty_in_inv">×%1$s im Inventar</string>
     <!-- Translator note: %1$s = formatted coin amount -->
     <string name="shop_price_each">je %1$s Münzen</string>
     <!-- Translator note: %1$s = item name -->

--- a/app/src/main/res/values-es-rES/strings.xml
+++ b/app/src/main/res/values-es-rES/strings.xml
@@ -277,6 +277,8 @@
     <string name="settings_profile_layout_tabs">Pestanas</string>
     <string name="settings_quest_dots">Quest dots on skills</string> <!-- untranslated -->
     <string name="settings_quest_dots_desc">Show a gold dot on skills that have an open quest</string> <!-- untranslated -->
+    <string name="settings_compact_numbers">Compact Numbers</string> <!-- untranslated -->
+    <string name="settings_compact_numbers_desc">Abbreviate large item quantities (e.g. 2.46M instead of 2,461,940)</string> <!-- untranslated -->
     <string name="settings_home_screen">Home Screen</string> <!-- untranslated -->
     <string name="settings_home_screen_desc">Choose what appears on the home screen</string> <!-- untranslated -->
     <string name="settings_recent_activity">Recent Activity Log</string> <!-- untranslated -->
@@ -664,7 +666,7 @@
     <string name="quest_legend_gold_dot">Timed quest is available.</string> <!-- untranslated -->
     <string name="quest_legend_notes">Dimmed icons can\'t be completed yet (missing level or materials). A small raised number means several quests of that type want the same thing.</string> <!-- untranslated -->
     <!-- Translator note: %1$d = quantity -->
-    <string name="shop_qty_in_inv">×%1$d en inventario</string>
+    <string name="shop_qty_in_inv">×%1$s en inventario</string>
     <!-- Translator note: %1$s = formatted coin amount -->
     <string name="shop_price_each">%1$s monedas cada una.</string>
     <!-- Translator note: %1$s = item name -->

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -277,6 +277,8 @@
     <string name="settings_profile_layout_tabs">Pestanas</string>
     <string name="settings_quest_dots">Quest dots on skills</string> <!-- untranslated -->
     <string name="settings_quest_dots_desc">Show a gold dot on skills that have an open quest</string> <!-- untranslated -->
+    <string name="settings_compact_numbers">Compact Numbers</string> <!-- untranslated -->
+    <string name="settings_compact_numbers_desc">Abbreviate large item quantities (e.g. 2.46M instead of 2,461,940)</string> <!-- untranslated -->
     <string name="settings_home_screen">Pantalla de Inicio</string>
     <string name="settings_home_screen_desc">Elige qué se muestra en la pantalla de inicio</string>
     <string name="settings_recent_activity">Registro de actividad reciente</string>
@@ -666,7 +668,7 @@
     <string name="quest_legend_gold_dot">Timed quest is available.</string> <!-- untranslated -->
     <string name="quest_legend_notes">Los iconos atenuados aún no se pueden completar (falta nivel o materiales). Un pequeño número elevado indica que varias misiones de ese tipo piden lo mismo.</string>
     <!-- Translator note: %1$d = quantity -->
-    <string name="shop_qty_in_inv">×%1$d en inventario</string>
+    <string name="shop_qty_in_inv">×%1$s en inventario</string>
     <!-- Translator note: %1$s = formatted coin amount -->
     <string name="shop_price_each">%1$s monedas cada una.</string>
     <!-- Translator note: %1$s = item name -->

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -277,6 +277,8 @@
     <string name="settings_profile_layout_tabs">Onglets</string>
     <string name="settings_quest_dots">Point de quête sur aptitudes</string>
     <string name="settings_quest_dots_desc">Montre un point doré sur les aptitudes qui ont une quête possible</string>
+    <string name="settings_compact_numbers">Compact Numbers</string> <!-- untranslated -->
+    <string name="settings_compact_numbers_desc">Abbreviate large item quantities (e.g. 2.46M instead of 2,461,940)</string> <!-- untranslated -->
     <string name="settings_home_screen">Écran d\'Accueil</string>
     <string name="settings_home_screen_desc">Choisir ce qui apparaît sur l\'écran d\'accueil</string>
     <string name="settings_recent_activity">Journal d’activité récente</string>
@@ -667,7 +669,7 @@
     <string name="quest_legend_gold_dot">Une quête temporaire est disponible.</string>
     <string name="quest_legend_notes">Les icônes estompées ne peuvent pas encore être terminées (niveau ou matériaux manquants). Un petit chiffre en exposant indique que plusieurs quêtes de ce type visent la même chose.</string>
     <!-- Translator note: %1$d = quantity -->
-    <string name="shop_qty_in_inv">×%1$d dans l\'inventaire</string>
+    <string name="shop_qty_in_inv">×%1$s dans l\'inventaire</string>
     <!-- Translator note: %1$s = formatted coin amount -->
     <string name="shop_price_each">%1$s pièces l’unité</string>
     <!-- Translator note: %1$s = item name -->

--- a/app/src/main/res/values-ga/strings.xml
+++ b/app/src/main/res/values-ga/strings.xml
@@ -305,6 +305,8 @@
     <string name="settings_profile_layout_tabs">Tábaí</string>
     <string name="settings_quest_dots">Quest dots on skills</string> <!-- untranslated -->
     <string name="settings_quest_dots_desc">Show a gold dot on skills that have an open quest</string> <!-- untranslated -->
+    <string name="settings_compact_numbers">Compact Numbers</string> <!-- untranslated -->
+    <string name="settings_compact_numbers_desc">Abbreviate large item quantities (e.g. 2.46M instead of 2,461,940)</string> <!-- untranslated -->
     <string name="settings_home_screen">Home Screen</string> <!-- untranslated -->
     <string name="settings_home_screen_desc">Choose what appears on the home screen</string> <!-- untranslated -->
     <string name="settings_recent_activity">Recent Activity Log</string> <!-- untranslated -->
@@ -694,7 +696,7 @@
     <string name="quest_legend_gold_dot">Timed quest is available.</string> <!-- untranslated -->
     <string name="quest_legend_notes">Dimmed icons can\'t be completed yet (missing level or materials). A small raised number means several quests of that type want the same thing.</string> <!-- untranslated -->
     <!-- Translator note: %1$d = quantity -->
-    <string name="shop_qty_in_inv">×%1$d in inventory</string> <!-- untranslated -->
+    <string name="shop_qty_in_inv">×%1$s in inventory</string> <!-- untranslated -->
     <!-- Translator note: %1$s = formatted coin amount -->
     <string name="shop_price_each">%1$s coins ea.</string> <!-- untranslated -->
     <!-- Translator note: %1$s = item name -->

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -270,6 +270,8 @@
     <string name="settings_profile_layout_tabs">Tab</string>
     <string name="settings_quest_dots">Quest dots on skills</string> <!-- untranslated -->
     <string name="settings_quest_dots_desc">Show a gold dot on skills that have an open quest</string> <!-- untranslated -->
+    <string name="settings_compact_numbers">Compact Numbers</string> <!-- untranslated -->
+    <string name="settings_compact_numbers_desc">Abbreviate large item quantities (e.g. 2.46M instead of 2,461,940)</string> <!-- untranslated -->
     <string name="settings_home_screen">Layar Beranda</string>
     <string name="settings_home_screen_desc">Pilih apa yang muncul di layar beranda</string>
     <string name="settings_recent_activity">Catatan Aktivitas</string>
@@ -658,7 +660,7 @@
     <string name="quest_legend_gold_dot">Timed quest is available.</string> <!-- untranslated -->
     <string name="quest_legend_notes">Ikon redup belum bisa diselesaikan (level atau bahan kurang). Angka kecil di atas berarti beberapa quest jenis itu menginginkan hal yang sama.</string>
     <!-- Translator note: %1$d = quantity -->
-    <string name="shop_qty_in_inv">×%1$d di inventaris</string>
+    <string name="shop_qty_in_inv">×%1$s di inventaris</string>
     <!-- Translator note: %1$s = formatted coin amount -->
     <string name="shop_price_each">%1$s setiap koin</string>
     <!-- Translator note: %1$s = item name -->

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -277,6 +277,8 @@
     <string name="settings_profile_layout_tabs">Schede</string>
     <string name="settings_quest_dots">Quest dots on skills</string> <!-- untranslated -->
     <string name="settings_quest_dots_desc">Show a gold dot on skills that have an open quest</string> <!-- untranslated -->
+    <string name="settings_compact_numbers">Compact Numbers</string> <!-- untranslated -->
+    <string name="settings_compact_numbers_desc">Abbreviate large item quantities (e.g. 2.46M instead of 2,461,940)</string> <!-- untranslated -->
     <string name="settings_home_screen">Schermata Principale</string>
     <string name="settings_home_screen_desc">Scegli cosa mostrare nella schermata principale</string>
     <string name="settings_recent_activity">Registro delle ultime attività</string>
@@ -666,7 +668,7 @@
     <string name="quest_legend_gold_dot">Timed quest is available.</string> <!-- untranslated -->
     <string name="quest_legend_notes">Le icone attenuate non possono ancora essere completate (livello o materiali mancanti). Un piccolo numero in apice indica che più missioni di quel tipo richiedono la stessa cosa.</string>
     <!-- Translator note: %1$d = quantity -->
-    <string name="shop_qty_in_inv">Hai ×%1$d</string>
+    <string name="shop_qty_in_inv">Hai ×%1$s</string>
     <!-- Translator note: %1$s = formatted coin amount -->
     <string name="shop_price_each">%1$s monete cad.</string>
     <!-- Translator note: %1$s = item name -->

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -277,6 +277,8 @@
     <string name="settings_profile_layout_tabs">タブ</string>
     <string name="settings_quest_dots">Quest dots on skills</string> <!-- untranslated -->
     <string name="settings_quest_dots_desc">Show a gold dot on skills that have an open quest</string> <!-- untranslated -->
+    <string name="settings_compact_numbers">Compact Numbers</string> <!-- untranslated -->
+    <string name="settings_compact_numbers_desc">Abbreviate large item quantities (e.g. 2.46M instead of 2,461,940)</string> <!-- untranslated -->
     <string name="settings_home_screen">ホーム画面</string>
     <string name="settings_home_screen_desc">ホーム画面に表示する内容を選択</string>
     <string name="settings_recent_activity">最近の活動ログ</string>
@@ -666,7 +668,7 @@
     <string name="quest_legend_gold_dot">Timed quest is available.</string> <!-- untranslated -->
     <string name="quest_legend_notes">薄いアイコンはまだ達成できません（レベルや素材が不足）。小さな上付き数字は、同じ対象を求めるクエストがその種類に複数あることを示します。</string>
     <!-- Translator note: %1$d = quantity -->
-    <string name="shop_qty_in_inv">インベントリ所持数: ×%1$d</string>
+    <string name="shop_qty_in_inv">インベントリ所持数: ×%1$s</string>
     <!-- Translator note: %1$s = formatted coin amount -->
     <string name="shop_price_each">各 %1$s コイン</string>
     <!-- Translator note: %1$s = item name -->

--- a/app/src/main/res/values-lt/strings.xml
+++ b/app/src/main/res/values-lt/strings.xml
@@ -277,6 +277,8 @@
     <string name="settings_profile_layout_tabs">Tabs</string> <!-- untranslated -->
     <string name="settings_quest_dots">Quest dots on skills</string> <!-- untranslated -->
     <string name="settings_quest_dots_desc">Show a gold dot on skills that have an open quest</string> <!-- untranslated -->
+    <string name="settings_compact_numbers">Compact Numbers</string> <!-- untranslated -->
+    <string name="settings_compact_numbers_desc">Abbreviate large item quantities (e.g. 2.46M instead of 2,461,940)</string> <!-- untranslated -->
     <string name="settings_home_screen">Home Screen</string> <!-- untranslated -->
     <string name="settings_home_screen_desc">Choose what appears on the home screen</string> <!-- untranslated -->
     <string name="settings_recent_activity">Recent Activity Log</string> <!-- untranslated -->
@@ -666,7 +668,7 @@
     <string name="quest_legend_gold_dot">Timed quest is available.</string> <!-- untranslated -->
     <string name="quest_legend_notes">Dimmed icons can\'t be completed yet (missing level or materials). A small raised number means several quests of that type want the same thing.</string> <!-- untranslated -->
     <!-- Translator note: %1$d = quantity -->
-    <string name="shop_qty_in_inv">×%1$d in inventory</string> <!-- untranslated -->
+    <string name="shop_qty_in_inv">×%1$s in inventory</string> <!-- untranslated -->
     <!-- Translator note: %1$s = formatted coin amount -->
     <string name="shop_price_each">%1$s coins ea.</string> <!-- untranslated -->
     <!-- Translator note: %1$s = item name -->

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -277,6 +277,8 @@
     <string name="settings_profile_layout_tabs">Tabbladen</string>
     <string name="settings_quest_dots">Quest dots on skills</string> <!-- untranslated -->
     <string name="settings_quest_dots_desc">Show a gold dot on skills that have an open quest</string> <!-- untranslated -->
+    <string name="settings_compact_numbers">Compact Numbers</string> <!-- untranslated -->
+    <string name="settings_compact_numbers_desc">Abbreviate large item quantities (e.g. 2.46M instead of 2,461,940)</string> <!-- untranslated -->
     <string name="settings_home_screen">Startscherm</string>
     <string name="settings_home_screen_desc">Kies wat er op het startscherm wordt weergegeven</string>
     <string name="settings_recent_activity">Logboek recente activiteit</string>
@@ -666,7 +668,7 @@
     <string name="quest_legend_gold_dot">Timed quest is available.</string> <!-- untranslated -->
     <string name="quest_legend_notes">Gedimde pictogrammen kunnen nog niet voltooid worden (level of materialen ontbreken). Een klein verhoogd cijfer betekent dat meerdere quests van dat type hetzelfde willen.</string>
     <!-- Translator note: %1$d = quantity -->
-    <string name="shop_qty_in_inv">×%1$d in inventaris</string>
+    <string name="shop_qty_in_inv">×%1$s in inventaris</string>
     <!-- Translator note: %1$s = formatted coin amount -->
     <string name="shop_price_each">%1$s ducaten p/s.</string>
     <!-- Translator note: %1$s = item name -->

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -291,6 +291,8 @@
     <string name="settings_profile_layout_tabs">Zakładki</string>
     <string name="settings_quest_dots">Quest dots on skills</string> <!-- untranslated -->
     <string name="settings_quest_dots_desc">Show a gold dot on skills that have an open quest</string> <!-- untranslated -->
+    <string name="settings_compact_numbers">Compact Numbers</string> <!-- untranslated -->
+    <string name="settings_compact_numbers_desc">Abbreviate large item quantities (e.g. 2.46M instead of 2,461,940)</string> <!-- untranslated -->
     <string name="settings_home_screen">Ekran Główny</string>
     <string name="settings_home_screen_desc">Wybierz, co wyświetla się na ekranie głównym</string>
     <string name="settings_recent_activity">Dziennik ostatniej aktywności</string>
@@ -682,7 +684,7 @@
     <string name="quest_legend_gold_dot">Timed quest is available.</string> <!-- untranslated -->
     <string name="quest_legend_notes">Przyciemnione ikony nie mogą być jeszcze ukończone (brak poziomu lub materiałów). Mała podniesiona cyfra oznacza, że kilka zadań tego typu dotyczy tego samego.</string>
     <!-- Translator note: %1$d = quantity -->
-    <string name="shop_qty_in_inv">×%1$d w ekwipunku</string>
+    <string name="shop_qty_in_inv">×%1$s w ekwipunku</string>
     <!-- Translator note: %1$s = formatted coin amount -->
     <string name="shop_price_each">%1$s monet za szt.</string>
     <!-- Translator note: %1$s = item name -->

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -277,6 +277,8 @@
     <string name="settings_profile_layout_tabs">Abas</string>
     <string name="settings_quest_dots">Quest dots on skills</string> <!-- untranslated -->
     <string name="settings_quest_dots_desc">Show a gold dot on skills that have an open quest</string> <!-- untranslated -->
+    <string name="settings_compact_numbers">Compact Numbers</string> <!-- untranslated -->
+    <string name="settings_compact_numbers_desc">Abbreviate large item quantities (e.g. 2.46M instead of 2,461,940)</string> <!-- untranslated -->
     <string name="settings_home_screen">Tela Inicial</string>
     <string name="settings_home_screen_desc">Escolha o que aparece na tela inicial</string>
     <string name="settings_recent_activity">Registro de Atividade Recente</string>
@@ -666,7 +668,7 @@
     <string name="quest_legend_gold_dot">Timed quest is available.</string> <!-- untranslated -->
     <string name="quest_legend_notes">Ícones esmaecidos ainda não podem ser concluídos (falta nível ou materiais). Um pequeno número elevado indica que várias missões desse tipo pedem a mesma coisa.</string>
     <!-- Translator note: %1$d = quantity -->
-    <string name="shop_qty_in_inv">×%1$d no inventário</string>
+    <string name="shop_qty_in_inv">×%1$s no inventário</string>
     <!-- Translator note: %1$s = formatted coin amount -->
     <string name="shop_price_each">%1$s moedas cada</string>
     <!-- Translator note: %1$s = item name -->

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -291,6 +291,8 @@
     <string name="settings_profile_layout_tabs">Вкладки</string>
     <string name="settings_quest_dots">Quest dots on skills</string> <!-- untranslated -->
     <string name="settings_quest_dots_desc">Show a gold dot on skills that have an open quest</string> <!-- untranslated -->
+    <string name="settings_compact_numbers">Compact Numbers</string> <!-- untranslated -->
+    <string name="settings_compact_numbers_desc">Abbreviate large item quantities (e.g. 2.46M instead of 2,461,940)</string> <!-- untranslated -->
     <string name="settings_home_screen">Главный экран</string>
     <string name="settings_home_screen_desc">Выберите, что отображается на главном экране</string>
     <string name="settings_recent_activity">Журнал последней активности</string>
@@ -682,7 +684,7 @@
     <string name="quest_legend_gold_dot">Timed quest is available.</string> <!-- untranslated -->
     <string name="quest_legend_notes">Тусклые значки пока нельзя выполнить (не хватает уровня или материалов). Маленькая надстрочная цифра означает, что несколько заданий этого типа требуют одного и того же.</string>
     <!-- Translator note: %1$d = quantity -->
-    <string name="shop_qty_in_inv">×%1$d в инвентаре</string>
+    <string name="shop_qty_in_inv">×%1$s в инвентаре</string>
     <!-- Translator note: %1$s = formatted coin amount -->
     <string name="shop_price_each">%1$s монет шт.</string>
     <!-- Translator note: %1$s = item name -->

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -277,6 +277,8 @@
     <string name="settings_profile_layout_tabs">Sekmeler</string>
     <string name="settings_quest_dots">Quest dots on skills</string> <!-- untranslated -->
     <string name="settings_quest_dots_desc">Show a gold dot on skills that have an open quest</string> <!-- untranslated -->
+    <string name="settings_compact_numbers">Compact Numbers</string> <!-- untranslated -->
+    <string name="settings_compact_numbers_desc">Abbreviate large item quantities (e.g. 2.46M instead of 2,461,940)</string> <!-- untranslated -->
     <string name="settings_home_screen">Ana Ekran</string>
     <string name="settings_home_screen_desc">Ana ekranda neyin görüneceğini seç</string>
     <string name="settings_recent_activity">Son Aktivite Günlüğü</string>
@@ -666,7 +668,7 @@
     <string name="quest_legend_gold_dot">Timed quest is available.</string> <!-- untranslated -->
     <string name="quest_legend_notes">Soluk simgeler henüz tamamlanamaz (seviye veya malzeme eksik). Küçük üst simge sayı, aynı hedefi isteyen birden fazla görev olduğunu gösterir.</string>
     <!-- Translator note: %1$d = quantity -->
-    <string name="shop_qty_in_inv">Envanterde ×%1$d adet</string>
+    <string name="shop_qty_in_inv">Envanterde ×%1$s adet</string>
     <!-- Translator note: %1$s = formatted coin amount -->
     <string name="shop_price_each">Tanesi %1$s altın</string>
     <!-- Translator note: %1$s = item name -->

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -277,6 +277,8 @@
     <string name="settings_profile_layout_tabs">标签页</string>
     <string name="settings_quest_dots">Quest dots on skills</string> <!-- untranslated -->
     <string name="settings_quest_dots_desc">Show a gold dot on skills that have an open quest</string> <!-- untranslated -->
+    <string name="settings_compact_numbers">Compact Numbers</string> <!-- untranslated -->
+    <string name="settings_compact_numbers_desc">Abbreviate large item quantities (e.g. 2.46M instead of 2,461,940)</string> <!-- untranslated -->
     <string name="settings_home_screen">主页</string>
     <string name="settings_home_screen_desc">Choose what appears on the home screen</string> <!-- untranslated -->
     <string name="settings_recent_activity">最近行动按钮</string>
@@ -666,7 +668,7 @@
     <string name="quest_legend_gold_dot">Timed quest is available.</string> <!-- untranslated -->
     <string name="quest_legend_notes">Dimmed icons can\'t be completed yet (missing level or materials). A small raised number means several quests of that type want the same thing.</string> <!-- untranslated -->
     <!-- Translator note: %1$d = quantity -->
-    <string name="shop_qty_in_inv">×%1$d in inventory</string> <!-- untranslated -->
+    <string name="shop_qty_in_inv">×%1$s in inventory</string> <!-- untranslated -->
     <!-- Translator note: %1$s = formatted coin amount -->
     <string name="shop_price_each">%1$s 金币/件</string>
     <!-- Translator note: %1$s = item name -->

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -277,6 +277,8 @@
     <string name="settings_profile_layout_tabs">Tabs</string>
     <string name="settings_quest_dots">Quest dots on skills</string>
     <string name="settings_quest_dots_desc">Show a gold dot on skills that have an open quest</string>
+    <string name="settings_compact_numbers">Compact Numbers</string>
+    <string name="settings_compact_numbers_desc">Abbreviate large item quantities (e.g. 2.46M instead of 2,461,940)</string>
     <string name="settings_home_screen">Home Screen</string>
     <string name="settings_home_screen_desc">Choose what appears on the home screen</string>
     <string name="settings_recent_activity">Recent Activity Log</string>
@@ -665,8 +667,8 @@
     <string name="quest_legend_quest">Quest</string>
     <string name="quest_legend_gold_dot">Timed quest is available.</string>
     <string name="quest_legend_notes">Dimmed icons can\'t be completed yet (missing level or materials). A small raised number means several quests of that type want the same thing.</string>
-    <!-- Translator note: %1$d = quantity -->
-    <string name="shop_qty_in_inv">×%1$d in inventory</string>
+    <!-- Translator note: %1$s = quantity in inventory -->
+    <string name="shop_qty_in_inv">×%1$s in inventory</string>
     <!-- Translator note: %1$s = formatted coin amount -->
     <string name="shop_price_each">%1$s coins ea.</string>
     <!-- Translator note: %1$s = item name -->

--- a/app/src/test/kotlin/com/fantasyidler/util/ExtensionsTest.kt
+++ b/app/src/test/kotlin/com/fantasyidler/util/ExtensionsTest.kt
@@ -43,8 +43,31 @@ class ExtensionsTest {
     @Test
     fun `formatCoins uses the same boundaries as formatXp`() {
         assertEquals("500", 500L.formatCoins())
+        assertEquals("500", 500.formatCoins())
         assertEquals("1,000", 1_000L.formatCoins())
+        assertEquals("1,000", 1_000.formatCoins())
         assertEquals("2.5M", 2_500_000L.formatCoins())
+    }
+
+    @Test
+    fun `formatQuantity formats full and compact numbers correctly`() {
+        // Full formatting (compact = false)
+        assertEquals("0", 0.formatQuantity(compact = false))
+        assertEquals("455", 455.formatQuantity(compact = false))
+        assertEquals("1,021", 1_021.formatQuantity(compact = false))
+        assertEquals("35,715", 35_715.formatQuantity(compact = false))
+        assertEquals("2,461,940", 2_461_940.formatQuantity(compact = false))
+
+        // Compact formatting (compact = true)
+        assertEquals("0", 0.formatQuantity(compact = true))
+        assertEquals("455", 455.formatQuantity(compact = true))
+        assertEquals("1k", 1_000.formatQuantity(compact = true))
+        assertEquals("1k", 1_021.formatQuantity(compact = true))
+        assertEquals("1.5k", 1_500.formatQuantity(compact = true))
+        assertEquals("35.7k", 35_715.formatQuantity(compact = true))
+        assertEquals("1M", 1_000_000.formatQuantity(compact = true))
+        assertEquals("2.4M", 2_400_000.formatQuantity(compact = true))
+        assertEquals("2.46M", 2_461_940.formatQuantity(compact = true))
     }
 
     @Test


### PR DESCRIPTION
## Before submitting

- [x] I've tested any changes with the appropriate tests (eg. Unit tests, validation scripts)
- [x] I've pulled and merged the latest changes from the repository

## Summary

Adds digit grouping separators (thousands commas) to the Shop screen (quantities, prices, and transaction totals) and introduces an optional "Compact Numbers" toggle under Settings > Appearance for players who prefer abbreviated numbers (e.g. `2.46M` / `35.7k` instead of full counts).

## Related issue(s) or discussion(s)

## Changelog

- Format shop inventory quantities, unit prices, and transaction totals with digit grouping
- Add `Compact Numbers` toggle under Settings > Appearance to abbreviate large item stacks
- Add `formatQuantity()` extension helper with unit tests

## Anything else?
