### PR TITLE
Fix coin display rounding hiding insufficient funds

### DIFF
--- a/app/src/main/kotlin/com/fantasyidler/util/Extensions.kt
+++ b/app/src/main/kotlin/com/fantasyidler/util/Extensions.kt
@@ -23,9 +23,14 @@ fun xpMultiplierBreakdown(baseXp: Long, boostActive: Boolean, blessingMult: Floa
     return "(${baseXp.formatXp()} × ${factors.joinToString(" × ")})"
 }
 
-/** Format a coin amount with thousands separators. */
+/**
+ * Format a coin amount with thousands separators. Amounts >= 1M are floored (not rounded) to one
+ * decimal place so the displayed value never overstates what the player actually has — otherwise
+ * e.g. 99.96M would display as "100.0M" and make an affordability-gated button look wrongly
+ * disabled (issue #1470).
+ */
 fun Long.formatCoins(): String = when {
-    this >= 1_000_000L -> "%.1fM".format(this / 1_000_000.0)
+    this >= 1_000_000L -> "%.1fM".format(kotlin.math.floor(this / 100_000.0) / 10.0)
     this >= 1_000L     -> "%,d".format(this)
     else               -> toString()
 }
@@ -35,7 +40,7 @@ fun Int.formatCoins(): String = toLong().formatCoins()
 
 /** Abbreviated coin format for compact UI (e.g. 50000 → "50k"). */
 fun Long.formatCoinsBrief(): String = when {
-    this >= 1_000_000L -> "%.1fM".format(this / 1_000_000.0)
+    this >= 1_000_000L -> "%.1fM".format(kotlin.math.floor(this / 100_000.0) / 10.0)
     this >= 1_000L     -> "${this / 1000}k"
     else               -> toString()
 }

--- a/app/src/test/kotlin/com/fantasyidler/util/ExtensionsTest.kt
+++ b/app/src/test/kotlin/com/fantasyidler/util/ExtensionsTest.kt
@@ -50,6 +50,13 @@ class ExtensionsTest {
     }
 
     @Test
+    fun `formatCoins floors instead of rounds so it never overstates affordability`() {
+        assertEquals("99.9M", 99_960_000L.formatCoins())
+        assertEquals("100.0M", 100_000_000L.formatCoins())
+        assertEquals("100.0M", 100_049_999L.formatCoins())
+    }
+
+    @Test
     fun `formatQuantity formats full and compact numbers correctly`() {
         // Full formatting (compact = false)
         assertEquals("0", 0.formatQuantity(compact = false))


### PR DESCRIPTION
## Before submitting

- [x] I've tested any changes with the appropriate tests (eg. Unit tests, validation scripts)
- [x] I've pulled and merged the latest changes from the repository

## Summary

`Long.formatCoins()` / `formatCoinsBrief()` rounded amounts >= 1M to the nearest 0.1M, so e.g. 99,960,000 coins displayed as "100.0M" even though it's short of a 100M-cost purchase. Switched both functions to floor to one decimal instead of rounding, so the displayed amount never overstates what the player actually has.

## Related issue(s) or discussion(s)

Fixes #1470

## Changelog

- Fix coin amounts displaying rounded up instead of floored, which could make an affordability-gated button (e.g. Grand Monument's Gilded stage) look wrongly disabled.

## Anything else?
