### PR TITLE
Fix profile tab resetting when navigating away and back

### DIFF
--- a/app/src/main/kotlin/com/fantasyidler/ui/navigation/AppNavigation.kt
+++ b/app/src/main/kotlin/com/fantasyidler/ui/navigation/AppNavigation.kt
@@ -140,7 +140,7 @@ fun AppNavigation(
                                         saveState = true
                                     }
                                     launchSingleTop = true
-                                    restoreState = !isHome && screen !is Screen.Profile
+                                    restoreState = !isHome
                                 }
                             }
                         },

--- a/app/src/main/kotlin/com/fantasyidler/ui/screen/ProfileScreen.kt
+++ b/app/src/main/kotlin/com/fantasyidler/ui/screen/ProfileScreen.kt
@@ -63,6 +63,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -137,7 +138,7 @@ fun ProfileScreen(
         stringResource(R.string.tab_bonuses),
         stringResource(R.string.label_banners),
     )
-    var selectedTab  by remember { mutableIntStateOf(0) }
+    var selectedTab  by rememberSaveable { mutableIntStateOf(0) }
     var showEditSheet by remember { mutableStateOf(false) }
     var showAppearanceSheet by remember { mutableStateOf(false) }
     var showAddItemSheet by remember { mutableStateOf(false) }


### PR DESCRIPTION
## Before submitting

- [x] I've tested any changes with the appropriate tests (eg. Unit tests, validation scripts)
- [x] I've pulled and merged the latest changes from the repository

## Summary

Navigating away from the Profile screen and back reset the selected tab to the first tab instead of restoring the tab the user was previously on. It doesn't seem to be the expected behaviour, since other tabs are not doing the same. 

**Before PR (ignore the stats section, I'm doesn't belong in this PR)**

https://github.com/user-attachments/assets/da65eabf-9615-4309-b379-dc98c0905bd9


**After PR**

https://github.com/user-attachments/assets/7537e6f2-6a6c-4668-aace-e2256919da18


## Related issue(s) or discussion(s)


## Changelog

- Restore Profile screen state (including tab selection) when navigating back to it.

## Anything else?