### PR TITLE
Add combat style icons to Combat > Gear

### DIFF
--- a/app/src/main/kotlin/com/fantasyidler/ui/screen/CombatScreen.kt
+++ b/app/src/main/kotlin/com/fantasyidler/ui/screen/CombatScreen.kt
@@ -16,9 +16,9 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
-import androidx.compose.foundation.verticalScroll
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.BottomSheetDefaults
@@ -32,9 +32,7 @@ import androidx.compose.material3.IconButton
 import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalBottomSheet
-import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Scaffold
-import androidx.compose.material3.Surface
 import androidx.compose.material3.ScrollableTabRow
 import androidx.compose.material3.Tab
 import androidx.compose.material3.TabRow
@@ -53,7 +51,6 @@ import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.mutableLongStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.saveable.rememberSaveable
@@ -63,7 +60,6 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
@@ -73,25 +69,19 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
-import kotlin.math.roundToInt
-import com.fantasyidler.BuildConfig
 import com.fantasyidler.R
 import com.fantasyidler.simulator.CombatSimulator
 import com.fantasyidler.data.json.BossData
 import com.fantasyidler.data.json.CookingRecipe
 import com.fantasyidler.data.json.DungeonData
-import com.fantasyidler.data.json.EnemyData
 import com.fantasyidler.data.json.EquipmentData
 import com.fantasyidler.data.json.SpellData
 import androidx.compose.foundation.layout.ExperimentalLayoutApi
-import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.WindowInsetsSides
 import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.safeDrawing
 import com.fantasyidler.data.model.EquipSlot
-import com.fantasyidler.data.model.SessionFrame
-import com.fantasyidler.data.model.SkillSession
 import com.fantasyidler.data.model.Skills
 import com.fantasyidler.ui.theme.ScaledSheetContent
 import com.fantasyidler.ui.viewmodel.CombatViewModel
@@ -100,13 +90,8 @@ import com.fantasyidler.ui.viewmodel.combatLevelFrom
 import com.fantasyidler.ui.viewmodel.slotDisplayName
 import com.fantasyidler.ui.viewmodel.xpProgressFraction
 import com.fantasyidler.util.GameStrings
-import com.fantasyidler.util.formatCoins
 import com.fantasyidler.util.formatXp
-import com.fantasyidler.util.toCountdown
-import com.fantasyidler.util.toTitleCase
-import kotlinx.coroutines.delay
-import kotlinx.serialization.decodeFromString
-import kotlinx.serialization.json.Json
+
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun CombatScreen(
@@ -565,16 +550,28 @@ private fun CombatGearTab(
     LazyColumn(modifier = Modifier.fillMaxSize()) {
         item { SlotSectionHeader(stringResource(R.string.profile_combat_style)) }
         item {
-            FlowRow(
-                modifier              = Modifier.padding(horizontal = 16.dp, vertical = 4.dp),
+            Row(
+                modifier              = Modifier
+                    .horizontalScroll(rememberScrollState())
+                    .padding(horizontal = 12.dp, vertical = 4.dp),
                 horizontalArrangement = Arrangement.spacedBy(8.dp),
             ) {
                 EquipSlot.WEAPON_SLOTS.forEach { slot ->
                     val style = EquipSlot.combatStyleForSlot(slot)!!
+                    val iconRes = GameStrings.skillIconRes(style)
                     FilterChip(
                         selected = activeWeaponSlot == slot,
                         onClick  = { onSelectStyle(slot) },
                         label    = { Text(GameStrings.skillName(context, style)) },
+                        leadingIcon = if (iconRes != null) {
+                            {
+                                Image(
+                                    painter = painterResource(iconRes),
+                                    contentDescription = null,
+                                    modifier = Modifier.size(16.dp),
+                                )
+                            }
+                        } else null,
                     )
                 }
             }


### PR DESCRIPTION
## Before submitting

- [x] I've tested any changes with the appropriate tests (eg. Unit tests, validation scripts)
- [x] I've pulled and merged the latest changes from the repository

## Summary

Adds a skill icon to each combat style chip (attack/strength/ranged/magic) on the Combat > Gear tab.

<img width="504" height="311" alt="image" src="https://github.com/user-attachments/assets/b3d521f4-68c0-4780-a16c-cdac231f4b78" />


## Related issue(s) or discussion(s)


## Changelog

- Added skill icons to combat style filter chips on the Gear Page

## Anything else?