### PR TITLE
Fix guild hall skill section sorting

### DIFF
--- a/app/src/main/kotlin/com/fantasyidler/ui/screen/GuildHallScreen.kt
+++ b/app/src/main/kotlin/com/fantasyidler/ui/screen/GuildHallScreen.kt
@@ -61,15 +61,15 @@ private val GUILD_GROUPS = listOf(
     ),
     GuildGroup(
         headerRes = R.string.label_crafting_skills,
-        keys = listOf("smithing", "cooking", "fletching", "crafting", "runecrafting", "herblore", "firemaking", "construction"),
-    ),
-    GuildGroup(
-        headerRes = R.string.label_combat,
-        keys = listOf("warriors", "archers", "mages", "slayer"),
+        keys = listOf("smithing", "cooking", "fletching", "crafting", "firemaking", "runecrafting", "herblore", "construction"),
     ),
     GuildGroup(
         headerRes = R.string.label_support_skills,
         keys = listOf("prayer", "mercantile", "agility"),
+    ),
+    GuildGroup(
+        headerRes = R.string.label_combat,
+        keys = listOf("warriors", "archers", "mages", "slayer"),
     ),
 )
 


### PR DESCRIPTION
## Before submitting

- [x] I've tested any changes with the appropriate tests (eg. Unit tests, validation scripts)
- [x] I've pulled and merged the latest changes from the repository

## Summary

It has always bothered me that the skills sorting and the skills in the guild hall differs. Reordered them accordingly to match in both places, and not cause confusion. I followed the wiki and the README on the correct order. Please tell me if we should follow a different format entirely. 

**From Readme:**
<img width="1140" height="350" alt="image" src="https://github.com/user-attachments/assets/f0536f62-0185-42dd-829c-060c88af9258" />

**From Wiki:**
<img width="1146" height="440" alt="image" src="https://github.com/user-attachments/assets/bd9af33f-96b0-49ee-93f2-7287b6f6e4d3" />

Reorders the Guild Hall skills to match skill ordering used in Skills page: 
1. Firemaking Guild now sits above Runecrafting Guild.
2. Combat section is moved to the end of the list.

## Related issue(s) or discussion(s)


## Changelog

- Fix the guild hall skill sorting to match Skills ordering

## Anything else?