### PR TITLE
Add combat-style icons to boss and dungeon weapon loadout pickers

### DIFF
--- a/app/src/main/kotlin/com/fantasyidler/ui/screen/BossInfoSheet.kt
+++ b/app/src/main/kotlin/com/fantasyidler/ui/screen/BossInfoSheet.kt
@@ -1,6 +1,6 @@
 package com.fantasyidler.ui.screen
 
-import androidx.compose.foundation.background
+import androidx.compose.foundation.Image
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
@@ -8,20 +8,13 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.verticalScroll
-import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material3.AlertDialog
-import androidx.compose.material3.BottomSheetDefaults
 import androidx.compose.material3.Button
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.DropdownMenuItem
@@ -29,84 +22,39 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ExposedDropdownMenuBox
 import androidx.compose.material3.ExposedDropdownMenuDefaults
 import androidx.compose.material3.FilterChip
-import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
-import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.OutlinedTextField
-import androidx.compose.material3.Scaffold
-import androidx.compose.material3.Surface
-import androidx.compose.material3.SnackbarHost
-import androidx.compose.material3.SnackbarHostState
-import androidx.compose.material3.ScrollableTabRow
-import androidx.compose.material3.Tab
-import androidx.compose.material3.TabRow
 import androidx.compose.material3.Text
-import androidx.compose.material3.TextButton
-import androidx.compose.material3.TopAppBar
-import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
-import androidx.compose.foundation.pager.HorizontalPager
-import androidx.compose.foundation.pager.rememberPagerState
-import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.mutableLongStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
-import kotlinx.coroutines.launch
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.Remove
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
-import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
-import androidx.hilt.navigation.compose.hiltViewModel
-import kotlin.math.roundToInt
-import com.fantasyidler.BuildConfig
 import com.fantasyidler.R
 import com.fantasyidler.repository.PlayerRepository
-import com.fantasyidler.simulator.CombatSimulator
 import com.fantasyidler.data.json.BossData
-import com.fantasyidler.data.json.CookingRecipe
-import com.fantasyidler.data.json.DungeonData
-import com.fantasyidler.data.json.EnemyData
 import com.fantasyidler.data.json.EquipmentData
 import com.fantasyidler.data.json.SpellData
 import androidx.compose.foundation.layout.ExperimentalLayoutApi
 import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.ui.res.painterResource
 import com.fantasyidler.data.model.EquipSlot
-import com.fantasyidler.data.model.SessionFrame
-import com.fantasyidler.data.model.SkillSession
-import com.fantasyidler.data.model.Skills
-import com.fantasyidler.ui.viewmodel.CombatViewModel
 import com.fantasyidler.ui.viewmodel.CombatViewModel.Companion.MAX_BOSS_REPEAT_COUNT
-import com.fantasyidler.ui.viewmodel.InventoryViewModel
-import com.fantasyidler.ui.viewmodel.combatLevelFrom
-import com.fantasyidler.ui.viewmodel.slotDisplayName
-import com.fantasyidler.ui.viewmodel.xpProgressFraction
 import com.fantasyidler.util.GameStrings
-import com.fantasyidler.util.formatCoins
-import com.fantasyidler.util.formatXp
-import com.fantasyidler.util.toCountdown
 import com.fantasyidler.util.toTitleCase
-import kotlinx.coroutines.delay
-import kotlinx.serialization.decodeFromString
-import kotlinx.serialization.json.Json
 
 // ---------------------------------------------------------------------------
 // Boss info / start sheet
@@ -221,6 +169,8 @@ internal fun BossInfoSheet(
             val currentWeaponSlot = selectedWeaponSlot
                 ?: EquipSlot.WEAPON_SLOTS.firstOrNull { equippedWeapons.containsKey(it) }
             var weaponExpanded by remember { mutableStateOf(false) }
+            val style = currentWeaponSlot?.let { EquipSlot.combatStyleForSlot(it) }
+            val iconRes = style?.let { GameStrings.skillIconRes(it) }
             ExposedDropdownMenuBox(
                 expanded         = weaponExpanded,
                 onExpandedChange = { weaponExpanded = it },
@@ -233,13 +183,33 @@ internal fun BossInfoSheet(
                     colors        = ExposedDropdownMenuDefaults.outlinedTextFieldColors(),
                     singleLine    = true,
                     modifier      = Modifier.menuAnchor().fillMaxWidth(),
+                    leadingIcon = if (iconRes != null) {
+                        {
+                            Image(
+                                painter = painterResource(iconRes),
+                                contentDescription = null,
+                                modifier = Modifier.size(16.dp),
+                            )
+                        }
+                    } else null,
                 )
                 ExposedDropdownMenu(
                     expanded         = weaponExpanded,
                     onDismissRequest = { weaponExpanded = false },
                 ) {
                     equippedWeapons.forEach { (slot, weaponData) ->
+                        val style = EquipSlot.combatStyleForSlot(slot)!!
+                        val iconRes = GameStrings.skillIconRes(style)
                         DropdownMenuItem(
+                            leadingIcon = if (iconRes != null) {
+                                {
+                                    Image(
+                                        painter = painterResource(iconRes),
+                                        contentDescription = null,
+                                        modifier = Modifier.size(16.dp),
+                                    )
+                                }
+                            } else null,
                             text = {
                                 weaponData.combatStyle?.let { style ->
                                     Text(

--- a/app/src/main/kotlin/com/fantasyidler/ui/screen/DungeonInfoSheet.kt
+++ b/app/src/main/kotlin/com/fantasyidler/ui/screen/DungeonInfoSheet.kt
@@ -1,7 +1,9 @@
 package com.fantasyidler.ui.screen
 
+import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -84,6 +86,7 @@ import com.fantasyidler.data.json.EquipmentData
 import com.fantasyidler.data.json.SpellData
 import androidx.compose.foundation.layout.ExperimentalLayoutApi
 import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.ui.res.painterResource
 import com.fantasyidler.data.model.EquipSlot
 import com.fantasyidler.data.model.SessionFrame
 import com.fantasyidler.data.model.SkillSession
@@ -185,7 +188,7 @@ internal fun DungeonInfoSheet(
     Column(
         modifier = Modifier
             .fillMaxWidth()
-            .padding(horizontal = 24.dp)
+            .padding(horizontal = 20.dp)
             .padding(bottom = 40.dp),
     ) {
         Column(modifier = Modifier
@@ -239,11 +242,17 @@ internal fun DungeonInfoSheet(
                 style = MaterialTheme.typography.labelMedium,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
             )
-            Spacer(Modifier.height(4.dp))
-            FlowRow(horizontalArrangement = Arrangement.spacedBy(8.dp), verticalArrangement = Arrangement.spacedBy(4.dp)) {
+            Row(
+                modifier              = Modifier
+                    .horizontalScroll(rememberScrollState())
+                    .padding( vertical = 4.dp),
+                horizontalArrangement = Arrangement.spacedBy(6.dp),
+            ) {
                 equippedWeapons.forEach { (slot, weaponData) ->
                     val isSelected = slot == (selectedWeaponSlot
                         ?: EquipSlot.WEAPON_SLOTS.firstOrNull { equippedWeapons.containsKey(it) })
+                    val style = EquipSlot.combatStyleForSlot(slot)!!
+                    val iconRes = GameStrings.skillIconRes(style)
                     FilterChip(
                         selected = isSelected,
                         onClick  = { onWeaponSlotSelected(slot) },
@@ -255,6 +264,15 @@ internal fun DungeonInfoSheet(
                                 )
                             }
                         },
+                        leadingIcon = if (iconRes != null) {
+                            {
+                                Image(
+                                    painter = painterResource(iconRes),
+                                    contentDescription = null,
+                                    modifier = Modifier.size(16.dp),
+                                )
+                            }
+                        } else null,
                     )
                 }
             }


### PR DESCRIPTION
## Before submitting

- [x] I've tested any changes with the appropriate tests (eg. Unit tests, validation scripts)
- [x] I've pulled and merged the latest changes from the repository

## Summary

Adds a combat icon next to each weapon option in the loadout pickers on the Boss and Dungeon info sheets, matching the icon style already used elsewhere in the app. 

**Dungeon**
<img width="501" height="988" alt="image" src="https://github.com/user-attachments/assets/0292df2c-6699-4b9f-8e85-c1da88c2ff23" />

**Bosses**
<img width="516" height="908" alt="image" src="https://github.com/user-attachments/assets/189601d9-fb77-4df6-a410-7cf44864936c" />

## Related issue(s) or discussion(s)



## Changelog

- Add more Combat Icons for Loadouts in Dungeon and Bosses.

## Anything else?