### PR TITLE
feat: add skirts for slayer and tower rewards

### DIFF
--- a/app/src/main/assets/data/equipment.json
+++ b/app/src/main/assets/data/equipment.json
@@ -1693,6 +1693,19 @@
       "defense": 45
     }
   },
+  "slayer_plateskirt": {
+    "name": "slayer_plateskirt",
+    "display_name": "Slayer Plateskirt",
+    "slot": "legs",
+    "combat_style": null,
+    "description": "Protective skirt crafted for extended dungeon runs.",
+    "attack_bonus": 0,
+    "strength_bonus": 0,
+    "defense_bonus": 65,
+    "requirements": {
+      "defense": 45
+    }
+  },
   "runite_med_helmet": {
     "name": "runite_med_helmet",
     "display_name": "Runite Med Helmet",

--- a/app/src/main/assets/data/equipment.json
+++ b/app/src/main/assets/data/equipment.json
@@ -814,7 +814,7 @@
     "requirements": {
       "ranged": 50
     },
-    "ranged_strength_bonus": 48  
+    "ranged_strength_bonus": 48
   },
   "magic_shortbow": {
     "name": "magic_shortbow",
@@ -886,7 +886,7 @@
     "defense_bonus": 2,
     "requirements": {
       "magic": 5
-    }  
+    }
   },
   "staff_of_air": {
     "name": "staff_of_air",

--- a/app/src/main/assets/data/equipment.json
+++ b/app/src/main/assets/data/equipment.json
@@ -1924,6 +1924,18 @@
       "defense": 70
     }
   },
+  "tower_plateskirt": {
+    "name": "tower_plateskirt",
+    "display_name": "Tower Plateskirt",
+    "slot": "legs",
+    "description": "A plateskirt forged in the tower's deepest forge.",
+    "attack_bonus": 0,
+    "strength_bonus": 0,
+    "defense_bonus": 125,
+    "requirements": {
+      "defense": 70
+    }
+  },
   "tower_boots": {
     "name": "tower_boots",
     "display_name": "Tower Boots",

--- a/app/src/main/kotlin/com/fantasyidler/ui/screen/SlayerScreen.kt
+++ b/app/src/main/kotlin/com/fantasyidler/ui/screen/SlayerScreen.kt
@@ -77,6 +77,7 @@ private val SHOP_ITEMS = listOf(
     ShopItem("abyssal_whip",       R.string.item_abyssal_whip_name, R.string.item_abyssal_whip_desc,  cost = 300, isEquipment = true),
     ShopItem("slayer_platebody",   R.string.item_slayer_platebody_name, R.string.item_slayer_platebody_desc, cost = 350, isEquipment = true),
     ShopItem("slayer_platelegs",   R.string.item_slayer_platelegs_name, R.string.item_slayer_platelegs_desc, cost = 250, isEquipment = true),
+    ShopItem("slayer_plateskirt",   R.string.item_slayer_plateskirt_name, R.string.item_slayer_plateskirt_desc, cost = 250, isEquipment = true),
 )
 
 @OptIn(ExperimentalMaterial3Api::class)

--- a/app/src/main/kotlin/com/fantasyidler/ui/viewmodel/SlayerViewModel.kt
+++ b/app/src/main/kotlin/com/fantasyidler/ui/viewmodel/SlayerViewModel.kt
@@ -83,7 +83,7 @@ class SlayerViewModel @Inject constructor(
 
     /** Equipment data keyed by item key, for the shop stats display. */
     val shopEquipment: Map<String, EquipmentData> by lazy {
-        listOf("slayer_helm", "abyssal_whip", "slayer_platebody", "slayer_platelegs")
+        listOf("slayer_helm", "abyssal_whip", "slayer_platebody", "slayer_platelegs", "slayer_plateskirt")
             .mapNotNull { key -> gameData.equipment[key]?.let { key to it } }
             .toMap()
     }

--- a/app/src/main/kotlin/com/fantasyidler/ui/viewmodel/TowerViewModel.kt
+++ b/app/src/main/kotlin/com/fantasyidler/ui/viewmodel/TowerViewModel.kt
@@ -83,7 +83,7 @@ class TowerViewModel @Inject constructor(
 ) : ViewModel() {
 
     init {
-        // Tower Boots joined the floor 150 milestone after many players had already
+        // Tower Boots and Tower Plateskirt joined the floor 150 milestone after many players had already
         // claimed it; grant them once retroactively since milestones can't be re-claimed
         viewModelScope.launch {
             val flags = playerRepo.getFlags()
@@ -91,6 +91,9 @@ class TowerViewModel @Inject constructor(
                 val inventory: Map<String, Int> = json.decodeFromString(playerRepo.getOrCreatePlayer().inventory)
                 if ("tower_boots" !in inventory) {
                     playerRepo.addItems(mapOf("tower_boots" to 1))
+                }
+                if ("tower_plateskirt" !in inventory) {
+                	playerRepo.addItems(mapOf("tower_plateskirt" to 1))
                 }
             }
         }
@@ -136,7 +139,7 @@ class TowerViewModel @Inject constructor(
             TowerMilestone(120, "Tower Plate (defense +132)"),
             TowerMilestone(130, "+2% tower XP all skills"),
             TowerMilestone(140, "100,000 coins"),
-            TowerMilestone(150, "Tower Legs (defense +125) + Tower Boots (defense +58)"),
+            TowerMilestone(150, "Tower Legs (defense +125) + Tower Boots (defense +58) + Tower Plateskirt (defense +125)"),
             TowerMilestone(160, "+50 max HP"),
             TowerMilestone(170, "+1% tower coin drops"),
             TowerMilestone(180, "Tower Sword (attack +72, strength +75)"),
@@ -633,7 +636,7 @@ class TowerViewModel @Inject constructor(
                 120 -> playerRepo.addItems(mapOf("tower_body" to 1))
                 130 -> newFlags = newFlags.copy(towerXpBonusPct = newFlags.towerXpBonusPct + 2)
                 140 -> playerRepo.addCoins(100_000L)
-                150 -> playerRepo.addItems(mapOf("tower_legs" to 1, "tower_boots" to 1))
+                150 -> playerRepo.addItems(mapOf("tower_legs" to 1, "tower_boots" to 1, "tower_plateskirt" to 1))
                 160 -> newFlags = newFlags.copy(towerHpBonus = newFlags.towerHpBonus + 5)
                 170 -> newFlags = newFlags.copy(towerCoinBonusPct = newFlags.towerCoinBonusPct + 1)
                 180 -> playerRepo.addItems(mapOf("tower_sword" to 1))

--- a/app/src/main/res/values/strings_items.xml
+++ b/app/src/main/res/values/strings_items.xml
@@ -1065,6 +1065,8 @@
     <string name="item_tower_body_desc">Impenetrable armour from the tower\'s inner sanctum.</string>
     <string name="item_tower_legs_name">Tower Greaves</string>
     <string name="item_tower_legs_desc">Greaves forged in the tower\'s deepest forge.</string>
+    <string name="item_tower_plateskirt_name">Tower Plateskirt</string>
+    <string name="item_tower_plateskirt_desc">A Plateskirt forged in the tower\'s deepest forge.</string>
     <string name="item_tower_boots_name">Tower Boots</string>
     <string name="item_tower_boots_desc">Boots forged in the tower\'s deepest forge.</string>
     <string name="item_tower_shield_name">Tower Shield</string>

--- a/app/src/main/res/values/strings_items.xml
+++ b/app/src/main/res/values/strings_items.xml
@@ -321,6 +321,8 @@
     <string name="item_slayer_platebody_desc">Heavy armour etched with slayer runes.</string>
     <string name="item_slayer_platelegs_name">Slayer Platelegs</string>
     <string name="item_slayer_platelegs_desc">Protective legs crafted for extended dungeon runs.</string>
+    <string name="item_slayer_plateskirt_name">Slayer Plateskirt</string>
+    <string name="item_slayer_plateskirt_desc">Protective skirt crafted for extended dungeon runs.</string>
 
     <!-- ===== Tools — pickaxes ===== -->
     <string name="item_bronze_pickaxe_name">Bronze Pickaxe</string>


### PR DESCRIPTION
## Before submitting

- [x] I've tested any changes with the appropriate tests (eg. Unit tests, validation scripts)
- [x] I've pulled and merged the latest changes from the repository

## Summary

<!-- Short summary of the pull request and what it changes -->
Adds two skirts which are identical in stats to their greaves/pants counterparts.


## Related issue(s) or discussion(s)

<!-- Prepend issues with "Fixes" if this should close the issue, e.g. Fixes #283, Relates to #284 -->



## Changelog

<!-- Concise list of changes, e.g.
- Fix time-slot bug causing XP gains to not show in notification banner
- Added ellipsis for quests XP gains exceeding screen width
-->

- Added `tower_plateskirt` & `slayer_plateskirt` to equipment.json
- Added translatable strings to both items. 
- Made sure to retroactively give the tower plateskirt to players who have already claimed the milestone it is apart of. 
- Added the slayer plateskirt to the slayer shop.


## Anything else?

Tests I performed:
```yaml
Tests:
  
  Tower Plateskirt:
    Item is present in inventory?: yes
    Item can be equipped?: yes
    Given to player on claim interaction?: yes
    Given to player retroactivley?: yes
    Displays in milestone rewards list?: yes
    Displays in armory correctly?: yes

  Slayer Plateskirt:
    Displays in shop correctly?: yes
    Can buy?: yes
    Can equip?: yes
    Translatable?: yes
    Displays in armory correctly?: yes
```

This is my first time adding translatable new text, and also my first pull request. Let me know if anything needs changing. 
