### PR TITLE
Add shared PlayerStatsBar component and surface it on the Profile screen

### DIFF
--- a/app/src/main/kotlin/com/fantasyidler/ui/component/PlayerStatsBar.kt
+++ b/app/src/main/kotlin/com/fantasyidler/ui/component/PlayerStatsBar.kt
@@ -1,0 +1,116 @@
+package com.fantasyidler.ui.component
+
+import android.content.Context
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Star
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import com.fantasyidler.R
+import com.fantasyidler.data.json.BlessingType
+import com.fantasyidler.repository.ChurchRepository
+import com.fantasyidler.ui.screen.StatInline
+import com.fantasyidler.util.formatCoins
+import com.fantasyidler.util.formatDurationMs
+
+@OptIn(ExperimentalLayoutApi::class)
+@Composable
+fun PlayerStatsBar(
+    context: Context,
+    combatLevel: Int,
+    totalLevel: Int,
+    coins: Long,
+    activeBlessingKey: String,
+    activeBlessingRemainingMs: Long,
+    xpBoostRemainingMs: Long,
+    modifier: Modifier = Modifier,
+) {
+    val blessingActive = activeBlessingKey.isNotEmpty() && activeBlessingRemainingMs > 0
+    val boostActive = xpBoostRemainingMs > 0
+
+    Column(modifier) {
+        FlowRow(
+            modifier              = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalArrangement   = Arrangement.spacedBy(4.dp),
+        ) {
+            StatInline(
+                label = stringResource(R.string.label_combat_level),
+                value = combatLevel.toString(),
+            )
+            StatInline(
+                label = stringResource(R.string.label_total_level),
+                value = totalLevel.toString(),
+            )
+            StatInline(
+                label      = stringResource(R.string.label_coins),
+                value      = coins.formatCoins(),
+                valueColor = MaterialTheme.colorScheme.primary,
+            )
+        }
+        if (blessingActive) {
+            val nameResId = context.resources.getIdentifier(
+                "blessing_${activeBlessingKey}_name", "string", context.packageName,
+            )
+            val blessingName = if (nameResId != 0) stringResource(nameResId) else activeBlessingKey
+            val blessingData = ChurchRepository.ALL_BLESSINGS.firstOrNull { it.key == activeBlessingKey }
+            val boostDesc = blessingData?.let { b ->
+                when (b.type) {
+                    BlessingType.XP      -> "${b.magnitude}x XP"
+                    BlessingType.DEFENSE -> "+${b.magnitude.toInt()} DEF"
+                    BlessingType.COINS   -> "+${(b.magnitude * 100).toInt()}% coins"
+                }
+            }
+            val timeLeft = activeBlessingRemainingMs.formatDurationMs(context)
+            val blessingText = if (boostDesc != null) "$blessingName ($boostDesc) - $timeLeft"
+                              else "$blessingName - $timeLeft"
+            Spacer(Modifier.height(4.dp))
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Icon(
+                    imageVector        = Icons.Filled.Star,
+                    contentDescription = null,
+                    tint               = MaterialTheme.colorScheme.primary,
+                    modifier           = Modifier.size(12.dp),
+                )
+                Spacer(Modifier.width(4.dp))
+                Text(
+                    text  = blessingText,
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.primary,
+                )
+            }
+        }
+        if (boostActive) {
+            Spacer(Modifier.height(4.dp))
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Icon(
+                    imageVector        = Icons.Filled.Star,
+                    contentDescription = null,
+                    tint               = MaterialTheme.colorScheme.tertiary,
+                    modifier           = Modifier.size(12.dp),
+                )
+                Spacer(Modifier.width(4.dp))
+                Text(
+                    text  = stringResource(R.string.home_xp_boost_active, xpBoostRemainingMs.formatDurationMs(context)),
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.tertiary,
+                )
+            }
+        }
+    }
+}

--- a/app/src/main/kotlin/com/fantasyidler/ui/screen/HomeScreen.kt
+++ b/app/src/main/kotlin/com/fantasyidler/ui/screen/HomeScreen.kt
@@ -88,8 +88,7 @@ import com.fantasyidler.data.model.HiredWorker
 import com.fantasyidler.data.model.QueuedAction
 import com.fantasyidler.data.model.SkillSession
 import com.fantasyidler.data.model.WorkerTier
-import com.fantasyidler.data.json.BlessingType
-import com.fantasyidler.repository.ChurchRepository
+import com.fantasyidler.ui.component.PlayerStatsBar
 import com.fantasyidler.ui.theme.ScaledSheetContent
 import com.fantasyidler.ui.viewmodel.HomeViewModel
 import com.fantasyidler.ui.viewmodel.SessionSummary
@@ -99,7 +98,6 @@ import com.fantasyidler.util.GameStrings
 import com.fantasyidler.util.formatCoins
 import com.fantasyidler.util.formatXp
 import com.fantasyidler.simulator.XpTable
-import com.fantasyidler.util.formatDurationMs
 import com.fantasyidler.util.toCountdown
 import androidx.compose.ui.text.style.TextOverflow
 import kotlinx.coroutines.delay
@@ -618,84 +616,21 @@ fun HomeScreen(
 
             // ── Stats bar ───────────────────────────────────────────────
             if (state.showStatsBar) {
-                val blessingActive = state.activeBlessingKey.isNotEmpty() && state.activeBlessingRemainingMs > 0
-                val boostActive = state.xpBoostRemainingMs > 0
                 Surface(
                     shape    = RoundedCornerShape(16.dp),
                     color    = MaterialTheme.colorScheme.surfaceVariant,
                     modifier = Modifier.fillMaxWidth(),
                 ) {
-                    Column(Modifier.padding(horizontal = 16.dp, vertical = 10.dp)) {
-                        FlowRow(
-                            modifier              = Modifier.fillMaxWidth(),
-                            horizontalArrangement = Arrangement.SpaceBetween,
-                            verticalArrangement   = Arrangement.spacedBy(4.dp),
-                        ) {
-                            StatInline(
-                                label = stringResource(R.string.label_combat_level),
-                                value = combatLevelFrom(state.skillLevels).toString(),
-                            )
-                            StatInline(
-                                label = stringResource(R.string.label_total_level),
-                                value = totalLevelFrom(state.skillLevels).toString(),
-                            )
-                            StatInline(
-                                label      = stringResource(R.string.label_coins),
-                                value      = state.coins.formatCoins(),
-                                valueColor = MaterialTheme.colorScheme.primary,
-                            )
-                        }
-                        if (blessingActive) {
-                            val context = LocalContext.current
-                            val nameResId = context.resources.getIdentifier(
-                                "blessing_${state.activeBlessingKey}_name", "string", context.packageName,
-                            )
-                            val blessingName = if (nameResId != 0) stringResource(nameResId) else state.activeBlessingKey
-                            val blessingData = ChurchRepository.ALL_BLESSINGS.firstOrNull { it.key == state.activeBlessingKey }
-                            val boostDesc = blessingData?.let { b ->
-                                when (b.type) {
-                                    BlessingType.XP      -> "${b.magnitude}x XP"
-                                    BlessingType.DEFENSE -> "+${b.magnitude.toInt()} DEF"
-                                    BlessingType.COINS   -> "+${(b.magnitude * 100).toInt()}% coins"
-                                }
-                            }
-                            val timeLeft = state.activeBlessingRemainingMs.formatDurationMs(context)
-                            val blessingText = if (boostDesc != null) "$blessingName ($boostDesc) - $timeLeft"
-                                              else "$blessingName - $timeLeft"
-                            Spacer(Modifier.height(4.dp))
-                            Row(verticalAlignment = Alignment.CenterVertically) {
-                                Icon(
-                                    imageVector        = Icons.Filled.Star,
-                                    contentDescription = null,
-                                    tint               = MaterialTheme.colorScheme.primary,
-                                    modifier           = Modifier.size(12.dp),
-                                )
-                                Spacer(Modifier.width(4.dp))
-                                Text(
-                                    text  = blessingText,
-                                    style = MaterialTheme.typography.labelSmall,
-                                    color = MaterialTheme.colorScheme.primary,
-                                )
-                            }
-                        }
-                        if (boostActive) {
-                            Spacer(Modifier.height(4.dp))
-                            Row(verticalAlignment = Alignment.CenterVertically) {
-                                Icon(
-                                    imageVector        = Icons.Filled.Star,
-                                    contentDescription = null,
-                                    tint               = MaterialTheme.colorScheme.tertiary,
-                                    modifier           = Modifier.size(12.dp),
-                                )
-                                Spacer(Modifier.width(4.dp))
-                                Text(
-                                    text  = stringResource(R.string.home_xp_boost_active, state.xpBoostRemainingMs.formatDurationMs(context)),
-                                    style = MaterialTheme.typography.labelSmall,
-                                    color = MaterialTheme.colorScheme.tertiary,
-                                )
-                            }
-                        }
-                    }
+                    PlayerStatsBar(
+                        context                    = context,
+                        combatLevel                = combatLevelFrom(state.skillLevels),
+                        totalLevel                 = totalLevelFrom(state.skillLevels),
+                        coins                      = state.coins,
+                        activeBlessingKey          = state.activeBlessingKey,
+                        activeBlessingRemainingMs  = state.activeBlessingRemainingMs,
+                        xpBoostRemainingMs         = state.xpBoostRemainingMs,
+                        modifier                   = Modifier.padding(horizontal = 16.dp, vertical = 10.dp),
+                    )
                 }
             }
 

--- a/app/src/main/kotlin/com/fantasyidler/ui/screen/ProfileScreen.kt
+++ b/app/src/main/kotlin/com/fantasyidler/ui/screen/ProfileScreen.kt
@@ -87,6 +87,7 @@ import com.fantasyidler.BuildConfig
 import com.fantasyidler.R
 import com.fantasyidler.data.json.PetData
 import com.fantasyidler.data.json.SkillingDungeonData
+import com.fantasyidler.ui.component.PlayerStatsBar
 import com.fantasyidler.ui.theme.ScaledSheetContent
 import com.fantasyidler.ui.viewmodel.Achievement
 import com.fantasyidler.ui.viewmodel.AchievementsViewModel
@@ -98,9 +99,9 @@ import com.fantasyidler.ui.viewmodel.TitleCatalog
 import com.fantasyidler.util.drawableByName
 import com.fantasyidler.ui.viewmodel.InventoryViewModel
 import com.fantasyidler.ui.viewmodel.SettingsViewModel
+import com.fantasyidler.ui.viewmodel.combatLevelFrom
 import com.fantasyidler.ui.viewmodel.xpProgressFraction
 import com.fantasyidler.util.GameStrings
-import com.fantasyidler.util.formatCoins
 import com.fantasyidler.util.stringByName
 
 private val SKILL_CATEGORY_GROUPS: List<Pair<Int, List<String>>> = listOf(
@@ -160,15 +161,13 @@ fun ProfileScreen(
                 .fillMaxSize()
                 .padding(padding),
         ) {
-            CoinsBanner(state.coins)
-
             // ── Character identity header ────────────────────────────────
             Surface(
                 color    = MaterialTheme.colorScheme.surfaceVariant,
                 modifier = Modifier.fillMaxWidth(),
             ) {
                 Row(
-                    modifier = Modifier.padding(horizontal = 16.dp, vertical = 12.dp),
+                    modifier = Modifier.padding(start = 16.dp, end = 16.dp, top = 12.dp),
                     verticalAlignment = Alignment.CenterVertically,
                 ) {
                     Column(Modifier.weight(1f)) {
@@ -236,25 +235,17 @@ fun ProfileScreen(
                 color    = MaterialTheme.colorScheme.surfaceVariant,
                 modifier = Modifier.fillMaxWidth(),
             ) {
-                Row(
-                    modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
-                    horizontalArrangement = Arrangement.SpaceBetween,
-                    verticalAlignment = Alignment.CenterVertically,
-                ) {
-                    Text(
-                        text  = stringResource(R.string.label_total_level),
-                        style = MaterialTheme.typography.labelMedium,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    )
-                    Text(
-                        text       = state.totalLevel.toString(),
-                        style      = MaterialTheme.typography.labelLarge,
-                        fontWeight = FontWeight.Bold,
-                    )
-                }
+                PlayerStatsBar(
+                    context                   = context,
+                    combatLevel               = combatLevelFrom(state.skillLevels),
+                    totalLevel                = state.totalLevel,
+                    coins                     = state.coins,
+                    activeBlessingKey         = state.activeBlessingKey,
+                    activeBlessingRemainingMs = (state.activeBlessingExpiresAt - System.currentTimeMillis()).coerceAtLeast(0L),
+                    xpBoostRemainingMs        = if (state.ironman) 0L else (state.xpBoostExpiresAt - System.currentTimeMillis()).coerceAtLeast(0L),
+                    modifier                  = Modifier.padding(start = 16.dp, end = 16.dp, top = 8.dp, bottom = 16.dp),
+                )
             }
-
-            HorizontalDivider()
 
             val tabContent: @Composable (Int) -> Unit = { tab ->
                 when (tab) {
@@ -467,36 +458,6 @@ private fun TabsLayout(
         }
         HorizontalPager(state = pagerState, modifier = Modifier.weight(1f).fillMaxSize()) { page ->
             content(page)
-        }
-    }
-}
-
-// ---------------------------------------------------------------------------
-// Coins banner (also used by SkillsScreen result sheet)
-// ---------------------------------------------------------------------------
-
-@Composable
-fun CoinsBanner(coins: Long) {
-    Surface(
-        color    = MaterialTheme.colorScheme.primary.copy(alpha = 0.15f),
-        modifier = Modifier.fillMaxWidth(),
-    ) {
-        Row(
-            modifier = Modifier.padding(horizontal = 16.dp, vertical = 10.dp),
-            verticalAlignment = Alignment.CenterVertically,
-        ) {
-            Text(
-                text  = stringResource(R.string.label_coins),
-                style = MaterialTheme.typography.labelMedium,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-            )
-            Spacer(Modifier.width(8.dp))
-            Text(
-                text       = coins.formatCoins(),
-                style      = MaterialTheme.typography.titleMedium,
-                fontWeight = FontWeight.Bold,
-                color      = MaterialTheme.colorScheme.primary,
-            )
         }
     }
 }


### PR DESCRIPTION
## Before submitting

- [x] I've tested any changes with the appropriate tests (eg. Unit tests, validation scripts)
- [x] I've pulled and merged the latest changes from the repository

## Summary

- Created a reusable `PlayerStatsBar` composable from the Home Screen
- Used that `PlayerStatsBar` in both Home and Profile screen.
- Remove coin banner in Profile page
- showStatsBar setting toggle only hides the `PlayerStatsBar` at Home, but not profile.

**Profile Layout Tabs**
<img width="500" height="302" alt="image" src="https://github.com/user-attachments/assets/678c249a-64bc-4aa7-b24e-da9a10e85a9a" />

**Profile Layout Rails**
<img width="414" height="814" alt="image" src="https://github.com/user-attachments/assets/4734e89e-7a4c-4666-9551-cf5af6220c26" />


## Related issue(s) or discussion(s)


## Changelog

- Refactoring work for `PlayerStatsBar`

## Anything else?