### PR TITLE
Update wiki docs: skill categories, prestige notes, and build details

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ See the [contributors graph](https://github.com/tristinbaker/IdleFantasy/graphs/
 **Language:** Kotlin
 **UI:** Jetpack Compose + Material 3  
 **Database:** Room (SQLite)  
-**Background work:** WorkManager  
+**Background work:** AlarmManager  
 **JSON parsing:** kotlinx.serialization  
 **Architecture:** MVVM + Repository  
 **Dependency injection:** Hilt  
@@ -102,7 +102,7 @@ No Google Play Services dependency. F-Droid compatible.
 
 ### Building from source
 
-Requirements: Android Studio Hedgehog or newer, JDK 17+, Android SDK 34
+Requirements: Android Studio Hedgehog or newer, JDK 17+, Android SDK 35
 
 ```bash
 git clone https://github.com/tristinbaker/IdleFantasy.git

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,8 +6,8 @@ Only the latest release of Idle Fantasy receives security updates.
 
 | Version  | Supported          |
 | -------- | ------------------ |
-| 1.8.12   | :white_check_mark: |
-| < 1.8.12 | :x:                |
+| 1.13.8   | :white_check_mark: |
+| < 1.13.8 | :x:                |
 
 ## Reporting a Vulnerability
 

--- a/TRANSLATING.md
+++ b/TRANSLATING.md
@@ -1,6 +1,6 @@
-# Translating Fantasy Idler
+# Translating Idle Fantasy
 
-Thank you for helping translate Fantasy Idler! Translations are managed through
+Thank you for helping translate Idle Fantasy! Translations are managed through
 the project's own translation site at
 **[translate.tristinbaker.xyz](https://translate.tristinbaker.xyz)** — no Git
 knowledge required.

--- a/docs/gen/templates/readme.md
+++ b/docs/gen/templates/readme.md
@@ -88,7 +88,7 @@ See the [contributors graph](https://github.com/tristinbaker/IdleFantasy/graphs/
 **Language:** Kotlin
 **UI:** Jetpack Compose + Material 3  
 **Database:** Room (SQLite)  
-**Background work:** WorkManager  
+**Background work:** AlarmManager  
 **JSON parsing:** kotlinx.serialization  
 **Architecture:** MVVM + Repository  
 **Dependency injection:** Hilt  
@@ -99,7 +99,7 @@ No Google Play Services dependency. F-Droid compatible.
 
 ### Building from source
 
-Requirements: Android Studio Hedgehog or newer, JDK 17+, Android SDK 34
+Requirements: Android Studio Hedgehog or newer, JDK 17+, Android SDK 35
 
 ```bash
 git clone https://github.com/tristinbaker/IdleFantasy.git

--- a/wiki/src/pages.py
+++ b/wiki/src/pages.py
@@ -587,10 +587,10 @@ def gen_skills() -> str:
         ("Fishing", "gathering", "Catch fish and aquatic creatures."),
         ("Woodcutting", "gathering", "Chop trees for logs."),
         ("Farming", "gathering", "Plant seeds and harvest crops."),
-        ("Firemaking", "gathering", "Burn logs for XP. Produces ashes for Prayer."),
-        ("Agility", "gathering", "Reduces session time across all skills (60→40 min at level 99)."),
+        ("Firemaking", "crafting", "Burn logs for XP. Produces ashes for Prayer."),
+        ("Agility", "support", "Reduces session time across all skills (60→40 min at level 99)."),
         ("Thieving", "gathering", "Pickpocket NPCs in the Town for coins and loot."),
-        ("Mercantile", "gathering",
+        ("Mercantile", "support",
          "Send trade caravans and explore skilling expeditions for lore and dungeon unlocks."),
         ("Smithing", "crafting", "Smelt ores into bars and forge equipment."),
         ("Cooking", "crafting", "Cook raw food to restore HP in combat."),
@@ -605,7 +605,7 @@ def gen_skills() -> str:
         ("Ranged", "combat", "Attack from a distance with a bow."),
         ("Magic", "combat", "Cast spells using runes."),
         ("Hitpoints", "combat", "Total health. Increases with combat."),
-        ("Prayer", "combat", "Bury bones to unlock combat prayers."),
+        ("Prayer", "support", "Bury bones to unlock combat prayers."),
         ("Slayer", "combat", "Receive tasks from the Slayer Master to kill specific enemies for bonus XP and points."),
     ]
     rows = [
@@ -1379,6 +1379,8 @@ def gen_shop() -> str:
 
 def _pet_boost(pet: dict) -> str:
     if pet.get("boost_percent"):
+        if pet.get("effect_type") == "coin_boost":
+            return f"+{pet['boost_percent']}% Coins"
         if "boosted_skill" in pet:
             try:
                 return f"+{pet['boost_percent']}% {link(pet["boosted_skill"])} XP"
@@ -1414,7 +1416,7 @@ def gen_workers() -> str:
         ("Long Laborer", 8,  0.5,  5_000,  4.0,  "Uncapped (2 min/item)"),
         ("Apprentice",   8,  1.0,  10_000, 8.0,  "480 items"),
         ("Journeyman",   6,  1.5,  20_000, 9.0,  "540 items (40 sec/item)"),
-        ("Master",       4,  2.0,  50_000, 8.0,  "480 items (30 sec/item)"),
+        ("Master",       4,  2.5,  50_000, 10.0,  "600 items (24 sec/item)"),
     ]
     tier_rows = [
         [name, f"{dur}h", f"{eff:.2f}×", f"{cost:,}", f"{gather:.1f}×", craft]
@@ -1740,6 +1742,7 @@ def gen_titles() -> str:
 
     other_rows = [
         ["Godslayer", "Defeat every raid boss at least once"],
+        ["Patron of the Realm", "Complete the Grand Monument"],
     ]
     other_table = table(["Title", "Requirement"], other_rows)
 

--- a/wiki/templates/combat/combat.md
+++ b/wiki/templates/combat/combat.md
@@ -1,6 +1,6 @@
 # Combat
 
-_Note: The explanations on this page are valid as of v1.12.3 and could be subject to changes in future versions of the game, although we'll do our best to keep this page up-to-date._
+_Note: The explanations on this page are valid as of v1.13.8 and could be subject to changes in future versions of the game, although we'll do our best to keep this page up-to-date._
 
 Combat is a core mechanic of the game allowing you to fight monsters for loot and receive special items only available through combat.
 
@@ -12,7 +12,7 @@ Combat level acts as an overarching level indicating your combat ability. Access
 
 Combat level is calculated using the below formula with a minimum level of at least 1:
 
-$`Combat\ Level = \dfrac{3\times (attackLvl + strengthLvl)}{8} + \dfrac{defenceLvl + hitpointsLvl}{4}`$
+$`Combat\ Level = 0.325 \times (attackLvl + strengthLvl) + 0.25 \times (defenceLvl + hitpointsLvl)`$
 
 ## Dungeons
 
@@ -56,7 +56,7 @@ During the enemy spawning phase, the enemies are spawned from a spawn pool speci
 
 During a single frame, only one enemy type is encountered, and if an enemy is killed during the tick-by-tick combat loop, then the same enemy is respawned repeatedly until the next frame.
 
-If no enemies were killed in a frame then the enemy currently being attacked is carried over to the new frame where combat continues. However, if at least one kill has occurred, any progress towards killing the last enemy is lost once the frame ends.
+If no enemies were killed in a frame then the enemy currently being attacked is carried over to the new frame where combat continues. If at least one kill has occurred, the freshly respawned enemy is only carried over if it took damage before the frame ended — a respawned enemy still at full health is not, so that the session does not become locked onto a single enemy type.
 
 ### Tick-by-tick combat loop
 
@@ -100,7 +100,7 @@ Assuming the player succeeds in hitting the enemy, the damage is a random number
 | Combat Style | Maximum Damage                                                                                              |
 |--------------|-------------------------------------------------------------------------------------------------------------|
 | Melee        | $`maximumDamage = 1 + (playerStrength + weaponStrengthBonus) \times \dfrac{weaponStrengthBonus + 64}{640}`$ |
-| Ranged       | $`maximumDamage = 1 + (playerRanged + arrowStrengthBonus) \times \dfrac{arrowStrengthBonus + 64}{640}`$     |
+| Ranged       | $`maximumDamage = 1 + (playerRanged + rangedGearStrengthBonus + arrowStrengthBonus) \times \dfrac{rangedGearStrengthBonus + arrowStrengthBonus + 64}{640}`$ |
 | Magic        | $`maximumDamage = spellMaxHit`$                                                                             |
 
 #### Phase 2: Enemy respawning / rewards
@@ -128,7 +128,7 @@ $`enemyAttack`$ is calculated as the attack level plus the attack bonus for the 
 
 #### Phase 4: Healing the player
 
-Finally, once both the enemy and the player have had the chance to make hits, the player will heal themselves repeatedly by eating equipped food until the maximum allowed food has been eaten (300) or until there is less missing HP than the food would heal (e.g. the player will stop eating if they have 90/100 HP and the food has > 10 healing power). Additionally, if the enemy can kill the player in a single hit or the current HP is less than half the maximum, the player will also continue to eat.
+Finally, once both the enemy and the player have had the chance to make hits, the player will heal themselves by eating equipped food whenever the current HP is at or below a configurable eat threshold (defaulting to 50% of the player's maximum HP), or whenever the enemy could kill the player in a single hit. Healing is applied up to the player's maximum HP.
 
 Up to a maximum of 300 food can be consumed within a dungeon and the best equipped food (by healing) will be consumed first before lower tier food.
 

--- a/wiki/templates/contributing/getting_started_game.md
+++ b/wiki/templates/contributing/getting_started_game.md
@@ -41,7 +41,7 @@ It's quite common while developing an idea that you come up with lots of additio
 To get started and build the game, you'll need to install [Android Studio](https://developer.android.com/studio). Once done, you'll need to have the following prerequisites:
 
 * JDK 17+
-* Android SDK 34
+* Android SDK 35
 
 Then in the terminal run:
 

--- a/wiki/templates/contributing/getting_started_wiki.md
+++ b/wiki/templates/contributing/getting_started_wiki.md
@@ -61,14 +61,14 @@ From there, you can run the following command to see what you can do:
 # Activate the virtual environment (Only run in Windows terminal)
 .venv/Scripts/activate
 # Activate the virtual environment (Only run in bash terminal)
-source .venv/Scripts/activate
+source .venv/bin/activate
 # See help information for program
 python -m wiki.src -h
 ```
 
-The main command you'll need use is `python -m wiki.src write_html`. This writes out the HTML version of the wiki into `out/IdleFantasy-site`. You can then open any of the HTML pages and the website should come up. If you're using Pycharm, I'd recommend opening it using the Live Preview option which should update things more seamlessly.
+The main command you'll need use is `python -m wiki.src write-html`. This writes out the HTML version of the wiki into `out/IdleFantasy-site`. You can then open any of the HTML pages and the website should come up. If you're using Pycharm, I'd recommend opening it using the Live Preview option which should update things more seamlessly.
 
-`python -m wiki.src validate` is the next most common command which you can use to validate the wiki and perform several tests that can help you pick up errors
+`python -m wiki.src validity` is the next most common command which you can use to validate the wiki and perform several tests that can help you pick up errors
 
 ## Wiki code structure
 

--- a/wiki/templates/miscellaneous/expeditions.md
+++ b/wiki/templates/miscellaneous/expeditions.md
@@ -1,6 +1,6 @@
 # {icon} Expeditions
 
-Expeditions are skilling activities that combine resource gathering with lore discovery. Each expedition is tied to a gathering skill and rewards XP and items as you progress.
+Expeditions are skilling activities that combine resource gathering with lore discovery. Each expedition is tied to a skill and rewards XP and items as you progress.
 
 As you complete expedition sessions, hidden lore notes are gradually uncovered. Collecting all five notes reveals a secret combat dungeon. Some advanced expeditions require an earlier dungeon to have been unlocked before they become available.
 

--- a/wiki/templates/miscellaneous/pets.md
+++ b/wiki/templates/miscellaneous/pets.md
@@ -1,6 +1,6 @@
 # Pets
 
-Pets are rare drops from dungeons and bosses. Each pet provides a permanent passive bonus once collected. Duplicates are automatically converted to coins.
+Pets are rare rewards found throughout the game — raid drops, skill session loot, and prizes from special content like the Carnival shop. Each pet provides a permanent passive bonus once collected.
 
 {pet_table}
 

--- a/wiki/templates/miscellaneous/seasonal_events.md
+++ b/wiki/templates/miscellaneous/seasonal_events.md
@@ -2,7 +2,7 @@
 
 Seasonal Events are limited-time events with their own tasks and rewards. Completing tasks across up to four "pillars" earns Tokens toward the event's reward:
 
-- **Bounty Board** — three rotating task slots (one gathering, one crafting, one combat) tied to the event's theme. Completing a slot's task and claiming it earns a token, then a new task rotates into that slot after a short cooldown.
+- **Bounty Board** — one task slot per bounty type the event uses (gathering, crafting, combat, and sometimes turn-in donations), each offering tasks the player's skill levels can already work on. Claiming a completed task earns a token and starts that slot's rotation cooldown before a new task re-rolls in; slots left untouched re-roll at the daily 6:00 AM reset.
 - **Expedition** — completing the event's featured Expedition earns a token.
 - **Boss** — defeating the event's featured boss earns a token.
 - **Minigame** — winning the event's featured minigame earns a token; it has its own cooldown between attempts, shorter on Hard difficulty.

--- a/wiki/templates/miscellaneous/titles.md
+++ b/wiki/templates/miscellaneous/titles.md
@@ -4,7 +4,7 @@ Titles are permanent, earned once and kept forever — even if the way you earne
 
 ## Skill Mastery
 
-Awarded for completing every quest in a skill's full quest chain. Combat, Agility, and Farming have no quest chain of their own, so they don't have a skill mastery title — see Guild Mastery below for those two instead.
+Awarded for completing every quest in a skill's full quest chain. Combat has a quest chain but no mastery title of its own, while Agility and Farming have no quest chain — those two instead earn their titles through Guild Mastery below.
 
 {skill_table}
 

--- a/wiki/templates/skills/gathering/farming.md
+++ b/wiki/templates/skills/gathering/farming.md
@@ -1,6 +1,6 @@
 # {icon} Farming
 
-Plant seeds in up to **5 patches** and return after the growth time to harvest.
+Plant seeds in up to **5 patches** and return after the growth time to harvest. A **Garden** building adds up to 2 more patches.
 
 {seed_table}
 

--- a/wiki/templates/skills/skills.md
+++ b/wiki/templates/skills/skills.md
@@ -1,6 +1,6 @@
 # Skills
 
-Idle Fantasy has 21 skills split across three categories.
+Idle Fantasy has 23 skills split across four categories: gathering, crafting, support, and combat.
 
 {skills_table}
 
@@ -8,7 +8,7 @@ All skills cap at **level 99**.
 
 ## Prestige
 
-Once a skill reaches level 99 you can prestige it. Prestiging resets the skill back to level 1, but grants a permanent bonus that stays even after the reset. Each skill can be prestiged up to **3 times**. In Ironman mode **you will not receive bonuses from prestiging.**
+Once a skill reaches level 99 you can prestige it. Prestiging resets the skill back to level 1, but grants a permanent bonus that stays even after the reset. Each skill can be prestiged up to **3 times**. Ironman characters **cannot prestige**.
 
 Every skill gains **+10% XP per prestige level** (so +10% at prestige 1, +20% at prestige 2, +30% at prestige 3).
 
@@ -16,7 +16,7 @@ Each prestige level (except combat) also adds a +1 multiplier to the bonus recei
 
 ### Agility prestige
 
-For agility, each prestige level also lowers the floor for the session time by 3 minutes as shown in the table below. Agility capes also provide bonuses to XP instead of yield.
+For agility, each prestige level also lowers the floor for the session time by about 3 minutes as shown in the table below. Agility capes also provide bonuses to XP instead of yield.
 
 {agility_prestige_table}
 

--- a/wiki/templates/skills/support/agility.md
+++ b/wiki/templates/skills/support/agility.md
@@ -6,7 +6,7 @@ Agility reduces session time across **all skills**. Higher levels mean faster se
 
 {session_duration_table}
 
-Duration scales linearly from 60 minutes at level 1 to 40 minutes at level 99. Additionally, each agility prestige reduces the floor by 3 mins. For more info, see {prestige_link}.
+Duration scales linearly from 60 minutes at level 1 to 40 minutes at level 99. Additionally, each agility prestige reduces the floor by about 3 mins. For more info, see {prestige_link}.
 
 ## Courses
 

--- a/wiki/templates/skills/support/prayer.md
+++ b/wiki/templates/skills/support/prayer.md
@@ -4,4 +4,4 @@ Bury bones to earn Prayer XP. Higher-tier bones give more XP. Ashes from Firemak
 
 {prayer_table}
 
-> Tip: Dragon and superior bones give the most XP per session. Farm higher-level dungeons for better bone drops.
+> Tip: Dragon and giant bones give the most XP per session. Farm higher-level dungeons for better bone drops.

--- a/wiki/templates/town/guilds.md
+++ b/wiki/templates/town/guilds.md
@@ -14,7 +14,7 @@ Upgrading the **Guild Hall** building reduces quest requirements. See the [Build
 
 ## Daily Guild Quests
 
-Each guild also offers a rotating daily quest, refreshed at 6 AM, that counts toward the dailies requirement for your current guild level.
+Each guild also offers up to four rotating daily quests, refreshed at 6 AM, that count toward the dailies requirement for your current guild level.
 
 ---
 

--- a/wiki/templates/town/workers.md
+++ b/wiki/templates/town/workers.md
@@ -11,7 +11,7 @@ There are two worker slots:
 
 Every hire is one job per hire: the worker is dismissed as soon as you collect their session, in both slots. Hire a new worker to keep that slot working.
 
-Each worker has a daily name that changes at 6 AM. Firing and rehiring on the same day gives you a new random name from the same pool.
+Each worker's daily name is seeded for the day and changes at 6 AM. Rehiring the same tier on the same day shows the same name again, unless that name is already taken by the other worker slot.
 
 ## Worker Tiers
 


### PR DESCRIPTION
## Before submitting

- [x] I've tested any changes with the appropriate tests (eg. Unit tests, validation scripts)
- [x] I've pulled and merged the latest changes from the repository

## Summary

Updates the wiki and repo docs to reflect current game state: corrected skill category assignments (Firemaking → crafting, Agility → support, Mercantile → support, Prayer → support), updated the skills overview to list 23 skills across four categories, clarified prestige rules for Ironman characters, and refreshed build details in README (AlarmManager as background work, Android SDK 35).

## Changelog

- Corrected skill category assignments in skills table (Firemaking → crafting, Agility → support, Mercantile → support, Prayer → support)
- Updated skills overview: 21 → 23 skills across four categories (gathering, crafting, support, combat)
- Clarified prestige rules — Ironman characters cannot prestige
- Added "Patron of the Realm" title to titles table
- Added coin boost effect display for pets (effect_type = coin_boost)
- Updated Master worker tier stats (efficiency, gathering, craft times)
- Updated README: AlarmManager as background work, Android SDK version bump to 35
- Minor wording fixes across wiki pages (agility, expedition, etc.)