### PR TITLE
Add skill icons to Expeditions screen

### DIFF
--- a/app/src/main/kotlin/com/fantasyidler/ui/screen/ExpeditionsScreen.kt
+++ b/app/src/main/kotlin/com/fantasyidler/ui/screen/ExpeditionsScreen.kt
@@ -1,6 +1,9 @@
 package com.fantasyidler.ui.screen
 
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -8,9 +11,11 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material3.Button
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
@@ -18,11 +23,12 @@ import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.text.font.FontWeight
@@ -30,7 +36,6 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.compose.ui.platform.LocalContext
 import com.fantasyidler.R
-import com.fantasyidler.ui.viewmodel.ExpeditionsUiState
 import com.fantasyidler.ui.viewmodel.ExpeditionsViewModel
 import com.fantasyidler.ui.viewmodel.SkillingDungeonUiItem
 import com.fantasyidler.util.GameStrings
@@ -72,12 +77,25 @@ fun ExpeditionsScreen(
                 val dungeons = state.dungeonsBySkill[skill]
                 if (!dungeons.isNullOrEmpty()) {
                     item {
-                        Text(
-                            text = GameStrings.skillName(context, skill),
-                            style = MaterialTheme.typography.titleMedium,
-                            fontWeight = FontWeight.Bold,
+                        Row(
+                            verticalAlignment = Alignment.CenterVertically,
                             modifier = Modifier.padding(top = 8.dp, bottom = 4.dp),
-                        )
+                        ) {
+                            val iconRes = GameStrings.skillIconRes(skill)
+                            if (iconRes != null) {
+                                Image(
+                                    painter = painterResource(iconRes),
+                                    contentDescription = null,
+                                    modifier = Modifier.size(18.dp),
+                                )
+                                Spacer(modifier = Modifier.width(8.dp))
+                            }
+                            Text(
+                                text = GameStrings.skillName(context, skill),
+                                style = MaterialTheme.typography.titleMedium,
+                                fontWeight = FontWeight.Bold,
+                            )
+                        }
                     }
                     items(dungeons, key = { it.key }) { item ->
                         SkillingDungeonCard(


### PR DESCRIPTION
## Before submitting

- [x] I've tested any changes with the appropriate tests (eg. Unit tests, validation scripts)
- [x] I've pulled and merged the latest changes from the repository

## Summary

Adds askill-icon badge next to each skill section header on the Expeditions screen, reusing the existing `GameStrings.skillIconRes()` drawables (mining, woodcutting, fishing, agility, thieving) already used elsewhere in the app.

<img width="506" height="987" alt="image" src="https://github.com/user-attachments/assets/25b13542-6105-4b91-a95e-ae588e0e1cea" />

## Related issue(s) or discussion(s)


## Changelog

- Added skill icon badges to Expeditions screen section headers

## Anything else?