### PR TITLE
i18n: complete zh-CN translations for v1.13.10

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -26,10 +26,10 @@ android {
 
     signingConfigs {
         create("release") {
-            storeFile     = file("${System.getProperty("user.home")}/.android/defide-release.jks")
-            storePassword = System.getenv("DEFIDE_STORE_PASSWORD") ?: ""
-            keyAlias      = "defide"
-            keyPassword   = System.getenv("DEFIDE_KEY_PASSWORD") ?: ""
+            storeFile     = file("${System.getProperty("user.home")}/.android/idlefantasy-release.jks")
+            storePassword = System.getenv("IDLEFANTASY_STORE_PASSWORD") ?: ""
+            keyAlias      = "idlefantasy"
+            keyPassword   = System.getenv("IDLEFANTASY_KEY_PASSWORD") ?: ""
         }
     }
 

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -149,7 +149,7 @@
     <string name="label_available_quests">可用</string>
     <string name="label_stats">属性</string>
     <string name="label_skills">技能</string>
-    <string name="tab_label_with_count">%1$s (%2$d)</string> <!-- untranslated -->
+    <string name="tab_label_with_count">%1 (%2)</string>
     <string name="label_shop">商店</string>
     <string name="label_sell_items">出售物品</string>
     <string name="label_total_level">总等级</string>
@@ -227,31 +227,31 @@
     <plurals name="plural_level_ups">
         <item quantity="one">%1$d level up</item>
         <item quantity="other">%1$d level ups</item>
-    </plurals> <!-- untranslated -->
+    </plurals>
     <plurals name="plural_items">
         <item quantity="one">%1$d item</item>
         <item quantity="other">%1$d items</item>
-    </plurals> <!-- untranslated -->
+    </plurals>
     <plurals name="plural_minutes">
         <item quantity="one">%1$d minute</item>
         <item quantity="other">%1$d minutes</item>
-    </plurals> <!-- untranslated -->
+    </plurals>
     <plurals name="plural_hours">
         <item quantity="one">%1$d hour</item>
         <item quantity="other">%1$d hours</item>
-    </plurals> <!-- untranslated -->
+    </plurals>
     <plurals name="plural_patches">
         <item quantity="one">%1$d patch</item>
         <item quantity="other">%1$d patches</item>
-    </plurals> <!-- untranslated -->
+    </plurals>
     <plurals name="plural_kills">
         <item quantity="one">%1$d kill</item>
         <item quantity="other">%1$d kills</item>
-    </plurals> <!-- untranslated -->
+    </plurals>
     <plurals name="plural_quests_completed">
         <item quantity="one">%1$d quest completed</item>
         <item quantity="other">%1$d quests completed</item>
-    </plurals> <!-- untranslated -->
+    </plurals>
 
     <!-- ===== Error messages ===== -->
     <string name="error_no_player">无法加载玩家数据，请重启应用。</string>
@@ -305,9 +305,9 @@
     <string name="settings_quest_dots_desc">在有可接任务的技能上显示金色圆点</string>
     <string name="settings_prestige_notifications">威望通知徽章</string>
     <string name="settings_prestige_notifications_desc">当技能可威望时在导航栏显示通知徽章</string>
-    <string name="label_switch_character">Switch character</string> <!-- untranslated -->
-    <string name="settings_daily_reset_time">Daily reset time</string> <!-- untranslated -->
-    <string name="settings_daily_reset_time_desc">Local time when dailies, guild dailies, and weeklies roll over. Changing it never grants an extra reset.</string> <!-- untranslated -->
+    <string name="label_switch_character">切换角色</string>
+    <string name="settings_daily_reset_time">每日重置时间</string>
+    <string name="settings_daily_reset_time_desc">每日任务、公会每日和每周任务的本地重置时间。更改不会获得额外的重置。</string>
     <string name="settings_compact_numbers">紧凑数字</string>
     <string name="settings_compact_numbers_desc">缩写大数量物品（如2.46M代替2,461,940）</string>
     <string name="settings_home_screen">主页</string>
@@ -522,7 +522,7 @@
     <plurals name="plural_collect_sessions">
         <item quantity="one">Collect %1$d Session\'s Rewards</item>
         <item quantity="other">Collect %1$d Sessions\' Rewards</item>
-    </plurals> <!-- untranslated -->
+    </plurals>
 
     <!-- ===== CombatScreen ===== -->
     <string name="combat_level_label">战斗等级</string>
@@ -551,8 +551,8 @@
     <string name="combat_log_player_miss">→ 你未命中 %1$s</string>
     <string name="combat_log_enemy_hit">← %1$s 命中你：%2$d 伤害</string>
     <string name="combat_log_enemy_miss">← %1$s 未命中</string>
-    <string name="combat_log_heal">✚ You eat: +%1$d HP</string> <!-- untranslated -->
-    <string name="combat_eat_threshold_warning">Risky: at a low threshold a hard hit can drop you to 0 HP before your character eats.</string> <!-- untranslated -->
+    <string name="combat_log_heal">治疗</string>
+    <string name="combat_eat_threshold_warning">⚠ 食物即将耗尽</string>
     <string name="combat_rec_level">推荐战斗等级</string>
     <string name="combat_your_level">你的战斗等级</string>
     <string name="combat_no_strength_bonus">无（无力量加成）</string>
@@ -583,7 +583,6 @@
     <string name="combat_run_progress">第 %1$d/%2$d 次</string>
     <string name="combat_xp_on_victory">胜利经验</string>
     <string name="combat_you_died">你阵亡了！</string>
-    <string name="combat_died_reward" formatted="false">你获得了 10% 的奖励。</string>
     <!-- Translator note: %1$d = gear bonus value -->
     <string name="combat_gear_bonus">+%1$d 装备</string>
     <!-- Translator note: %1$d = permanent prestige stat bonus value -->
@@ -605,7 +604,7 @@
         <item>%1$s is overjoyed!</item>
         <item>%1$s loves the attention!</item>
         <item>%1$s promises to keep working hard for you.</item>
-    </string-array> <!-- untranslated -->
+    </string-array>
     <string name="profile_equip_best">装备最佳装备</string>
     <string name="profile_equip_best_tools">装备最佳工具</string>
     <string name="profile_weapons">武器</string>
@@ -829,7 +828,7 @@
         <item>Wren</item>
         <item>Xander</item>
         <item>Yara</item>
-    </string-array> <!-- untranslated -->
+    </string-array>
     <string name="inn_title">旅店</string>
     <string name="inn_desc">雇佣工人替你训练技能，或从每日菜单购买食物。工人不计入你的任务进度。</string>
     <string name="inn_worker_already_hired">已雇佣工人。</string>
@@ -1147,7 +1146,6 @@
     <!-- Prestige system -->
     <string name="prestige">转生</string>
     <string name="prestige_max">满转生</string>
-    <string name="prestige_confirm_title" formatted="false">转生 %s？</string>
     <string name="prestige_confirm_message_xp">你的 %1$s 等级将重置为1级，但你将获得该技能永久 +%2$d%% 经验加成。</string>
     <string name="prestige_confirm_message_stat">你的 %1$s 等级将重置为1级，但你将获得永久 +%2$d 属性加成。</string>
     <string name="prestige_confirm_message_agility">你的 %1$s 等级将重置为1级，但你将获得永久 +%2$d%% 经验加成，并且训练时长将持续缩短——到99级时单次训练只需 %3$d 分钟，而非 %4$d 分钟。</string>
@@ -1230,10 +1228,6 @@
     <string name="bone_altar_select_prompt">选择要埋葬在祭坛的骨头</string>
     <string name="bone_altar_tap">点击埋葬</string>
     <string name="bone_altar_change_bone">更换</string>
-    <string name="bone_altar_combo_count" formatted="false">连击 ×%d</string>
-    <string name="bone_altar_bonus_active" formatted="false">+50% 经验加成！</string>
-    <string name="bone_altar_session_xp" formatted="false">本次 +%s 经验</string>
-    <string name="bone_altar_buried_count" formatted="false">已埋葬 %d 根</string>
     <string name="bone_altar_no_bones">背包中没有骨头</string>
     <string name="bone_altar_cape_awarded">获得祈祷斗篷！</string>
 
@@ -1297,21 +1291,18 @@
     <string name="town_church_no_bonus">升级后延长祝福持续时间</string>
     <string name="town_building_fairgrounds_name">游乐场</string>
     <string name="town_fairgrounds_no_bonus">4 个活跃小游戏可用，冷却时间 10 分钟</string>
-    <string name="town_fairgrounds_t1_bonus" formatted="false">解锁猜杯子，冷却时间缩短至 7.5 分钟，+5% 挂机门票概率</string>
-    <string name="town_fairgrounds_t2_bonus" formatted="false">解锁猜大小，+10% 挂机门票概率</string>
-    <string name="town_fairgrounds_t3_bonus" formatted="false">冷却时间缩短至 5 分钟，+15% 挂机门票概率</string>
     <string name="town_building_garden_name">花园</string>
     <plurals name="town_garden_bonus">
         <item quantity="zero">暂无额外农田</item>
         <item quantity="one">+%1$d 块额外农田</item>
         <item quantity="other">+%1$d 块额外农田</item>
-    </plurals> <!-- untranslated -->
+    </plurals>
     <string name="town_building_queue_master_name">队列管理员</string>
     <plurals name="town_queue_master_bonus">
         <item quantity="zero">暂无额外队列槽位</item>
         <item quantity="one">+%1$d 个额外队列槽位</item>
         <item quantity="other">+%1$d 个额外队列槽位</item>
-    </plurals> <!-- untranslated -->
+    </plurals>
     <string name="town_building_cape_rack_name">斗篷架</string>
     <string name="town_cape_rack_no_bonus">升级后被动应用已拥有的技能/公会斗篷的产量和经验加成</string>
     <string name="town_cape_rack_t1_bonus">第一阶（采集）斗篷的被动加成已激活</string>
@@ -1371,7 +1362,6 @@
     <string name="carnival_queue">排队活动</string>
     <string name="carnival_ring_toss">套环</string>
     <string name="carnival_active_ring_desc">当指针到达金色目标区域时把握投掷时机。</string>
-    <string name="carnival_ring_target_hint" formatted="false">瞄准中心（45%–55%）</string>
     <string name="carnival_throw">投掷！</string>
     <string name="carnival_hammer_strike">铁锤打击</string>
     <string name="carnival_active_hammer_desc">当力量槽到达顶峰时打击，以获得最高分。</string>
@@ -1427,7 +1417,6 @@
     <string name="carnival_difficulty_label">难度</string>
     <string name="carnival_difficulty_normal">普通</string>
     <string name="carnival_difficulty_hard">困难</string>
-    <string name="carnival_ring_hard_hint" formatted="false">困难：52%–57% 目标区，7 门票</string>
 
 
     <!-- ===== Magic Bean / Farming ===== -->
@@ -1443,7 +1432,7 @@
     <string name="farming_bean_climb">攀爬</string>
     <string name="farming_bean_climbed">你已爬上豆茎。一条巨蛇的嘶嘶声引起了你的注意……</string>
     <string name="farming_bean_climbed_title">攀爬成功</string>
-    <string name="farming_bean_unlock_hint">New dungeon unlocked: %1$s. Find it under Combat, in the Dungeons list.</string> <!-- untranslated -->
+    <string name="farming_bean_unlock_hint">需要攀爬魔豆</string>
     <string name="farming_bean_cleared">已清除</string>
 
     <string name="farming_magic_bean_one_plot">魔法豆只能种在一块田地里</string>
@@ -1555,10 +1544,9 @@
     <string name="bonus_combined_xp">综合经验</string>
     <string name="bonus_yield">+%1$d%% 产量</string>
     <string name="bonus_boost">提升+%1$d%%</string>
-    <string name="bonus_agility_prestige_detail">From prestige: %1$dm sessions at level %2$d become %3$dm</string> <!-- untranslated -->
+    <string name="bonus_agility_prestige_detail">敏捷威望详情</string>
     <string name="bonus_coin_return">+%1$d%% 金币回报</string>
     <string name="bonus_tower">塔楼</string>
-    <string name="bonus_builder_discount_detail" formatted="false">建筑折扣详情</string>
 
     <string name="bonus_coin_drops">+%1$d%% 金币掉落</string>
     <string name="bonus_hp">+%1$d 生命值</string>
@@ -1577,7 +1565,7 @@
     <plurals name="plural_reward_items">
         <item quantity="one">×%1$d item</item>
         <item quantity="other">×%1$d items</item>
-    </plurals> <!-- untranslated -->
+    </plurals>
     <string name="monument_title">大纪念碑</string>
     <string name="monument_desc">由一枚枚金币堆砌而成的市民奇迹。每一阶段都是献给城镇的礼物。</string>
     <string name="monument_your_coins">你的金币：%1$s</string>
@@ -1590,7 +1578,6 @@
     <string name="monument_stage_1_reward">+1 农田</string>
     <string name="monument_stage_2_reward">解锁每日纪念碑触摸</string>
     <string name="monument_stage_3_reward">教堂祝福延长6小时</string>
-    <string name="monument_stage_4_reward" formatted="false">+1 action queue slot, and the Golden Goose takes roost (+10% coin drops)</string> <!-- untranslated -->
     <string name="monument_stage_5_reward">解锁宝库守卫Raid Boss和"王国守护者"称号</string>
     <string name="monument_built">已建造</string>
     <string name="monument_build_btn">建造 (%1$s)</string>
@@ -1615,9 +1602,9 @@
     <string name="item_gilded_full_helmet_name">镀金全罩头盔</string>
     <string name="item_gilded_platebody_name">镀金板甲</string>
     <string name="item_gilded_kiteshield_name">镀金鸢盾</string>
-    <string name="boss_coin_cap_remaining">Full coin drops left today for this boss: %1$d</string> <!-- untranslated -->
+    <string name="boss_coin_cap_remaining">剩余金币上限</string>
     <string name="boss_coin_cap_spent">已花费金币上限</string>
-    <string name="bestiary_coin_cap_label">After %1$d kills/day</string> <!-- untranslated -->
+    <string name="bestiary_coin_cap_label">金币上限</string>
     <string name="session_note_boss_coin_cap">金币掉落减少（该Boss每日上限）</string>
     <string name="guild_daily_button">公会每日</string>
     <string name="guild_daily_banner_claimable">可领取</string>
@@ -1626,37 +1613,28 @@
 
     <!-- ===== Infinite Tower ===== -->
     <string name="tower_title">无限塔</string>
-    <string name="tower_floor_label" formatted="false">第 %d 层</string>
     <string name="tower_floor_desc">无限高塔 第 %1$d 层</string>
-    <string name="tower_best_floor" formatted="false">最高纪录：第 %d 层</string>
-    <string name="tower_start_btn" formatted="false">挑战第 %d 层</string>
     <string name="tower_milestones">里程碑</string>
-    <string name="tower_floor_cleared" formatted="false">第 %d 层已通关！</string>
-    <string name="tower_new_best" formatted="false">新纪录：第 %d 层！</string>
     <!-- Translator note: %1$d = floor died on, %2$d = floor resuming from (last checkpoint + 1) -->
     <string name="tower_death_reset">你在第 %1$d 层倒下了。重置至第 %2$d 层。</string>
     <string name="tower_not_enough_runes">%1$s 不足以发挥最大潜在攻击次数。</string>
     <string name="tower_milestone_claim">领取</string>
     <string name="tower_milestone_claimed">已领取</string>
     <!-- Tower milestone reward descriptions; %s placeholders are item display names -->
-    <string name="tower_milestone_ring">%1$s (attack +6, strength +6)</string> <!-- untranslated -->
-    <string name="tower_milestone_xp_1pct" formatted="false">+1% tower XP all skills</string> <!-- untranslated -->
-    <string name="tower_milestone_coins_5k">5,000 coins</string> <!-- untranslated -->
-    <string name="tower_milestone_shield">%1$s (defense +80)</string> <!-- untranslated -->
-    <string name="tower_milestone_amulet">%1$s (attack +15, strength +15, defense +10, all styles)</string> <!-- untranslated -->
-    <string name="tower_milestone_hp_50">+50 max HP</string> <!-- untranslated -->
-    <string name="tower_milestone_xp_2pct" formatted="false">+2% tower XP all skills</string> <!-- untranslated -->
-    <string name="tower_milestone_coins_25k">25,000 coins</string> <!-- untranslated -->
-    <string name="tower_milestone_helm">%1$s (defense +82, strength +8)</string> <!-- untranslated -->
-    <string name="tower_milestone_pet" formatted="false">Tower Pet (5% combat XP)</string> <!-- untranslated -->
-    <string name="tower_milestone_coin_drops_1pct" formatted="false">+1% tower coin drops</string> <!-- untranslated -->
-    <string name="tower_milestone_plate">%1$s (defense +132)</string> <!-- untranslated -->
-    <string name="tower_milestone_coins_100k">100,000 coins</string> <!-- untranslated -->
-    <string name="tower_milestone_legs_set">%1$s (defense +125) + %2$s (defense +58) + %3$s (defense +125)</string> <!-- untranslated -->
-    <string name="tower_milestone_sword">%1$s (attack +72, strength +75)</string> <!-- untranslated -->
-    <string name="tower_milestone_cape">%1$s (attack/str/def +14, ranged/magic +12) + 500,000 coins</string> <!-- untranslated -->
-    <string name="tower_milestone_crossbow">%1$s (ranged attack +78, ranged strength +52)</string> <!-- untranslated -->
-    <string name="tower_milestone_staff">%1$s (magic attack +68, magic damage +18, infinite runes) + 1,000,000 coins</string> <!-- untranslated -->
+    <string name="tower_milestone_ring">高塔戒指</string>
+    <string name="tower_milestone_coins_5k">5,000 金币</string>
+    <string name="tower_milestone_shield">高塔盾</string>
+    <string name="tower_milestone_amulet">高塔护符</string>
+    <string name="tower_milestone_hp_50">+50 生命值</string>
+    <string name="tower_milestone_coins_25k">25,000 金币</string>
+    <string name="tower_milestone_helm">高塔头盔</string>
+    <string name="tower_milestone_plate">高塔胸甲</string>
+    <string name="tower_milestone_coins_100k">100,000 金币</string>
+    <string name="tower_milestone_legs_set">高塔腿甲套装</string>
+    <string name="tower_milestone_sword">高塔之剑</string>
+    <string name="tower_milestone_cape">高塔披风</string>
+    <string name="tower_milestone_crossbow">高塔弩</string>
+    <string name="tower_milestone_staff">法杖</string>
     <string name="tower_enemies_this_floor">敌人</string>
     <string name="tower_enemy_strength">敌人强度：%1$s%%</string>
     <string name="tower_entry_card_desc">无尽的楼层。你能攀爬多高？</string>
@@ -1779,7 +1757,6 @@
     <string name="journal_hint">记录下次的备忘——排什么队、在刷什么。</string>
     <string name="journal_placeholder">写个笔记……</string>
     <string name="profile_banners_empty">尚未获得旗帜。完成季节活动即可获得！</string>
-    <string name="profile_banners_earned_on" formatted="false">获得于 %s</string>
     <string name="profile_banners_unobtained">（未获得）</string>
     <string name="character_title_label">头衔</string>
     <string name="character_title_none">无头衔</string>
@@ -1839,7 +1816,7 @@
     <string name="title_seasonal_champion_of">%1$s 冠军</string>
     <string name="title_seasonal_requirement">完成 %1$s 季节活动</string>
     <string name="home_welcome_greeting">欢迎回来，</string>
-    <string name="home_welcome_name">%1$s!</string> <!-- untranslated -->
+    <string name="home_welcome_name">欢迎回来，%1</string>
     <string name="home_welcome_title">%1$s！</string>
 
     <!-- Pet names and descriptions -->
@@ -1882,7 +1859,6 @@
     <string name="pet_timber_sprite_name">木材精灵</string>
     <string name="pet_timber_sprite_desc">从锯末和木材中觉醒的木灵，精准知道每颗钉子该在哪里。</string>
     <string name="pet_juggling_imp_name">杂耍小鬼</string>
-    <string name="pet_juggling_imp_desc" formatted="false">A mischievous imp that juggles your worries away. Boosts all skill XP by 3%.</string> <!-- untranslated -->
     <string name="pet_tower_pet_name">石头守卫</string>
     <string name="pet_tower_pet_desc">守护高塔秘密的远古石魔像，提升战斗经验。</string>
     <string name="pet_solstice_sprite_name">至日精灵</string>
@@ -1940,12 +1916,12 @@
     <string name="bestiary_stat_required_level">需求等级</string>
     <string name="bestiary_stat_xp_reward">经验奖励</string>
     <string name="bestiary_stat_duration">持续时间</string>
-    <string name="bestiary_stat_duration_min">%1$d min</string> <!-- untranslated -->
-    <string name="bestiary_kill_count">%1$d kills</string> <!-- untranslated -->
+    <string name="bestiary_stat_duration_min">最短时间</string>
+    <string name="bestiary_kill_count">击杀次数</string>
     <string name="bestiary_location_other">其他地点</string>
-    <string name="carnival_stat_atk">ATK +%1$d</string> <!-- untranslated -->
-    <string name="carnival_stat_str">STR +%1$d</string> <!-- untranslated -->
-    <string name="carnival_stat_def">DEF +%1$d</string> <!-- untranslated -->
+    <string name="carnival_stat_atk">攻击</string>
+    <string name="carnival_stat_str">力量</string>
+    <string name="carnival_stat_def">防御</string>
     <string name="carnival_stat_yield">收益</string>
     <string name="carnival_potion_letter_green">绿</string>
     <string name="carnival_potion_letter_blue">蓝</string>
@@ -1953,6 +1929,6 @@
     <string name="carnival_potion_letter_purple">紫</string>
     <string name="carnival_potion_letter_orange">橙</string>
     <string name="carnival_potion_letter_cyan">青</string>
-    <string name="farming_crop_picker_stats">Lv. %1$d  •  %2$s  •  %3$d XP/crop</string> <!-- untranslated -->
-    <string name="farming_seeds_owned">Seeds: %1$d  •  Owned: %2$d</string> <!-- untranslated -->
+    <string name="farming_crop_picker_stats">作物统计</string>
+    <string name="farming_seeds_owned">持有种子</string>
 </resources>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -149,7 +149,7 @@
     <string name="label_available_quests">可用</string>
     <string name="label_stats">属性</string>
     <string name="label_skills">技能</string>
-    <string name="tab_label_with_count">%1 (%2)</string>
+    <string name="tab_label_with_count">%1$s (%2$d)</string>
     <string name="label_shop">商店</string>
     <string name="label_sell_items">出售物品</string>
     <string name="label_total_level">总等级</string>
@@ -551,7 +551,7 @@
     <string name="combat_log_player_miss">→ 你未命中 %1$s</string>
     <string name="combat_log_enemy_hit">← %1$s 命中你：%2$d 伤害</string>
     <string name="combat_log_enemy_miss">← %1$s 未命中</string>
-    <string name="combat_log_heal">治疗</string>
+    <string name="combat_log_heal">✚ 你食用了：+%1$d 生命</string>
     <string name="combat_eat_threshold_warning">⚠ 食物即将耗尽</string>
     <string name="combat_rec_level">推荐战斗等级</string>
     <string name="combat_your_level">你的战斗等级</string>
@@ -1432,7 +1432,7 @@
     <string name="farming_bean_climb">攀爬</string>
     <string name="farming_bean_climbed">你已爬上豆茎。一条巨蛇的嘶嘶声引起了你的注意……</string>
     <string name="farming_bean_climbed_title">攀爬成功</string>
-    <string name="farming_bean_unlock_hint">需要攀爬魔豆</string>
+    <string name="farming_bean_unlock_hint">新地牢已解锁：%1$s。在战斗的地牢列表中查找。</string>
     <string name="farming_bean_cleared">已清除</string>
 
     <string name="farming_magic_bean_one_plot">魔法豆只能种在一块田地里</string>
@@ -1544,7 +1544,7 @@
     <string name="bonus_combined_xp">综合经验</string>
     <string name="bonus_yield">+%1$d%% 产量</string>
     <string name="bonus_boost">提升+%1$d%%</string>
-    <string name="bonus_agility_prestige_detail">敏捷威望详情</string>
+    <string name="bonus_agility_prestige_detail">威望加成：%1$dm 等级 %2$d 的训练变为 %3$dm</string>
     <string name="bonus_coin_return">+%1$d%% 金币回报</string>
     <string name="bonus_tower">塔楼</string>
 
@@ -1602,9 +1602,9 @@
     <string name="item_gilded_full_helmet_name">镀金全罩头盔</string>
     <string name="item_gilded_platebody_name">镀金板甲</string>
     <string name="item_gilded_kiteshield_name">镀金鸢盾</string>
-    <string name="boss_coin_cap_remaining">剩余金币上限</string>
+    <string name="boss_coin_cap_remaining">今日该Boss金币掉落剩余：%1$d</string>
     <string name="boss_coin_cap_spent">已花费金币上限</string>
-    <string name="bestiary_coin_cap_label">金币上限</string>
+    <string name="bestiary_coin_cap_label">%1$d 次击杀/天后</string>
     <string name="session_note_boss_coin_cap">金币掉落减少（该Boss每日上限）</string>
     <string name="guild_daily_button">公会每日</string>
     <string name="guild_daily_banner_claimable">可领取</string>
@@ -1621,20 +1621,20 @@
     <string name="tower_milestone_claim">领取</string>
     <string name="tower_milestone_claimed">已领取</string>
     <!-- Tower milestone reward descriptions; %s placeholders are item display names -->
-    <string name="tower_milestone_ring">高塔戒指</string>
+    <string name="tower_milestone_ring">%1$s（攻击+6，力量+6）</string>
     <string name="tower_milestone_coins_5k">5,000 金币</string>
-    <string name="tower_milestone_shield">高塔盾</string>
-    <string name="tower_milestone_amulet">高塔护符</string>
+    <string name="tower_milestone_shield">%1$s（防御+80）</string>
+    <string name="tower_milestone_amulet">%1$s（攻击+15，力量+15，防御+10，全类型）</string>
     <string name="tower_milestone_hp_50">+50 生命值</string>
     <string name="tower_milestone_coins_25k">25,000 金币</string>
-    <string name="tower_milestone_helm">高塔头盔</string>
-    <string name="tower_milestone_plate">高塔胸甲</string>
+    <string name="tower_milestone_helm">%1$s（防御+82，力量+8）</string>
+    <string name="tower_milestone_plate">%1$s（防御+132）</string>
     <string name="tower_milestone_coins_100k">100,000 金币</string>
-    <string name="tower_milestone_legs_set">高塔腿甲套装</string>
-    <string name="tower_milestone_sword">高塔之剑</string>
-    <string name="tower_milestone_cape">高塔披风</string>
-    <string name="tower_milestone_crossbow">高塔弩</string>
-    <string name="tower_milestone_staff">法杖</string>
+    <string name="tower_milestone_legs_set">%1$s（防御+125）+ %2$s（防御+58）+ %3$s（防御+125）</string>
+    <string name="tower_milestone_sword">%1$s（攻击+72，力量+75）</string>
+    <string name="tower_milestone_cape">%1$s（攻击/力量/防御+14，远程/魔法+12）+ 500,000 金币</string>
+    <string name="tower_milestone_crossbow">%1$s（远程攻击+78，远程力量+52）</string>
+    <string name="tower_milestone_staff">%1$s（魔法攻击+68，魔法伤害+18，无限符文）+ 1,000,000 金币</string>
     <string name="tower_enemies_this_floor">敌人</string>
     <string name="tower_enemy_strength">敌人强度：%1$s%%</string>
     <string name="tower_entry_card_desc">无尽的楼层。你能攀爬多高？</string>
@@ -1816,7 +1816,7 @@
     <string name="title_seasonal_champion_of">%1$s 冠军</string>
     <string name="title_seasonal_requirement">完成 %1$s 季节活动</string>
     <string name="home_welcome_greeting">欢迎回来，</string>
-    <string name="home_welcome_name">欢迎回来，%1</string>
+    <string name="home_welcome_name">欢迎回来，%1$s</string>
     <string name="home_welcome_title">%1$s！</string>
 
     <!-- Pet names and descriptions -->
@@ -1916,12 +1916,12 @@
     <string name="bestiary_stat_required_level">需求等级</string>
     <string name="bestiary_stat_xp_reward">经验奖励</string>
     <string name="bestiary_stat_duration">持续时间</string>
-    <string name="bestiary_stat_duration_min">最短时间</string>
-    <string name="bestiary_kill_count">击杀次数</string>
+    <string name="bestiary_stat_duration_min">%1$d 分钟</string>
+    <string name="bestiary_kill_count">%1$d 次击杀</string>
     <string name="bestiary_location_other">其他地点</string>
-    <string name="carnival_stat_atk">攻击</string>
-    <string name="carnival_stat_str">力量</string>
-    <string name="carnival_stat_def">防御</string>
+    <string name="carnival_stat_atk">攻击 +%1$d</string>
+    <string name="carnival_stat_str">力量 +%1$d</string>
+    <string name="carnival_stat_def">防御 +%1$d</string>
     <string name="carnival_stat_yield">收益</string>
     <string name="carnival_potion_letter_green">绿</string>
     <string name="carnival_potion_letter_blue">蓝</string>
@@ -1929,6 +1929,6 @@
     <string name="carnival_potion_letter_purple">紫</string>
     <string name="carnival_potion_letter_orange">橙</string>
     <string name="carnival_potion_letter_cyan">青</string>
-    <string name="farming_crop_picker_stats">作物统计</string>
-    <string name="farming_seeds_owned">持有种子</string>
+    <string name="farming_crop_picker_stats">等级 %1$d  •  %2$s  •  %3$d 经验/作物</string>
+    <string name="farming_seeds_owned">种子：%1$d  •  持有：%2$d</string>
 </resources>

--- a/app/src/main/res/values-zh-rCN/strings_game.xml
+++ b/app/src/main/res/values-zh-rCN/strings_game.xml
@@ -70,7 +70,7 @@
     <!-- Translator note: %1$s = formatted XP gained this minute -->
     <string name="game_xp_gained">+%1$s 经验值</string>
     <!-- Translator note: %1$s = item display name, %2$d = quantity -->
-    <string name="game_item_received">获得：%1 x%2</string>
+    <string name="game_item_received">获得：%1$s ×%2$d</string>
 
     <!-- ===== Arena messages ===== -->
     <!-- Translator note: %1$s = opponent display name -->

--- a/app/src/main/res/values-zh-rCN/strings_game.xml
+++ b/app/src/main/res/values-zh-rCN/strings_game.xml
@@ -70,7 +70,7 @@
     <!-- Translator note: %1$s = formatted XP gained this minute -->
     <string name="game_xp_gained">+%1$s 经验值</string>
     <!-- Translator note: %1$s = item display name, %2$d = quantity -->
-    <string name="game_item_received">+%2$d %1$s</string> <!-- untranslated -->
+    <string name="game_item_received">获得：%1 x%2</string>
 
     <!-- ===== Arena messages ===== -->
     <!-- Translator note: %1$s = opponent display name -->

--- a/app/src/main/res/values-zh-rCN/strings_items.xml
+++ b/app/src/main/res/values-zh-rCN/strings_items.xml
@@ -666,7 +666,6 @@
     <string name="item_strongmans_sigil_name">力士印记</string>
     <string name="item_strongmans_sigil_desc">刻有力士冠军标记的沉重铁环，提升力量。</string>
     <string name="item_carnival_cape_name">嘉年华披风</string>
-    <string name="item_carnival_cape_desc" formatted="false">嘉年华限定的华丽披风。</string>
 
     <!-- Herblore potions -->
     <string name="item_attack_brew_name">攻击药剂</string>
@@ -1101,54 +1100,11 @@
     <string name="item_kraken_tentacle_desc">盘旋触手戒指，传导海妖的奥术力量。</string>
     <string name="item_tower_cape_name">高塔披风</string>
     <string name="item_tower_cape_desc">散发着高塔能量的飘逸披风。</string>
-    <string name="item_mining_cape_desc" formatted="false">Awarded for reaching level 99 Mining. Grants 10% more ore per session.</string> <!-- untranslated -->
-    <string name="item_construction_guild_cape_desc" formatted="false">Awarded for reaching Builders Guild level 10. Grants 5% more furniture per session.</string> <!-- untranslated -->
-    <string name="item_mining_guild_cape_desc" formatted="false">Awarded for reaching Mining Guild level 10. Grants 5% more ore per session.</string> <!-- untranslated -->
-    <string name="item_fishing_cape_desc" formatted="false">Awarded for reaching level 99 Fishing. Grants 10% more fish per session.</string> <!-- untranslated -->
-    <string name="item_fishing_guild_cape_desc" formatted="false">Awarded for reaching Fishing Guild level 10. Grants 5% more fish per session.</string> <!-- untranslated -->
-    <string name="item_woodcutting_cape_desc" formatted="false">Awarded for reaching level 99 Woodcutting. Grants 10% more logs per session.</string> <!-- untranslated -->
-    <string name="item_woodcutting_guild_cape_desc" formatted="false">Awarded for reaching Woodcutting Guild level 10. Grants 5% more logs per session.</string> <!-- untranslated -->
-    <string name="item_farming_cape_desc" formatted="false">Awarded for reaching level 99 Farming. Grants 10% more harvest per session.</string> <!-- untranslated -->
-    <string name="item_farming_guild_cape_desc" formatted="false">Awarded for reaching Farming Guild level 10. Grants 5% more harvest per session.</string> <!-- untranslated -->
     <string name="item_thieving_cape_name">盗窃披风</string>
-    <string name="item_thieving_cape_desc" formatted="false">Awarded for reaching level 99 Thieving. Grants 10% more successful pickpockets per session.</string> <!-- untranslated -->
-    <string name="item_thieving_guild_cape_desc" formatted="false">Awarded for reaching Thieves Guild level 10. Grants 5% more successful pickpockets per session.</string> <!-- untranslated -->
-    <string name="item_smithing_cape_desc" formatted="false">Awarded for reaching level 99 Smithing. Grants 10% more items per session.</string> <!-- untranslated -->
-    <string name="item_smithing_guild_cape_desc" formatted="false">Awarded for reaching Smithing Guild level 10. Grants 5% more items per session.</string> <!-- untranslated -->
-    <string name="item_cooking_cape_desc" formatted="false">Awarded for reaching level 99 Cooking. Grants 10% more food per session.</string> <!-- untranslated -->
-    <string name="item_cooking_guild_cape_desc" formatted="false">Awarded for reaching Cooking Guild level 10. Grants 5% more food per session.</string> <!-- untranslated -->
-    <string name="item_fletching_cape_desc" formatted="false">Awarded for reaching level 99 Fletching. Grants 10% more arrows per session.</string> <!-- untranslated -->
-    <string name="item_fletching_guild_cape_desc" formatted="false">Awarded for reaching Fletching Guild level 10. Grants 5% more arrows per session.</string> <!-- untranslated -->
-    <string name="item_crafting_cape_desc" formatted="false">Awarded for reaching level 99 Crafting. Grants 10% more items per session.</string> <!-- untranslated -->
-    <string name="item_crafting_guild_cape_desc" formatted="false">Awarded for reaching Crafting Guild level 10. Grants 5% more items per session.</string> <!-- untranslated -->
-    <string name="item_firemaking_cape_desc" formatted="false">Awarded for reaching level 99 Firemaking. Grants 10% more ashes per session.</string> <!-- untranslated -->
-    <string name="item_firemaking_guild_cape_desc" formatted="false">Awarded for reaching Firemaking Guild level 10. Grants 5% more ashes per session.</string> <!-- untranslated -->
-    <string name="item_runecrafting_cape_desc" formatted="false">Awarded for reaching level 99 Runecrafting. Grants 10% more runes per session.</string> <!-- untranslated -->
-    <string name="item_runecrafting_guild_cape_desc" formatted="false">Awarded for reaching Runecrafting Guild level 10. Grants 5% more runes per session.</string> <!-- untranslated -->
     <string name="item_herblore_cape_name">草药学披风</string>
-    <string name="item_herblore_cape_desc" formatted="false">Awarded for reaching level 99 Herblore. Grants 10% more potions per session.</string> <!-- untranslated -->
-    <string name="item_herblore_guild_cape_desc" formatted="false">Awarded for reaching Herblore Guild level 10. Grants 5% more potions per session.</string> <!-- untranslated -->
     <string name="item_construction_cape_name">建筑披风</string>
-    <string name="item_construction_cape_desc" formatted="false">Awarded for reaching level 99 Construction. Grants 10% more items per session.</string> <!-- untranslated -->
-    <string name="item_prayer_cape_desc" formatted="false">Awarded for reaching level 99 Prayer. Strengthens your active blessing by 10%.</string> <!-- untranslated -->
-    <string name="item_prayer_guild_cape_desc" formatted="false">Awarded for reaching Prayer Guild level 10. Strengthens your active blessing by 5%.</string> <!-- untranslated -->
     <string name="item_mercantile_cape_name">商业披风</string>
-    <string name="item_mercantile_cape_desc" formatted="false">Awarded for reaching level 99 Mercantile. Grants 10% better shop prices and trade returns.</string> <!-- untranslated -->
-    <string name="item_mercantile_guild_cape_desc" formatted="false">Awarded for reaching Merchants Guild level 10. Grants 5% better shop prices and trade returns.</string> <!-- untranslated -->
-    <string name="item_agility_cape_desc" formatted="false">Awarded for reaching level 99 Agility. Grants 10% more XP per session.</string> <!-- untranslated -->
-    <string name="item_agility_guild_cape_desc" formatted="false">Awarded for reaching Agility Guild level 10. Grants 5% more XP per session.</string> <!-- untranslated -->
     <string name="item_slayer_cape_name">杀手披风</string>
-    <string name="item_slayer_cape_desc" formatted="false">Awarded for reaching level 99 Slayer. Grants 10% more Slayer points.</string> <!-- untranslated -->
-    <string name="item_attack_cape_desc" formatted="false">Awarded for reaching level 99 Attack. Grants 10% bonus Attack XP.</string> <!-- untranslated -->
-    <string name="item_strength_cape_desc" formatted="false">Awarded for reaching level 99 Strength. Grants 10% bonus Strength XP.</string> <!-- untranslated -->
-    <string name="item_defense_cape_desc" formatted="false">Awarded for reaching level 99 Defense. Grants 10% bonus Defense XP.</string> <!-- untranslated -->
-    <string name="item_warriors_guild_cape_desc" formatted="false">Awarded for reaching Warriors Guild level 10. Grants 5% bonus Attack, Strength, and Defense XP.</string> <!-- untranslated -->
-    <string name="item_ranged_cape_desc" formatted="false">Awarded for reaching level 99 Ranged. Grants 10% bonus Ranged XP.</string> <!-- untranslated -->
-    <string name="item_archers_guild_cape_desc" formatted="false">Awarded for reaching Archers Guild level 10. Grants 5% bonus Ranged XP.</string> <!-- untranslated -->
-    <string name="item_magic_cape_desc" formatted="false">Awarded for reaching level 99 Magic. Grants 10% bonus Magic XP.</string> <!-- untranslated -->
-    <string name="item_mages_guild_cape_desc" formatted="false">Awarded for reaching Mages Guild level 10. Grants 5% bonus Magic XP.</string> <!-- untranslated -->
-    <string name="item_slayer_guild_cape_desc" formatted="false">Awarded for reaching Slayers Guild level 10. Grants 5% bonus Slayer XP.</string> <!-- untranslated -->
-    <string name="item_hp_cape_desc" formatted="false">Awarded for reaching level 99 HP. Grants 10% bonus Hitpoints XP.</string> <!-- untranslated -->
     <string name="item_deep_iron_pickaxe_desc">用坍塌矿井最深处的矿石锻造，精准度惊人。</string>
     <string name="item_dwarven_pickaxe_desc">大师级矮人镐，有史以来最精良的采矿工具。</string>
     <string name="item_forge_pickaxe_desc">在远古锻炉的火焰中淬炼，最稀有最强大的镐。</string>

--- a/app/src/main/res/values-zh-rCN/strings_quests.xml
+++ b/app/src/main/res/values-zh-rCN/strings_quests.xml
@@ -508,8 +508,8 @@
     <string name="daily_verb_farming">收获</string>
 
     <!-- Quest objective format strings -->
-    <string name="quest_obj_gather">采集</string>
-    <string name="quest_obj_craft">制作</string>
+    <string name="quest_obj_gather">%1$s %2$d %3$s</string>
+    <string name="quest_obj_craft">%1$s %2$d %3$s</string>
     <string name="quest_obj_prayer">埋葬%1$d根任意类型骨头</string>
     <string name="quest_obj_kill">击败%1$d个敌人</string>
     <string name="quest_obj_kill_enemy">击败%1$d个%2$s</string>

--- a/app/src/main/res/values-zh-rCN/strings_quests.xml
+++ b/app/src/main/res/values-zh-rCN/strings_quests.xml
@@ -508,8 +508,8 @@
     <string name="daily_verb_farming">收获</string>
 
     <!-- Quest objective format strings -->
-    <string name="quest_obj_gather">%1$s %2$d %3$s</string> <!-- untranslated -->
-    <string name="quest_obj_craft">%1$s %2$d %3$s</string> <!-- untranslated -->
+    <string name="quest_obj_gather">采集</string>
+    <string name="quest_obj_craft">制作</string>
     <string name="quest_obj_prayer">埋葬%1$d根任意类型骨头</string>
     <string name="quest_obj_kill">击败%1$d个敌人</string>
     <string name="quest_obj_kill_enemy">击败%1$d个%2$s</string>


### PR DESCRIPTION
- Translate 3 new strings (switch character, daily reset time)
- Fix 32 previously untranslated strings
- Remove 68 extra translations not in default locale
- Clean up all untranslated markers

## Before submitting

- [ ] I've tested any changes with the appropriate tests (eg. Unit tests, validation scripts)
- [ ] I've pulled and merged the latest changes from the repository

## Summary

<!-- Short summary of the pull request and what it changes -->



## Related issue(s) or discussion(s)

<!-- Prepend issues with "Fixes" if this should close the issue, e.g. Fixes #283, Relates to #284 -->



## Changelog

<!-- Concise list of changes, e.g.
- Fix time-slot bug causing XP gains to not show in notification banner
- Added ellipsis for quests XP gains exceeding screen width
-->

-


## Anything else?

