### PR TITLE
Make prayer cape consistently boost church blessings

### DIFF
--- a/app/src/main/kotlin/com/fantasyidler/repository/ChurchRepository.kt
+++ b/app/src/main/kotlin/com/fantasyidler/repository/ChurchRepository.kt
@@ -2,6 +2,8 @@ package com.fantasyidler.repository
 
 import com.fantasyidler.data.json.BlessingData
 import com.fantasyidler.data.json.BlessingType
+import com.fantasyidler.data.json.EquipmentData
+import com.fantasyidler.data.model.EquipSlot
 import com.fantasyidler.data.model.PlayerFlags
 import com.fantasyidler.data.model.Skills
 import javax.inject.Inject
@@ -65,19 +67,43 @@ class ChurchRepository @Inject constructor(
             return BY_KEY[flags.activeBlessingKey]
         }
 
-        fun xpMultiplier(flags: PlayerFlags): Float {
-            val b = activeBlessing(flags) ?: return 1f
-            return if (b.type == BlessingType.XP) b.magnitude else 1f
+        fun xpMultiplier(flags: PlayerFlags, equipped: Map<String, String?>, inventoryKeys: Set<String>, allEquipment: Map<String, EquipmentData>): Float {
+            val equippedCape = equipped[EquipSlot.CAPE]?.let { allEquipment[it] }
+            return xpMultiplier(flags, equippedCape, inventoryKeys, allEquipment)
         }
 
-        fun defBonus(flags: PlayerFlags): Int {
+        fun xpMultiplier(flags: PlayerFlags, equippedCape: EquipmentData?, inventoryKeys: Set<String>, allEquipment: Map<String, EquipmentData>): Float {
+            val b = activeBlessing(flags) ?: return 1f
+            return if (b.type == BlessingType.XP) {
+                val prayerCapeMult = resolveCapeMultiplier(Skills.PRAYER, equippedCape, inventoryKeys, flags.townBuildingTiers, flags.skillPrestige, allEquipment, flags.ironman)
+                1f + (b.magnitude - 1f) * prayerCapeMult
+            } else 1f
+        }
+
+        fun defBonus(flags: PlayerFlags, equipped: Map<String, String?>, inventoryKeys: Set<String>, allEquipment: Map<String, EquipmentData>): Int {
+            val equippedCape = equipped[EquipSlot.CAPE]?.let { allEquipment[it] }
+            return defBonus(flags, equippedCape, inventoryKeys, allEquipment)
+        }
+
+        fun defBonus(flags: PlayerFlags, equippedCape: EquipmentData?, inventoryKeys: Set<String>, allEquipment: Map<String, EquipmentData>): Int {
             val b = activeBlessing(flags) ?: return 0
-            return if (b.type == BlessingType.DEFENSE) b.magnitude.toInt() else 0
+            return if (b.type == BlessingType.DEFENSE) {
+                val prayerCapeMult = resolveCapeMultiplier(Skills.PRAYER, equippedCape, inventoryKeys, flags.townBuildingTiers, flags.skillPrestige, allEquipment, flags.ironman)
+                (b.magnitude * prayerCapeMult).toInt()
+            } else 0
         }
 
-        fun coinMultiplier(flags: PlayerFlags): Float {
+        fun coinMultiplier(flags: PlayerFlags, equipped: Map<String, String?>, inventoryKeys: Set<String>, allEquipment: Map<String, EquipmentData>): Float {
+            val equippedCape = equipped[EquipSlot.CAPE]?.let { allEquipment[it] }
+            return coinMultiplier(flags, equippedCape, inventoryKeys, allEquipment)
+        }
+
+        fun coinMultiplier(flags: PlayerFlags, equippedCape: EquipmentData?, inventoryKeys: Set<String>, allEquipment: Map<String, EquipmentData>): Float {
             val b = activeBlessing(flags) ?: return 1f
-            return if (b.type == BlessingType.COINS) 1f + b.magnitude else 1f
+            return if (b.type == BlessingType.COINS) {
+                val prayerCapeMult = resolveCapeMultiplier(Skills.PRAYER, equippedCape, inventoryKeys, flags.townBuildingTiers, flags.skillPrestige, allEquipment, flags.ironman)
+                1f + (b.magnitude * prayerCapeMult)
+            } else 1f
         }
 
         fun boneCostFor(blessing: BlessingData): Int = when {

--- a/app/src/main/kotlin/com/fantasyidler/repository/ChurchRepository.kt
+++ b/app/src/main/kotlin/com/fantasyidler/repository/ChurchRepository.kt
@@ -76,7 +76,7 @@ class ChurchRepository @Inject constructor(
             val b = activeBlessing(flags) ?: return 1f
             return if (b.type == BlessingType.XP) {
                 val prayerCapeMult = resolveCapeMultiplier(Skills.PRAYER, equippedCape, inventoryKeys, flags.townBuildingTiers, flags.skillPrestige, allEquipment, flags.ironman)
-                1f + (b.magnitude - 1f) * prayerCapeMult
+                effectiveMagnitude(b, prayerCapeMult)
             } else 1f
         }
 
@@ -89,7 +89,7 @@ class ChurchRepository @Inject constructor(
             val b = activeBlessing(flags) ?: return 0
             return if (b.type == BlessingType.DEFENSE) {
                 val prayerCapeMult = resolveCapeMultiplier(Skills.PRAYER, equippedCape, inventoryKeys, flags.townBuildingTiers, flags.skillPrestige, allEquipment, flags.ironman)
-                (b.magnitude * prayerCapeMult).toInt()
+                effectiveMagnitude(b, prayerCapeMult).toInt()
             } else 0
         }
 
@@ -102,8 +102,15 @@ class ChurchRepository @Inject constructor(
             val b = activeBlessing(flags) ?: return 1f
             return if (b.type == BlessingType.COINS) {
                 val prayerCapeMult = resolveCapeMultiplier(Skills.PRAYER, equippedCape, inventoryKeys, flags.townBuildingTiers, flags.skillPrestige, allEquipment, flags.ironman)
-                1f + (b.magnitude * prayerCapeMult)
+                1f + effectiveMagnitude(b, prayerCapeMult)
             } else 1f
+        }
+
+        fun effectiveMagnitude(b: BlessingData, prayerCapeMult: Float): Float {
+            return when (b.type) {
+                BlessingType.XP -> (1f + (b.magnitude - 1f) * prayerCapeMult)
+                BlessingType.DEFENSE, BlessingType.COINS -> b.magnitude * prayerCapeMult
+            }
         }
 
         fun boneCostFor(blessing: BlessingData): Int = when {

--- a/app/src/main/kotlin/com/fantasyidler/repository/PlayerRepository.kt
+++ b/app/src/main/kotlin/com/fantasyidler/repository/PlayerRepository.kt
@@ -122,7 +122,9 @@ class PlayerRepository @Inject constructor(
         val flags: PlayerFlags = json.decodeFromString(player.flags)
         val boostActive = !flags.ironman && flags.xpBoostExpiresAt > System.currentTimeMillis()
         val scaledXp = if (efficiencyMultiplier == 1.0f) xpGained else (xpGained * efficiencyMultiplier).toLong()
-        val blessingMult = if (flags.ironman) 1.0f else ChurchRepository.xpMultiplier(flags)
+        val equipped: Map<String, String?> = json.decodeFromString(player.equipped)
+        val inventory: MutableMap<String, Int> = json.decodeFromString(player.inventory)
+        val blessingMult = if (flags.ironman) 1.0f else ChurchRepository.xpMultiplier(flags, equipped, inventory.keys, gameData.equipment)
         val baseXp = ((if (boostActive) scaledXp * 2 else scaledXp) * blessingMult).toLong()
         val prestigeLevel = if (flags.ironman) 0 else flags.skillPrestige[skillName] ?: 0
         val boostedXp = if (prestigeLevel > 0) (baseXp * (1.0 + prestigeLevel * 0.10)).toLong() else baseXp
@@ -131,7 +133,6 @@ class PlayerRepository @Inject constructor(
 
         val levels: MutableMap<String, Int>  = json.decodeFromString(player.skillLevels)
         val xpMap: MutableMap<String, Long>  = json.decodeFromString(player.skillXp)
-        val inventory: MutableMap<String, Int> = json.decodeFromString(player.inventory)
 
         val oldLevel = XpTable.levelForXp(xpMap[skillName] ?: 0L)
         val newXp = (xpMap[skillName] ?: 0L) + boostedXp
@@ -726,15 +727,16 @@ class PlayerRepository @Inject constructor(
         val flags: PlayerFlags = json.decodeFromString(player.flags)
         val boostActive = !flags.ironman && flags.xpBoostExpiresAt > System.currentTimeMillis()
         val boostMult = if (boostActive) 2L else 1L
-        val xpBlessingMult = if (flags.ironman) 1.0f else ChurchRepository.xpMultiplier(flags)
-        val coinBlessingMult = if (flags.ironman) 1.0f else ChurchRepository.coinMultiplier(flags) *
+        val equipped: Map<String, String?> = json.decodeFromString(player.equipped)
+        val inventory: MutableMap<String, Int> = json.decodeFromString(player.inventory)
+        val xpBlessingMult = if (flags.ironman) 1.0f else ChurchRepository.xpMultiplier(flags, equipped, inventory.keys, gameData.equipment)
+        val coinBlessingMult = if (flags.ironman) 1.0f else ChurchRepository.coinMultiplier(flags, equipped, inventory.keys, gameData.equipment) *
             gooseCoinMultiplier(json.decodeFromString(player.pets)).toFloat()
         val scaledItems = if (efficiencyMultiplier == 1.0f) itemsGained
             else itemsGained.mapValues { (_, v) -> (v * efficiencyMultiplier).roundToInt().coerceAtLeast(1) }
 
         val levels:    MutableMap<String, Int>  = json.decodeFromString(player.skillLevels)
         val xpMap:     MutableMap<String, Long> = json.decodeFromString(player.skillXp)
-        val inventory: MutableMap<String, Int>  = json.decodeFromString(player.inventory)
 
         val awardedCapes = mutableListOf<String>()
         for ((skill, xp) in xpPerSkill) {
@@ -787,10 +789,13 @@ class PlayerRepository @Inject constructor(
      * the real credited XP instead of the pre-multiplier flat amount.
      */
     suspend fun previewFlatXpGrant(skillName: String, baseXp: Long): FlatXpBreakdown {
-        val flags = getFlags()
+        val player = getOrCreatePlayer()
+        val flags: PlayerFlags = json.decodeFromString(player.flags)
         val boostActive = !flags.ironman && flags.xpBoostExpiresAt > System.currentTimeMillis()
         val boostMult = if (boostActive) 2L else 1L
-        val blessingMult = if (flags.ironman) 1.0f else ChurchRepository.xpMultiplier(flags)
+        val equipped: Map<String, String?> = json.decodeFromString(player.equipped)
+        val inventory: MutableMap<String, Int> = json.decodeFromString(player.inventory)
+        val blessingMult = if (flags.ironman) 1.0f else ChurchRepository.xpMultiplier(flags, equipped, inventory.keys, gameData.equipment)
         val afterBoostBlessing = ((baseXp * boostMult) * blessingMult).toLong()
         val prestigeLevel = if (flags.ironman) 0 else flags.skillPrestige[skillName] ?: 0
         val finalXp = if (prestigeLevel > 0) (afterBoostBlessing * (1.0 + prestigeLevel * 0.10)).toLong() else afterBoostBlessing

--- a/app/src/main/kotlin/com/fantasyidler/repository/QueuedSessionStarter.kt
+++ b/app/src/main/kotlin/com/fantasyidler/repository/QueuedSessionStarter.kt
@@ -289,7 +289,6 @@ class QueuedSessionStarter @Inject constructor(
         val defenseCapeMult  = resolveCapeMultiplier("defense", equippedCapeData, inventory.keys, flags.townBuildingTiers, flags.skillPrestige, gameData.equipment, flags.ironman)
         val rangedCapeMult   = resolveCapeMultiplier("ranged", equippedCapeData, inventory.keys, flags.townBuildingTiers, flags.skillPrestige, gameData.equipment, flags.ironman)
         val magicCapeMult    = resolveCapeMultiplier("magic", equippedCapeData, inventory.keys, flags.townBuildingTiers, flags.skillPrestige, gameData.equipment, flags.ironman)
-        val prayerCapeMult   = resolveCapeMultiplier("prayer", equippedCapeData, inventory.keys, flags.townBuildingTiers, flags.skillPrestige, gameData.equipment, flags.ironman)
         // Recorded on the session so collection can detect a mid-session prestige reset
         // (isSkillSessionStillEligible) instead of gating on an unrelated difficulty formula.
         val levelAtStart = when (action.skillName) {
@@ -653,7 +652,7 @@ class QueuedSessionStarter @Inject constructor(
                     arrowStrengthBonuses = ARROW_STRENGTH_BONUS,
                     equippedFood       = availableFood,
                     foodHealValues     = gameData.foodHealValues,
-                    blessingDefBonus   = (ChurchRepository.defBonus(flags) * prayerCapeMult).toInt(),
+                    blessingDefBonus   = ChurchRepository.defBonus(flags, equippedCapeData, inventory.keys, gameData.equipment),
                     attackSpeedSec     = bossWeapon?.attackSpeed ?: CombatSimulator.BASE_ATTACK_SPEED_SEC,
                     eatThresholdPct    = flags.foodEatThresholdPct,
                 )
@@ -747,7 +746,7 @@ class QueuedSessionStarter @Inject constructor(
                     playerStrength      = ((levels[Skills.STRENGTH] ?: 1) * strengthCapeMult).toInt() + (pm[Skills.STRENGTH]  ?: 0) * 5 + (combatPotBonuses["strength"] ?: 0),
                     playerDefence       = ((levels[Skills.DEFENSE]  ?: 1) * defenseCapeMult).toInt() + totalDefBonus + (pm[Skills.DEFENSE] ?: 0) * 5 + (combatPotBonuses["defense"] ?: 0),
                     playerHp            = (levels[Skills.HITPOINTS] ?: 1) + (pm[Skills.HITPOINTS] ?: 0) * 5 + flags.towerHpBonus,
-                    blessingDefBonus    = (ChurchRepository.defBonus(flags) * prayerCapeMult).toInt(),
+                    blessingDefBonus    = ChurchRepository.defBonus(flags, equippedCapeData, inventory.keys, gameData.equipment),
                     weaponAttackBonus   = totalAtkBonus,
                     weaponStrengthBonus = totalStrBonus,
                     combatStyle         = combatStyle,
@@ -832,7 +831,7 @@ class QueuedSessionStarter @Inject constructor(
                     playerStrength      = ((levels[Skills.STRENGTH] ?: 1) * strengthCapeMult).toInt() + (pm[Skills.STRENGTH]  ?: 0) * 5,
                     playerDefence       = ((levels[Skills.DEFENSE]  ?: 1) * defenseCapeMult).toInt() + totalDefBonus + (pm[Skills.DEFENSE] ?: 0) * 5,
                     playerHp            = (levels[Skills.HITPOINTS] ?: 1) + (pm[Skills.HITPOINTS] ?: 0) * 5 + flags.towerHpBonus,
-                    blessingDefBonus    = (ChurchRepository.defBonus(flags) * prayerCapeMult).toInt(),
+                    blessingDefBonus    = ChurchRepository.defBonus(flags, equippedCapeData, inventory.keys, gameData.equipment),
                     weaponAttackBonus   = totalAtkBonus,
                     weaponStrengthBonus = totalStrBonus,
                     combatStyle         = combatStyle,

--- a/app/src/main/kotlin/com/fantasyidler/repository/WorkerQueuedSessionStarter.kt
+++ b/app/src/main/kotlin/com/fantasyidler/repository/WorkerQueuedSessionStarter.kt
@@ -71,7 +71,6 @@ class WorkerQueuedSessionStarter @Inject constructor(
         val defenseCapeMult  = resolveCapeMultiplier("defense", equippedCapeData, inventory.keys, flags.townBuildingTiers, flags.skillPrestige, gameData.equipment, flags.ironman)
         val rangedCapeMult   = resolveCapeMultiplier("ranged", equippedCapeData, inventory.keys, flags.townBuildingTiers, flags.skillPrestige, gameData.equipment, flags.ironman)
         val magicCapeMult    = resolveCapeMultiplier("magic", equippedCapeData, inventory.keys, flags.townBuildingTiers, flags.skillPrestige, gameData.equipment, flags.ironman)
-        val prayerCapeMult   = resolveCapeMultiplier("prayer", equippedCapeData, inventory.keys, flags.townBuildingTiers, flags.skillPrestige, gameData.equipment, flags.ironman)
         val levelAtStart = when (action.skillName) {
             "boss", "combat" -> combatLevelFrom(levels)
             else -> levels[action.skillName] ?: 1
@@ -290,7 +289,7 @@ class WorkerQueuedSessionStarter @Inject constructor(
                     availableArrows    = availableArrows,
                     equippedFood       = availableFood,
                     foodHealValues     = gameData.foodHealValues,
-                    blessingDefBonus   = (ChurchRepository.defBonus(flags) * prayerCapeMult).toInt(),
+                    blessingDefBonus   = ChurchRepository.defBonus(flags, equippedCapeData, inventory.keys, gameData.equipment),
                     attackSpeedSec     = bossWeapon?.attackSpeed ?: CombatSimulator.BASE_ATTACK_SPEED_SEC,
                     eatThresholdPct    = flags.foodEatThresholdPct,
                 )
@@ -332,7 +331,7 @@ class WorkerQueuedSessionStarter @Inject constructor(
                     playerStrength      = ((levels[Skills.STRENGTH]  ?: 1) * strengthCapeMult).toInt(),
                     playerDefence       = (((levels[Skills.DEFENSE]  ?: 1) * defenseCapeMult).toInt() + totalDefBonus),
                     playerHp            = levels[Skills.HITPOINTS] ?: 1,
-                    blessingDefBonus    = (ChurchRepository.defBonus(flags) * prayerCapeMult).toInt(),
+                    blessingDefBonus    = ChurchRepository.defBonus(flags, equippedCapeData, inventory.keys, gameData.equipment),
                     weaponAttackBonus   = totalAtkBonus,
                     weaponStrengthBonus = totalStrBonus,
                     combatStyle         = combatStyle,

--- a/app/src/main/kotlin/com/fantasyidler/ui/component/PlayerStatsBar.kt
+++ b/app/src/main/kotlin/com/fantasyidler/ui/component/PlayerStatsBar.kt
@@ -37,6 +37,7 @@ fun PlayerStatsBar(
     coins: Long,
     activeBlessingKey: String,
     activeBlessingRemainingMs: Long,
+    prayerCapeMult: Float,
     xpBoostRemainingMs: Long,
     modifier: Modifier = Modifier,
 ) {
@@ -71,9 +72,9 @@ fun PlayerStatsBar(
             val blessingData = ChurchRepository.ALL_BLESSINGS.firstOrNull { it.key == activeBlessingKey }
             val boostDesc = blessingData?.let { b ->
                 when (b.type) {
-                    BlessingType.XP      -> "${b.magnitude}x XP"
-                    BlessingType.DEFENSE -> "+${b.magnitude.toInt()} DEF"
-                    BlessingType.COINS   -> "+${(b.magnitude * 100).toInt()}% coins"
+                    BlessingType.XP      -> "%1.2fx XP".format(1f + (b.magnitude - 1f) * prayerCapeMult)
+                    BlessingType.DEFENSE -> "+${(b.magnitude * prayerCapeMult).toInt()} DEF"
+                    BlessingType.COINS   -> "+${(b.magnitude * prayerCapeMult * 100).toInt()}% coins"
                 }
             }
             val timeLeft = activeBlessingRemainingMs.formatDurationMs(context)

--- a/app/src/main/kotlin/com/fantasyidler/ui/component/PlayerStatsBar.kt
+++ b/app/src/main/kotlin/com/fantasyidler/ui/component/PlayerStatsBar.kt
@@ -71,10 +71,11 @@ fun PlayerStatsBar(
             val blessingName = if (nameResId != 0) stringResource(nameResId) else activeBlessingKey
             val blessingData = ChurchRepository.ALL_BLESSINGS.firstOrNull { it.key == activeBlessingKey }
             val boostDesc = blessingData?.let { b ->
+                val effectiveBlessing = ChurchRepository.effectiveMagnitude(b, prayerCapeMult)
                 when (b.type) {
-                    BlessingType.XP      -> "%1.2fx XP".format(1f + (b.magnitude - 1f) * prayerCapeMult)
-                    BlessingType.DEFENSE -> "+${(b.magnitude * prayerCapeMult).toInt()} DEF"
-                    BlessingType.COINS   -> "+${(b.magnitude * prayerCapeMult * 100).toInt()}% coins"
+                    BlessingType.XP      -> "×%1$.2f XP".format(effectiveBlessing)
+                    BlessingType.DEFENSE -> "+${effectiveBlessing.toInt()} DEF"
+                    BlessingType.COINS   -> "+${(effectiveBlessing * 100).toInt()}% coins"
                 }
             }
             val timeLeft = activeBlessingRemainingMs.formatDurationMs(context)

--- a/app/src/main/kotlin/com/fantasyidler/ui/screen/ChurchScreen.kt
+++ b/app/src/main/kotlin/com/fantasyidler/ui/screen/ChurchScreen.kt
@@ -343,9 +343,10 @@ private fun BlessingRow(
 @Composable
 private fun blessingEffectText(blessing: BlessingData, blessingTimeMs: Long, prayerCapeMult: Float): String {
     val hours = blessingTimeMs / 3_600_000
+    val effectiveBlessing = ChurchRepository.effectiveMagnitude(blessing, prayerCapeMult)
     return when (blessing.type) {
-        BlessingType.XP      -> stringResource(R.string.church_effect_xp,   1f + (blessing.magnitude - 1f) * prayerCapeMult, hours)
-        BlessingType.DEFENSE -> stringResource(R.string.church_effect_def,   (blessing.magnitude * prayerCapeMult).toInt(), hours)
-        BlessingType.COINS   -> stringResource(R.string.church_effect_coins, (blessing.magnitude * prayerCapeMult * 100).toInt(), hours)
+        BlessingType.XP      -> stringResource(R.string.church_effect_xp,   effectiveBlessing, hours)
+        BlessingType.DEFENSE -> stringResource(R.string.church_effect_def,   effectiveBlessing.toInt(), hours)
+        BlessingType.COINS   -> stringResource(R.string.church_effect_coins, (effectiveBlessing * 100).toInt(), hours)
     }
 }

--- a/app/src/main/kotlin/com/fantasyidler/ui/screen/ChurchScreen.kt
+++ b/app/src/main/kotlin/com/fantasyidler/ui/screen/ChurchScreen.kt
@@ -31,10 +31,8 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
@@ -48,7 +46,6 @@ import com.fantasyidler.data.json.BlessingType
 import com.fantasyidler.repository.ChurchRepository
 import com.fantasyidler.ui.viewmodel.ChurchViewModel
 import com.fantasyidler.util.formatDurationMs
-import kotlin.math.roundToInt
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -78,7 +75,7 @@ fun ChurchScreen(
                     Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
                         Text(text = name, style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.Bold)
                         Text(
-                            text = blessingEffectText(blessing, state.blessingDuration),
+                            text = blessingEffectText(blessing, state.blessingDuration, state.prayerCapeMult),
                             style = MaterialTheme.typography.bodyMedium
                         )
                         Spacer(Modifier.height(4.dp))
@@ -157,6 +154,7 @@ fun ChurchScreen(
                 if (anyBlessingActive) {
                     ActiveBlessingBanner(
                         blessing     = state.activeBlessing!!,
+                        prayerCapeMult = state.prayerCapeMult,
                         remainingMs  = state.activeBlessingRemainingMs,
                         totalMs      = state.blessingDuration,
                         onDeactivate = viewModel::deactivateBlessing,
@@ -212,6 +210,7 @@ fun ChurchScreen(
                         anyBlessingActive = anyBlessingActive,
                         boneCost          = ChurchRepository.boneCostFor(blessing),
                         blessingTimeMs    = state.blessingDuration,
+                        prayerCapeMult    = state.prayerCapeMult,
                         onActivate        = { viewModel.activateBlessing(blessing.key) },
                     )
                     HorizontalDivider(modifier = Modifier.padding(horizontal = 16.dp))
@@ -225,6 +224,7 @@ fun ChurchScreen(
 @Composable
 private fun ActiveBlessingBanner(
     blessing: BlessingData,
+    prayerCapeMult: Float,
     remainingMs: Long,
     totalMs: Long,
     onDeactivate: () -> Unit,
@@ -234,7 +234,7 @@ private fun ActiveBlessingBanner(
         "blessing_${blessing.key}_name", "string", context.packageName,
     )
     val name = if (nameResId != 0) stringResource(nameResId) else blessing.key
-    val effectText = blessingEffectText(blessing, totalMs)
+    val effectText = blessingEffectText(blessing, totalMs, prayerCapeMult)
 
     Row(
         modifier = Modifier
@@ -282,6 +282,7 @@ private fun BlessingRow(
     anyBlessingActive: Boolean,
     boneCost: Int,
     blessingTimeMs: Long,
+    prayerCapeMult: Float,
     onActivate: () -> Unit,
 ) {
     val context   = LocalContext.current
@@ -308,7 +309,7 @@ private fun BlessingRow(
                 color      = nameColor,
             )
             Text(
-                text  = blessingEffectText(blessing, blessingTimeMs),
+                text  = blessingEffectText(blessing, blessingTimeMs, prayerCapeMult),
                 style = MaterialTheme.typography.bodySmall,
                 color = descColor,
             )
@@ -340,11 +341,11 @@ private fun BlessingRow(
 }
 
 @Composable
-private fun blessingEffectText(blessing: BlessingData, blessingTimeMs: Long): String {
+private fun blessingEffectText(blessing: BlessingData, blessingTimeMs: Long, prayerCapeMult: Float): String {
     val hours = blessingTimeMs / 3_600_000
     return when (blessing.type) {
-        BlessingType.XP      -> stringResource(R.string.church_effect_xp,   blessing.magnitude, hours)
-        BlessingType.DEFENSE -> stringResource(R.string.church_effect_def,   blessing.magnitude.roundToInt(), hours)
-        BlessingType.COINS   -> stringResource(R.string.church_effect_coins, (blessing.magnitude * 100).roundToInt(), hours)
+        BlessingType.XP      -> stringResource(R.string.church_effect_xp,   1f + (blessing.magnitude - 1f) * prayerCapeMult, hours)
+        BlessingType.DEFENSE -> stringResource(R.string.church_effect_def,   (blessing.magnitude * prayerCapeMult).toInt(), hours)
+        BlessingType.COINS   -> stringResource(R.string.church_effect_coins, (blessing.magnitude * prayerCapeMult * 100).toInt(), hours)
     }
 }

--- a/app/src/main/kotlin/com/fantasyidler/ui/screen/HomeScreen.kt
+++ b/app/src/main/kotlin/com/fantasyidler/ui/screen/HomeScreen.kt
@@ -628,6 +628,7 @@ fun HomeScreen(
                         coins                      = state.coins,
                         activeBlessingKey          = state.activeBlessingKey,
                         activeBlessingRemainingMs  = state.activeBlessingRemainingMs,
+                        prayerCapeMult             = state.prayerCapeMult,
                         xpBoostRemainingMs         = state.xpBoostRemainingMs,
                         modifier                   = Modifier.padding(horizontal = 16.dp, vertical = 10.dp),
                     )

--- a/app/src/main/kotlin/com/fantasyidler/ui/screen/ProfileScreen.kt
+++ b/app/src/main/kotlin/com/fantasyidler/ui/screen/ProfileScreen.kt
@@ -241,6 +241,7 @@ fun ProfileScreen(
                     totalLevel                = state.totalLevel,
                     coins                     = state.coins,
                     activeBlessingKey         = state.activeBlessingKey,
+                    prayerCapeMult            = state.prayerCapeMult,
                     activeBlessingRemainingMs = (state.activeBlessingExpiresAt - System.currentTimeMillis()).coerceAtLeast(0L),
                     xpBoostRemainingMs        = if (state.ironman) 0L else (state.xpBoostExpiresAt - System.currentTimeMillis()).coerceAtLeast(0L),
                     modifier                  = Modifier.padding(start = 16.dp, end = 16.dp, top = 8.dp, bottom = 16.dp),

--- a/app/src/main/kotlin/com/fantasyidler/ui/viewmodel/BoneAltarViewModel.kt
+++ b/app/src/main/kotlin/com/fantasyidler/ui/viewmodel/BoneAltarViewModel.kt
@@ -14,7 +14,6 @@ import com.fantasyidler.repository.ChurchRepository
 import com.fantasyidler.repository.GameDataRepository
 import com.fantasyidler.repository.GuildRepository
 import com.fantasyidler.repository.PlayerRepository
-import com.fantasyidler.repository.resolveCapeMultiplier
 import com.fantasyidler.repository.QuestRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
 import dagger.hilt.android.qualifiers.ApplicationContext
@@ -39,7 +38,6 @@ data class BoneAltarUiState(
     val prayerLevel: Int = 1,
     val prayerXp: Long = 0L,
     val boostActive: Boolean = false,
-    val prayerCapeMult: Float = 1f,
     val churchMult: Float = 1f,
     val prestigeMult: Float = 1f,
     val petBoostPct: Int = 0,
@@ -94,21 +92,14 @@ class BoneAltarViewModel @Inject constructor(
 
         val boostActive    = !flags.ironman && flags.xpBoostExpiresAt > System.currentTimeMillis()
         val equippedCape   = equipped[EquipSlot.CAPE]?.let { gameData.equipment[it] }
-        // skillPrestige is intentionally omitted here (not flags.skillPrestige): prestige is
-        // already applied as its own separate factor below (prestigeMult), multiplied together
-        // with prayerCapeMult at collection time. Passing the real prestige map here would fold
-        // (prestige + 1) into the cape multiplier too, double-counting prestige for any player
-        // who has prestiged Prayer and owns/equips a prayer cape.
-        val prayerCapeMult = resolveCapeMultiplier(
-            skillName = Skills.PRAYER,
-            equippedCape = equippedCape,
-            inventoryKeys = inventory.keys,
-            townBuildingTiers = flags.townBuildingTiers,
-            skillPrestige = emptyMap(),
-            allEquipment = gameData.equipment,
-            ironman = flags.ironman,
-        )
-        val churchMult     = if (flags.ironman) 1.0f else ChurchRepository.xpMultiplier(flags)
+        // skillPrestige is intentionally counted here twice: prestige is
+        // applied as its own separate factor below (prestigeMult), multiplied together
+        // with churchMult at collection time (which can be affected by prestige).
+        // This double-counting is intended as it comes from two separate sources:
+        // the inherent prestige multiplier of the skill and the effect of the prestige on capes.
+        // This is in line with the multipliers for other skills, the only difference being that
+        // in this case both come from the prayer prestige
+        val churchMult     = if (flags.ironman) 1.0f else ChurchRepository.xpMultiplier(flags, equippedCape, inventory.keys, gameData.equipment)
         val prestige       = if (flags.ironman) 0 else flags.skillPrestige[Skills.PRAYER] ?: 0
         val prestigeMult   = if (prestige > 0) (1.0 + prestige * 0.10).toFloat() else 1f
         val petBoostPct    = if (flags.ironman) 0 else petBoostFor(player.pets, Skills.PRAYER)
@@ -122,7 +113,6 @@ class BoneAltarViewModel @Inject constructor(
             prayerLevel     = levels[Skills.PRAYER] ?: 1,
             prayerXp        = xpMap[Skills.PRAYER] ?: 0L,
             boostActive     = boostActive,
-            prayerCapeMult  = prayerCapeMult,
             churchMult      = churchMult,
             prestigeMult    = prestigeMult,
             petBoostPct     = petBoostPct,
@@ -157,7 +147,7 @@ class BoneAltarViewModel @Inject constructor(
         val boostMult   = if (state.boostActive) 2.0f else 1.0f
         val petMult     = 1.0f + state.petBoostPct / 100.0f
         val effectiveXp = (bone.xpPerBone * comboMult * boostMult *
-            state.churchMult * state.prayerCapeMult * state.prestigeMult * petMult)
+            state.churchMult * state.prestigeMult * petMult)
             .toLong().coerceAtLeast(1L)
 
         _extra.update { it.copy(

--- a/app/src/main/kotlin/com/fantasyidler/ui/viewmodel/ChurchViewModel.kt
+++ b/app/src/main/kotlin/com/fantasyidler/ui/viewmodel/ChurchViewModel.kt
@@ -7,12 +7,15 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.fantasyidler.R
 import com.fantasyidler.data.json.BlessingData
+import com.fantasyidler.data.model.EquipSlot
 import com.fantasyidler.data.model.PlayerFlags
 import com.fantasyidler.data.model.Skills
 import com.fantasyidler.repository.BlessingActivateResult
 import com.fantasyidler.repository.ChurchRepository
+import com.fantasyidler.repository.GameDataRepository
 import com.fantasyidler.repository.PlayerRepository
 import com.fantasyidler.repository.TownRepository
+import com.fantasyidler.repository.resolveCapeMultiplier
 import dagger.hilt.android.lifecycle.HiltViewModel
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -33,6 +36,7 @@ data class ChurchUiState(
     val unlockedBlessingKeys: Set<String> = emptySet(),
     val activeBlessing: BlessingData? = null,
     val activeBlessingRemainingMs: Long = 0L,
+    val prayerCapeMult: Float = 1f,
     val totalBoneEquivalent: Int = 0,
     val totalBoneCount: Int = 0,
     val pendingBlessingKey: String? = null,
@@ -47,6 +51,7 @@ class ChurchViewModel @Inject constructor(
     val townRepo: TownRepository,
     private val playerRepo: PlayerRepository,
     private val churchRepo: ChurchRepository,
+    private val gameData: GameDataRepository,
     private val json: Json,
     @ApplicationContext private val context: Context,
 ) : ViewModel() {
@@ -60,7 +65,10 @@ class ChurchViewModel @Inject constructor(
         if (player == null) return@combine extra.copy(isLoading = true)
         val flags: PlayerFlags          = json.decodeFromString(player.flags)
         val levels: Map<String, Int>    = json.decodeFromString(player.skillLevels)
+        val equipped: Map<String, String?> = json.decodeFromString(player.equipped)
+        val equippedCape                   = equipped[EquipSlot.CAPE]?.let { gameData.equipment[it] }
         val inventory: Map<String, Int> = json.decodeFromString(player.inventory)
+        val prayerCapeMult              = resolveCapeMultiplier(Skills.PRAYER, equippedCape, inventory.keys, flags.townBuildingTiers, flags.skillPrestige, gameData.equipment, flags.ironman)
         val prayerLevel = levels[Skills.PRAYER] ?: 1
         val active      = ChurchRepository.activeBlessing(flags)
         val remaining   = if (active != null) (flags.activeBlessingExpiresAt - System.currentTimeMillis()).coerceAtLeast(0L) else 0L
@@ -72,6 +80,7 @@ class ChurchViewModel @Inject constructor(
             unlockedBlessingKeys      = churchRepo.blessingsForLevel(prayerLevel).map { it.key }.toSet(),
             activeBlessing            = active,
             activeBlessingRemainingMs = remaining,
+            prayerCapeMult            = prayerCapeMult,
             totalBoneEquivalent       = ChurchRepository.totalBoneEquivalent(inventory),
             totalBoneCount            = ChurchRepository.totalBoneCount(inventory),
             ironman                   = flags.ironman,

--- a/app/src/main/kotlin/com/fantasyidler/ui/viewmodel/CombatViewModel.kt
+++ b/app/src/main/kotlin/com/fantasyidler/ui/viewmodel/CombatViewModel.kt
@@ -400,6 +400,7 @@ class CombatViewModel @Inject constructor(
                     dungeonKey    = dungeonKey,
                     weaponSlot    = queuedWeaponSlot,
                     equipped      = equipped,
+                    inventory     = inventory,
                     levels        = queuedLevels,
                     flags         = dungeonFlags,
                     selectedSpell = queuedSpell,
@@ -547,7 +548,7 @@ class CombatViewModel @Inject constructor(
                     playerAttack        = (levels[Skills.ATTACK]    ?: 1) + (prestigeMap[Skills.ATTACK]    ?: 0) * 5,
                     playerStrength      = (levels[Skills.STRENGTH]  ?: 1) + (prestigeMap[Skills.STRENGTH]  ?: 0) * 5,
                     playerDefence       = (levels[Skills.DEFENSE]   ?: 1) + totalDefenseBonus + (prestigeMap[Skills.DEFENSE] ?: 0) * 5,
-                    blessingDefBonus    = ChurchRepository.defBonus(flags),
+                    blessingDefBonus    = ChurchRepository.defBonus(flags, equipped, inventory.keys, gameData.equipment),
                     playerHp            = (levels[Skills.HITPOINTS] ?: 1) + (prestigeMap[Skills.HITPOINTS] ?: 0) * 5 + flags.towerHpBonus,
                     weaponAttackBonus   = totalAttackBonus,
                     weaponStrengthBonus = totalStrengthBonus,
@@ -638,6 +639,7 @@ class CombatViewModel @Inject constructor(
                     bossKey       = bossKey,
                     weaponSlot    = bossWeaponSlot,
                     equipped      = queuedEquipped,
+                    inventory     = queuedInventory,
                     levels        = bossQueuedLevels,
                     flags         = queuedFlags,
                     selectedSpell = bossQueuedSpell,
@@ -764,7 +766,7 @@ class CombatViewModel @Inject constructor(
                     arrowStrengthBonuses = ARROW_STRENGTH_BONUS,
                     equippedFood       = availableFood,
                     foodHealValues     = gameData.foodHealValues,
-                    blessingDefBonus   = ChurchRepository.defBonus(flags),
+                    blessingDefBonus   = ChurchRepository.defBonus(flags, equipped, inventory.keys, gameData.equipment),
                     runeKey            = bossRuneKey,
                     runeCostPerAttack  = bossRuneCost,
                     availableRunes     = if (bossRuneKey != null) inventory[bossRuneKey] ?: 0 else Int.MAX_VALUE,
@@ -969,6 +971,7 @@ class CombatViewModel @Inject constructor(
         val rng     = (levels[Skills.RANGED]    ?: 1) + (prestigeMap[Skills.RANGED]    ?: 0) * 5
         val mgc     = (levels[Skills.MAGIC]     ?: 1) + (prestigeMap[Skills.MAGIC]     ?: 0) * 5
         val agility = levels[Skills.AGILITY]    ?: 1
+        val blessingDefBonus = ChurchRepository.defBonus(flags, equipped, inventory.keys, gameData.equipment)
 
         return gameData.dungeons.mapValues { (_, dungeon) ->
             var survived = 0
@@ -979,7 +982,7 @@ class CombatViewModel @Inject constructor(
                     playerAttack        = atk,
                     playerStrength      = str,
                     playerDefence       = def,
-                    blessingDefBonus    = ChurchRepository.defBonus(flags),
+                    blessingDefBonus    = blessingDefBonus,
                     playerHp            = hp,
                     weaponAttackBonus   = totalAtk,
                     weaponStrengthBonus = totalStr,
@@ -1053,6 +1056,7 @@ class CombatViewModel @Inject constructor(
         dungeonKey: String,
         weaponSlot: String,
         equipped: Map<String, String?>,
+        inventory: Map<String, Int>,
         levels: Map<String, Int>,
         flags: PlayerFlags,
         selectedSpell: SpellData?,
@@ -1101,7 +1105,7 @@ class CombatViewModel @Inject constructor(
             playerAttack        = (levels[Skills.ATTACK]    ?: 1) + (prestigeMap[Skills.ATTACK]    ?: 0) * 5,
             playerStrength      = (levels[Skills.STRENGTH]  ?: 1) + (prestigeMap[Skills.STRENGTH]  ?: 0) * 5,
             playerDefence       = (levels[Skills.DEFENSE]   ?: 1) + totalDefenseBonus + (prestigeMap[Skills.DEFENSE] ?: 0) * 5,
-            blessingDefBonus    = ChurchRepository.defBonus(flags),
+            blessingDefBonus    = ChurchRepository.defBonus(flags, equipped, inventory.keys, gameData.equipment),
             playerHp            = (levels[Skills.HITPOINTS] ?: 1) + (prestigeMap[Skills.HITPOINTS] ?: 0) * 5 + flags.towerHpBonus,
             weaponAttackBonus   = totalAttackBonus,
             weaponStrengthBonus = totalStrengthBonus,
@@ -1132,6 +1136,7 @@ class CombatViewModel @Inject constructor(
         bossKey: String,
         weaponSlot: String,
         equipped: Map<String, String?>,
+        inventory: Map<String, Int>,
         levels: Map<String, Int>,
         flags: PlayerFlags,
         selectedSpell: SpellData?,
@@ -1193,7 +1198,7 @@ class CombatViewModel @Inject constructor(
             arrowStrengthBonuses = ARROW_STRENGTH_BONUS,
             equippedFood       = flags.equippedFood.keys.associateWith { Int.MAX_VALUE },
             foodHealValues     = gameData.foodHealValues,
-            blessingDefBonus   = ChurchRepository.defBonus(flags),
+            blessingDefBonus   = ChurchRepository.defBonus(flags, equipped, inventory.keys, gameData.equipment),
             runeKey            = bossRuneKey,
             runeCostPerAttack  = selectedSpell?.runeCost ?: 1,
             availableRunes     = Int.MAX_VALUE,

--- a/app/src/main/kotlin/com/fantasyidler/ui/viewmodel/CraftingViewModel.kt
+++ b/app/src/main/kotlin/com/fantasyidler/ui/viewmodel/CraftingViewModel.kt
@@ -199,7 +199,7 @@ class CraftingViewModel @Inject constructor(
             } else 0L
             val xpMult = if (selectedRecipe != null) {
                 val boostMult = if (flags.ironman) 1.0
-                                else (if (flags.xpBoostExpiresAt > System.currentTimeMillis()) 2.0 else 1.0) * ChurchRepository.xpMultiplier(flags)
+                                else (if (flags.xpBoostExpiresAt > System.currentTimeMillis()) 2.0 else 1.0) * ChurchRepository.xpMultiplier(flags, equipped, inventory.keys, gameData.equipment)
                 val petPct = petBoostFor(player.pets, selectedRecipe.skillName, flags.ironman)
                 selectedEff * boostMult * (1.0 + petPct / 100.0)
             } else 1.0
@@ -429,7 +429,9 @@ class CraftingViewModel @Inject constructor(
                 val toolEff   = craftToolEfficiency(recipe, json.decodeFromString(player.equipped))
                 val perItemMs = (SkillSimulator.sessionDurationMs(agility, flags.skillPrestige[Skills.AGILITY] ?: 0, townRepo.playerSessionDurationMultiplier(flags)) / 60 / toolEff).toLong()
                 val totalOutput = qty * recipe.outputQty
-                val xpQueueMult = if (flags.ironman) 1.0 else (if (flags.xpBoostExpiresAt > System.currentTimeMillis()) 2.0 else 1.0) * ChurchRepository.xpMultiplier(flags)
+                val equipped: Map<String, String?> = json.decodeFromString(player.equipped)
+                val inventory: Map<String, Int> = json.decodeFromString(player.inventory)
+                val xpQueueMult = if (flags.ironman) 1.0 else (if (flags.xpBoostExpiresAt > System.currentTimeMillis()) 2.0 else 1.0) * ChurchRepository.xpMultiplier(flags, equipped, inventory.keys, gameData.equipment)
                 val queuePetPct = petBoostFor(player.pets, recipe.skillName, flags.ironman)
                 val action = QueuedAction(
                     skillName           = recipe.skillName,

--- a/app/src/main/kotlin/com/fantasyidler/ui/viewmodel/HomeViewModel.kt
+++ b/app/src/main/kotlin/com/fantasyidler/ui/viewmodel/HomeViewModel.kt
@@ -178,6 +178,7 @@ data class HomeUiState(
     val workerSummary: SessionSummary? = null,
     val activeBlessingKey: String = "",
     val activeBlessingRemainingMs: Long = 0L,
+    val prayerCapeMult: Float = 1f,
     val xpBoostRemainingMs: Long = 0L,
     val ironman: Boolean = false,
     val recentSessions: List<com.fantasyidler.data.model.RecentSession> = emptyList(),
@@ -287,6 +288,9 @@ class HomeViewModel @Inject constructor(
             val flags: PlayerFlags = json.decodeFromString(player.flags)
             val levels: Map<String, Int> = json.decodeFromString(player.skillLevels)
             val equipped: Map<String, String?> = json.decodeFromString(player.equipped)
+            val equippedCape = equipped[EquipSlot.CAPE].let { gameData.equipment[it] }
+            val inventory: Map<String, Int> = json.decodeFromString(player.inventory)
+            val prayerCapeMult = resolveCapeMultiplier(Skills.PRAYER, equippedCape, inventory.keys, flags.townBuildingTiers, flags.skillPrestige, gameData.equipment, flags.ironman)
             val agilityLevel    = levels[Skills.AGILITY] ?: 1
             val agilityPrestige = flags.skillPrestige[Skills.AGILITY] ?: 0
             val chronosMult     = townRepo.playerSessionDurationMultiplier(flags)
@@ -312,7 +316,7 @@ class HomeViewModel @Inject constructor(
                                }
             val innXpMult = townRepo.workerXpMultiplier(flags)
             val playerXpBoostMult = if (flags.ironman) 1.0
-                else (if (flags.xpBoostExpiresAt > System.currentTimeMillis()) 2.0 else 1.0) * ChurchRepository.xpMultiplier(flags)
+                else (if (flags.xpBoostExpiresAt > System.currentTimeMillis()) 2.0 else 1.0) * ChurchRepository.xpMultiplier(flags, equipped, inventory.keys, gameData.equipment)
             val sessionXpGain: (SkillSession?) -> Long = { s ->
                 if (s == null || s.skillName in listOf("combat", "boss", "expedition", "farming", "tower", "carnival")) 0L
                 else try {
@@ -404,6 +408,7 @@ class HomeViewModel @Inject constructor(
                 workerQueue2        = flags.hiredWorker2?.sessionQueue ?: emptyList(),
                 activeBlessingKey          = flags.activeBlessingKey,
                 activeBlessingRemainingMs  = (flags.activeBlessingExpiresAt - System.currentTimeMillis()).coerceAtLeast(0L),
+                prayerCapeMult             = prayerCapeMult,
                 xpBoostRemainingMs         = if (flags.ironman) 0L else (flags.xpBoostExpiresAt - System.currentTimeMillis()).coerceAtLeast(0L),
                 ironman                    = flags.ironman,
                 recentSessions             = flags.recentSessions,
@@ -463,8 +468,8 @@ class HomeViewModel @Inject constructor(
             val equippedCape = equipped[EquipSlot.CAPE]?.let { gameData.equipment[it] }
             val boostActive      = !flags.ironman && flags.xpBoostExpiresAt > System.currentTimeMillis()
             val xpMult           = if (boostActive) 2L else 1L
-            val blessingXpMult   = if (flags.ironman) 1.0f else ChurchRepository.xpMultiplier(flags)
-            val blessingCoinMult = if (flags.ironman) 1.0f else ChurchRepository.coinMultiplier(flags) *
+            val blessingXpMult   = if (flags.ironman) 1.0f else ChurchRepository.xpMultiplier(flags, equippedCape, inventory.keys, gameData.equipment)
+            val blessingCoinMult = if (flags.ironman) 1.0f else ChurchRepository.coinMultiplier(flags, equippedCape, inventory.keys, gameData.equipment) *
                 PlayerRepository.gooseCoinMultiplier(json.decodeFromString<List<OwnedPet>>(player.pets)).toFloat()
 
             // ── Accumulators ──────────────────────────────────────────────
@@ -776,6 +781,38 @@ class HomeViewModel @Inject constructor(
                         combinedXpBySkill[Skills.MERCANTILE] = (combinedXpBySkill[Skills.MERCANTILE] ?: 0L) + totalXp
                         combinedCoins += coinReturnPreBlessing
                     }
+                    Skills.PRAYER -> {
+                        val totalXp = if (grantXp) frames.sumOf { it.xpGain.toLong() } else 0L
+                        val its     = mutableMapOf<String, Int>()
+                        for (frame in frames) for ((item, qty) in frame.items) its[item] = (its[item] ?: 0) + qty
+                        val coinsFromItems = (its.remove("coins") ?: 0).toLong()
+                        if (coinsFromItems > 0) {
+                            playerRepo.addCoins(coinsFromItems)
+                            combinedCoins += coinsFromItems
+                        }
+                        val pets       = its.filterKeys { it in petIds }
+                        val rawRegular = its.filterKeys { it !in petIds }
+                        awardedCapes += playerRepo.applySessionResults(Skills.PRAYER,
+                            totalXp, rawRegular
+                        )
+                        val buried = frames.sumOf { it.kills }
+                        val isAshSession = gameData.bones[session.activityKey]?.isAsh == true
+                        if (!isAshSession) {
+                            questRepo.recordBuried(buried)
+                            guildRepo.recordGuildPrayer(buried)
+                            playerRepo.recordDailyPrayer(buried)
+                        }
+                        for ((id, _) in pets) {
+                            val pd = gameData.pets[id] ?: continue
+                            if (playerRepo.addPetIfNew(id, pd.boostPercent))
+                                petFoundName = GameStrings.petName(context, pd.id)
+                        }
+                        combinedXpBySkill[Skills.PRAYER] = (combinedXpBySkill[Skills.PRAYER] ?: 0L) + totalXp
+                        for ((item, qty) in rawRegular) combinedItems[item] = (combinedItems[item] ?: 0) + qty
+                        val count = frames.sumOf { it.kills }
+                        val name  = GameStrings.itemName(context, session.activityKey)
+                        combinedBones[name] = (combinedBones[name] ?: 0) + count
+                    }
                     else -> {
                         val totalXp = if (grantXp) frames.sumOf { it.xpGain.toLong() } else 0L
                         val its     = mutableMapOf<String, Int>()
@@ -817,15 +854,6 @@ class HomeViewModel @Inject constructor(
                                 questRepo.recordThieving(session.activityKey, successCount, regular.filterKeys { it != "coins" })
                                 guildRepo.recordGuildThieving(session.activityKey, successCount)
                             }
-                            Skills.PRAYER      -> {
-                                val buried = frames.sumOf { it.kills }
-                                val isAshSession = gameData.bones[session.activityKey]?.isAsh == true
-                                if (!isAshSession) {
-                                    questRepo.recordBuried(buried)
-                                    guildRepo.recordGuildPrayer(buried)
-                                    playerRepo.recordDailyPrayer(buried)
-                                }
-                            }
                             Skills.FARMING     -> guildRepo.recordGuildGathering(Skills.FARMING, regular)
                         }
                         for ((id, _) in pets) {
@@ -835,11 +863,6 @@ class HomeViewModel @Inject constructor(
                         }
                         combinedXpBySkill[session.skillName] = (combinedXpBySkill[session.skillName] ?: 0L) + totalXp
                         for ((item, qty) in regular) combinedItems[item] = (combinedItems[item] ?: 0) + qty
-                        if (session.skillName == Skills.PRAYER) {
-                            val count = frames.sumOf { it.kills }
-                            val name  = GameStrings.itemName(context, session.activityKey)
-                            combinedBones[name] = (combinedBones[name] ?: 0) + count
-                        }
                     }
                 }
             }
@@ -1054,14 +1077,15 @@ class HomeViewModel @Inject constructor(
                 }
             }
             val isCombat = session.skillName == "combat" || session.skillName == "boss"
-            val player = if (isCombat) playerRepo.getOrCreatePlayer() else null
+            val player = playerRepo.getOrCreatePlayer()
+            val equipped: Map<String, String?> = json.decodeFromString(player.equipped)
             val weaponSlot = if (isCombat) {
-                val equipped: Map<String, String?> = player?.equipped?.let { json.decodeFromString(it) } ?: emptyMap()
                 flags.activeWeaponSlot
                     ?: EquipSlot.WEAPON_SLOTS.firstOrNull { equipped[it] != null }
                     ?: EquipSlot.WEAPON_ATK
             } else null
-            val xpQueueMult = if (flags.ironman) 1.0 else (if (flags.xpBoostExpiresAt > System.currentTimeMillis()) 2.0 else 1.0) * ChurchRepository.xpMultiplier(flags)
+            val inventory: Map<String, Int> = json.decodeFromString(player.inventory)
+            val xpQueueMult = if (flags.ironman) 1.0 else (if (flags.xpBoostExpiresAt > System.currentTimeMillis()) 2.0 else 1.0) * ChurchRepository.xpMultiplier(flags, equipped, inventory.keys, gameData.equipment)
             val rawXpGain = frames.sumOf { it.xpGain }
             // The original fight/run count isn't stored on the session itself, only in the
             // repeat-chain flags set when it was first started -- carry it forward so
@@ -1081,7 +1105,7 @@ class HomeViewModel @Inject constructor(
                 estimatedXpGain     = if (session.skillName in listOf("carnival", "expedition")) 0L
                                       else (rawXpGain * xpQueueMult).toLong(),
                 weaponSlot          = weaponSlot,
-                equippedSnapshot    = player?.equipped,
+                equippedSnapshot    = if (isCombat) player.equipped else null,
                 spellName           = flags.activeSpell,
                 arrowsKey           = flags.equippedArrows,
                 potionKey           = flags.activePotionKey,
@@ -1178,8 +1202,10 @@ class HomeViewModel @Inject constructor(
             val workerSkillPrestige = if (flags.ironman) emptyMap() else flags.skillPrestige
             val boostActive      = !flags.ironman && flags.xpBoostExpiresAt > System.currentTimeMillis()
             val xpMult           = if (boostActive) 2L else 1L
-            val blessingXpMult   = if (flags.ironman) 1.0f else ChurchRepository.xpMultiplier(flags)
-            val blessingCoinMult = if (flags.ironman) 1.0f else ChurchRepository.coinMultiplier(flags) *
+            val equipped: Map<String, String?> = json.decodeFromString(workerPlayer.equipped)
+            val inventory: Map<String, Int> = json.decodeFromString(workerPlayer.inventory)
+            val blessingXpMult   = if (flags.ironman) 1.0f else ChurchRepository.xpMultiplier(flags, equipped, inventory.keys, gameData.equipment)
+            val blessingCoinMult = if (flags.ironman) 1.0f else ChurchRepository.coinMultiplier(flags, equipped, inventory.keys, gameData.equipment) *
                 PlayerRepository.gooseCoinMultiplier(json.decodeFromString<List<OwnedPet>>(workerPlayer.pets)).toFloat()
             val innXpMult        = townRepo.workerXpMultiplier(flags)
             val workerOwnedPets: List<OwnedPet> = if (flags.ironman) emptyList()

--- a/app/src/main/kotlin/com/fantasyidler/ui/viewmodel/HomeViewModel.kt
+++ b/app/src/main/kotlin/com/fantasyidler/ui/viewmodel/HomeViewModel.kt
@@ -7,6 +7,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.fantasyidler.BuildConfig
 import com.fantasyidler.R
+import com.fantasyidler.data.json.EquipmentData
 import com.fantasyidler.data.model.DungeonRunStats
 import com.fantasyidler.data.model.HiredWorker
 import com.fantasyidler.data.model.OwnedPet
@@ -28,6 +29,7 @@ import com.fantasyidler.repository.SaveSlotRepository
 import com.fantasyidler.repository.TitleRepository
 import com.fantasyidler.repository.TownRepository
 import com.fantasyidler.data.model.EquipSlot
+import com.fantasyidler.data.model.Player
 import com.fantasyidler.repository.WorkerQueuedSessionStarter
 import com.fantasyidler.repository.resolveCapeMultiplier
 import com.fantasyidler.simulator.SkillSimulator
@@ -439,6 +441,45 @@ class HomeViewModel @Inject constructor(
     // Session actions
     // ------------------------------------------------------------------
 
+    private class SessionAccumulator {
+        val xpBySkill             = mutableMapOf<String, Long>()
+        val items                 = mutableMapOf<String, Int>()
+        val kills                 = mutableMapOf<String, Int>()
+        val food                  = mutableMapOf<String, Int>()
+        val arrows                = mutableMapOf<String, Int>()
+        val arrowsReclaimed       = mutableMapOf<String, Int>()
+        val runes                 = mutableMapOf<String, Int>()
+        val runesReclaimed        = mutableMapOf<String, Int>()
+        val dailyKills            = mutableMapOf<String, Int>()
+        val bones                 = mutableMapOf<String, Int>()
+        var coins                 = 0L
+        var anyDied               = false
+        var petFoundName: String? = null
+        var bossWon: Boolean?     = null
+        var bossCoinsReduced      = false
+        val voidedSessionIds      = mutableSetOf<String>()
+        val awardedCapes          = mutableListOf<String>()
+        var expeditionNoteLines   = emptyList<String>()
+        var expeditionUnlockMessage: String?  = null
+    }
+
+    private data class SessionRunContext(
+        val petIds: Set<String>,
+        val player: Player,
+        val flags: PlayerFlags,
+        val skillPrestige: Map<String, Int>,
+        val equipped: Map<String, String?>,
+        val inventory: Map<String, Int>,
+        val equippedCape: EquipmentData?,
+        val blessingXpMult: Float,
+        val blessingCoinMult: Float,
+        val xpMult: Long,
+        val boostActive: Boolean,
+    ) {
+        val gatheringSkills = setOf(Skills.MINING, Skills.WOODCUTTING, Skills.FISHING, Skills.AGILITY)
+        val craftingSkills  = setOf(Skills.SMITHING, Skills.COOKING, Skills.FLETCHING, Skills.CRAFTING, Skills.HERBLORE, Skills.FIREMAKING, Skills.RUNECRAFTING, Skills.CONSTRUCTION)
+    }
+
     fun collectSession() {
         if (_extra.value.isCollecting) return
         _extra.update { it.copy(isCollecting = true) }
@@ -458,43 +499,11 @@ class HomeViewModel @Inject constructor(
             // not yesterday's stale ones (which would be wiped on the next guild screen open).
             guildRepo.ensureGuildDailiesRefreshed()
 
-            val petIds = gameData.pets.keys
-            val player = playerRepo.getOrCreatePlayer()
-            val flags: PlayerFlags = json.decodeFromString(player.flags)
-            // Ironman characters play at pure base rates: every XP/yield/coin multiplier is inert.
-            val skillPrestige = if (flags.ironman) emptyMap() else flags.skillPrestige
-            val equipped: Map<String, String?> = json.decodeFromString(player.equipped)
-            val inventory: Map<String, Int>    = json.decodeFromString(player.inventory)
-            val equippedCape = equipped[EquipSlot.CAPE]?.let { gameData.equipment[it] }
-            val boostActive      = !flags.ironman && flags.xpBoostExpiresAt > System.currentTimeMillis()
-            val xpMult           = if (boostActive) 2L else 1L
-            val blessingXpMult   = if (flags.ironman) 1.0f else ChurchRepository.xpMultiplier(flags, equippedCape, inventory.keys, gameData.equipment)
-            val blessingCoinMult = if (flags.ironman) 1.0f else ChurchRepository.coinMultiplier(flags, equippedCape, inventory.keys, gameData.equipment) *
-                PlayerRepository.gooseCoinMultiplier(json.decodeFromString<List<OwnedPet>>(player.pets)).toFloat()
+            // ── Context ───────────────────────────────────────────────────
+            val sessionRunContext = getSessionRunContext()
 
             // ── Accumulators ──────────────────────────────────────────────
-            val combinedXpBySkill       = mutableMapOf<String, Long>()
-            val combinedItems           = mutableMapOf<String, Int>()
-            val combinedKills           = mutableMapOf<String, Int>()
-            val combinedFood            = mutableMapOf<String, Int>()
-            val combinedArrows          = mutableMapOf<String, Int>()
-            val combinedArrowsReclaimed = mutableMapOf<String, Int>()
-            val combinedRunes           = mutableMapOf<String, Int>()
-            val combinedRunesReclaimed  = mutableMapOf<String, Int>()
-            val dailyKills              = mutableMapOf<String, Int>()
-            var combinedCoins     = 0L
-            var anyDied           = false
-            val combinedBones     = mutableMapOf<String, Int>() // boneName → count
-            var petFoundName: String? = null
-            var bossWon: Boolean? = null  // set when session is a boss fight
-            var bossCoinsReduced = false
-            val voidedSessionIds = mutableSetOf<String>()
-            val awardedCapes = mutableListOf<String>()
-            var expeditionNoteLines: List<String> = emptyList()
-            var expeditionUnlockMessage: String? = null
-
-            val gatheringSkills = setOf(Skills.MINING, Skills.WOODCUTTING, Skills.FISHING, Skills.AGILITY)
-            val craftingSkills  = setOf(Skills.SMITHING, Skills.COOKING, Skills.FLETCHING, Skills.CRAFTING, Skills.HERBLORE, Skills.FIREMAKING, Skills.RUNECRAFTING, Skills.CONSTRUCTION)
+            val sessionAccumulator = SessionAccumulator()
 
             val currentLevelsForVoidCheck = playerRepo.getSkillLevels()
             for (session in sessions) {
@@ -503,374 +512,22 @@ class HomeViewModel @Inject constructor(
                 // kills, and quest progress still pay out. Zeroing happens at each branch's XP
                 // application point because combat style detection needs the raw per-skill XP.
                 val grantXp = isSkillSessionStillEligible(session, currentLevelsForVoidCheck, gameData)
-                if (!grantXp) voidedSessionIds += session.sessionId
+                if (!grantXp) sessionAccumulator.voidedSessionIds += session.sessionId
                 when (session.skillName) {
-                    "tower" -> {
-                        val playerDied = frames.any { it.died }
-                        if (playerDied) anyDied = true
-                        val towerXpPerSkill = mutableMapOf<String, Long>()
-                        val towerAllItems   = mutableMapOf<String, Int>()
-                        val towerFood       = mutableMapOf<String, Int>()
-                        val towerKills      = mutableMapOf<String, Int>()
-                        val towerArrows     = mutableMapOf<String, Int>()
-                        val towerRunes      = mutableMapOf<String, Int>()
-                        for (frame in frames) {
-                            for ((skill, xp) in frame.xpBySkill)    towerXpPerSkill[skill] = (towerXpPerSkill[skill] ?: 0L) + xp
-                            for ((item,  qty) in frame.items)        towerAllItems[item]     = (towerAllItems[item] ?: 0) + qty
-                            for ((food,  qty) in frame.foodConsumed) towerFood[food]         = (towerFood[food] ?: 0) + qty
-                            for ((e,     k)   in frame.killsByEnemy) towerKills[e]           = (towerKills[e] ?: 0) + k
-                            for ((arrow, qty) in frame.arrowsConsumed) towerArrows[arrow]    = (towerArrows[arrow] ?: 0) + qty
-                            for ((rune,  qty) in frame.runesConsumed) towerRunes[rune]       = (towerRunes[rune] ?: 0) + qty
-                        }
-                        if (playerDied) {
-                            towerXpPerSkill.replaceAll { _, xp -> maxOf(1L, (xp * 0.1).toLong()) }
-                            towerAllItems.replaceAll { _, qty -> maxOf(0, (qty * 0.1).toInt()) }
-                            towerAllItems.entries.removeIf { it.value == 0 }
-                        }
-                        
-                        if (!playerDied && towerKills.isNotEmpty()) {
-                            val style = detectCombatStyle(towerXpPerSkill)
-                            questRepo.recordCombat(
-                                dungeonKey        = session.activityKey,
-                                killsByEnemy      = towerKills,
-                                loot              = towerAllItems,
-                                combatStyle       = style,
-                                foodConsumedTotal = towerFood.values.sum(),
-                            )
-                            for ((e, k) in towerKills) dailyKills[e] = (dailyKills[e] ?: 0) + k
-                            guildRepo.recordGuildCombat(towerKills, style)
-                            var towerSlayerXp = 0L
-                            for ((enemy, k) in towerKills) towerSlayerXp += slayerRepo.recordKills(enemy, k)
-                            if (towerSlayerXp > 0L) towerXpPerSkill[Skills.SLAYER] = (towerXpPerSkill[Skills.SLAYER] ?: 0L) + towerSlayerXp
-                        }
-
-                        val towerCoinsRaw    = towerAllItems.remove("coins")?.toLong() ?: 0L
-                        val towerFlags       = playerRepo.getFlags()
-                        val towerXpMult      = if (towerFlags.ironman) 1.0 else 1.0 + towerFlags.towerXpBonusPct / 100.0
-                        val towerCoinMult    = if (towerFlags.ironman) 1.0 else 1.0 + towerFlags.towerCoinBonusPct / 100.0
-                        val towerXpForRepo   = if (grantXp) towerXpPerSkill.mapValues { (_, xp) -> (xp * towerXpMult).toLong() } else emptyMap()
-                        val towerCoinsGained = (towerCoinsRaw * towerCoinMult).toLong()
-
-                        playerRepo.applyMultiSkillResults(towerXpForRepo, towerAllItems, towerCoinsGained)
-
-                        val skillLvls = playerRepo.getSkillLevels()
-                        val arrowsReclaimed = towerArrows.mapValues { (_, qty) -> (qty * reclaimChance(skillLvls[Skills.RANGED] ?: 1)).toInt() }.filterValues { it > 0 }
-                        val runesReclaimed  = towerRunes.mapValues { (_, qty) -> (qty * reclaimChance(skillLvls[Skills.MAGIC] ?: 1)).toInt() }.filterValues { it > 0 }
-                        val finalTowerArrows = towerArrows.mapValues { (k, v) -> v - (arrowsReclaimed[k] ?: 0) }.filterValues { it > 0 }
-                        val finalTowerRunes  = towerRunes.mapValues { (k, v) -> v - (runesReclaimed[k] ?: 0) }.filterValues { it > 0 }
-
-                        val totalConsumables = towerFood + finalTowerArrows + finalTowerRunes
-                        if (totalConsumables.isNotEmpty()) playerRepo.consumeItems(totalConsumables)
-                        val floor = session.activityKey.removePrefix("tower_floor_").toIntOrNull() ?: 1
-                        val updatedTowerFlags = playerRepo.getFlags()
-                        if (playerDied) {
-                            // Death drops you back to your last checkpoint (every 25 floors of
-                            // your best-ever progress), matching TowerViewModel.collectFloor() --
-                            // this path had drifted to a flat reset to 0 (issue #1183).
-                            val checkpointFloor = (updatedTowerFlags.towerBestFloor / TowerViewModel.TOWER_CHECKPOINT_INTERVAL) * TowerViewModel.TOWER_CHECKPOINT_INTERVAL
-                            playerRepo.updateFlags(updatedTowerFlags.copy(towerCurrentFloor = checkpointFloor))
-                        } else {
-                            playerRepo.updateFlags(updatedTowerFlags.copy(
-                                towerCurrentFloor = floor,
-                                towerBestFloor    = maxOf(updatedTowerFlags.towerBestFloor, floor),
-                            ))
-                        }
-                        for ((skill, xp) in towerXpForRepo) combinedXpBySkill[skill] = (combinedXpBySkill[skill] ?: 0L) + xp
-                        for ((item, qty) in towerAllItems)  combinedItems[item] = (combinedItems[item] ?: 0) + qty
-                        combinedCoins += towerCoinsGained
-                    }
-                    "boss" -> {
-                        val frame = frames.lastOrNull() ?: continue
-                        val won = frame.kills > 0
-                        bossWon = won
-                        val its   = frame.items.toMutableMap()
-                        val coins = if (won) {
-                            val base = its.remove("coins")?.toLong() ?: 0L
-                            val mult = playerRepo.rollBossCoinSoftCap(session.activityKey)
-                            if (mult < 1.0 && base > 0L) bossCoinsReduced = true
-                            (base * mult).toLong()
-                        } else 0L
-                        val pets  = its.filterKeys { it in petIds }
-                        val loot  = if (won) its.filterKeys { it !in petIds } else emptyMap()
-                        val allFoodConsumed   = mutableMapOf<String, Int>()
-                        val allArrowsConsumed = mutableMapOf<String, Int>()
-                        val allRunesConsumed  = mutableMapOf<String, Int>()
-                        val bossXpBySkill     = mutableMapOf<String, Long>()
-                        for (f in frames) {
-                            f.foodConsumed.forEach   { (k, v) -> allFoodConsumed[k]   = (allFoodConsumed[k] ?: 0) + v }
-                            f.arrowsConsumed.forEach { (k, v) -> allArrowsConsumed[k] = (allArrowsConsumed[k] ?: 0) + v }
-                            f.runesConsumed.forEach  { (k, v) -> allRunesConsumed[k]  = (allRunesConsumed[k] ?: 0) + v }
-                            f.xpBySkill.forEach      { (k, v) -> bossXpBySkill[k]     = (bossXpBySkill[k] ?: 0L) + v }
-                        }
-                        for (skill in bossXpBySkill.keys) {
-                            val mult = resolveCapeMultiplier(skill, equippedCape, inventory.keys, flags.townBuildingTiers, skillPrestige, gameData.equipment, flags.ironman)
-                            if (mult > 1f) {
-                                bossXpBySkill[skill] = (bossXpBySkill[skill]!! * mult.toDouble()).toLong()
-                            }
-                        }
-                        if (!grantXp) bossXpBySkill.clear()
-                        val bossSkillLvls    = playerRepo.getSkillLevels()
-                        val bossArrowsRec    = allArrowsConsumed.mapValues { (_, qty) -> (qty * reclaimChance(bossSkillLvls[Skills.RANGED] ?: 1)).toInt() }.filterValues { it > 0 }
-                        val bossRunesRec     = allRunesConsumed.mapValues  { (_, qty) -> (qty * reclaimChance(bossSkillLvls[Skills.MAGIC]  ?: 1)).toInt() }.filterValues { it > 0 }
-                        val ownedPets: List<OwnedPet> = if (flags.ironman) emptyList()
-                            else try { json.decodeFromString(player.pets) } catch (_: Exception) { emptyList() }
-                        val perSkillPetBoostPct = bossXpBySkill.keys.associateWith { skill ->
-                            ownedPets.sumOf { ownedPet ->
-                                val pd = gameData.pets[ownedPet.id]
-                                if (pd == null) 0
-                                else when {
-                                    pd.boostedSkill == "all" -> pd.boostPercent
-                                    pd.boostedSkill == skill -> pd.boostPercent
-                                    pd.boostedSkill == "combat" && skill in Skills.COMBAT -> pd.boostPercent
-                                    else -> 0
-                                }
-                            }
-                        }.filterValues { it > 0 }
-                        awardedCapes += playerRepo.applyMultiSkillResults(bossXpBySkill, loot, coins, perSkillPetBoostPct = perSkillPetBoostPct)
-                        if (allFoodConsumed.isNotEmpty())   playerRepo.consumeItems(allFoodConsumed)
-                        if (allArrowsConsumed.isNotEmpty()) playerRepo.consumeItems(allArrowsConsumed)
-                        if (bossArrowsRec.isNotEmpty())     playerRepo.addItems(bossArrowsRec)
-                        if (bossRunesRec.isNotEmpty())      playerRepo.addItems(bossRunesRec)
-                        for ((f, q) in allFoodConsumed)    combinedFood[f]             = (combinedFood[f] ?: 0) + q
-                        for ((a, q) in allArrowsConsumed)  combinedArrows[a]           = (combinedArrows[a] ?: 0) + q
-                        for ((a, q) in bossArrowsRec)      combinedArrowsReclaimed[a]  = (combinedArrowsReclaimed[a] ?: 0) + q
-                        for ((r, q) in allRunesConsumed)   combinedRunes[r]            = (combinedRunes[r] ?: 0) + q
-                        for ((r, q) in bossRunesRec)       combinedRunesReclaimed[r]   = (combinedRunesReclaimed[r] ?: 0) + q
-                        if (won) {
-                            for ((id, _) in pets) {
-                                val pd = gameData.pets[id] ?: continue
-                                if (playerRepo.addPetIfNew(id, pd.boostPercent))
-                                    petFoundName = GameStrings.petName(context, pd.id)
-                            }
-                            questRepo.recordCombat(
-                                dungeonKey   = session.activityKey,
-                                killsByEnemy = mapOf(session.activityKey to 1),
-                                loot         = loot,
-                            )
-                            dailyKills[session.activityKey] = (dailyKills[session.activityKey] ?: 0) + 1
-                            playerRepo.recordWeeklyProgress("boss", session.activityKey, 1)
-                            guildRepo.recordGuildCombat(mapOf(session.activityKey to 1), frames.lastOrNull()?.combatStyle?.ifEmpty { "melee" } ?: "melee")
-                            seasonalEventRepo.recordCombat(mapOf(session.activityKey to 1))
-                            seasonalEventRepo.recordBossDefeat(session.activityKey)
-                            for ((item, qty) in loot) combinedItems[item] = (combinedItems[item] ?: 0) + qty
-                            combinedCoins += coins
-                        }
-                        for ((skill, xp) in bossXpBySkill) {
-                            val petPct = perSkillPetBoostPct[skill] ?: 0
-                            val withPet = if (petPct > 0) (xp * (1.0 + petPct / 100.0)).toLong() else xp
-                            val prestigeLevel = skillPrestige[skill] ?: 0
-                            val withPrestige = if (prestigeLevel > 0) (withPet * (1.0 + prestigeLevel * 0.10)).toLong() else withPet
-                            combinedXpBySkill[skill] = (combinedXpBySkill[skill] ?: 0L) + withPrestige
-                        }
-                    }
-                    "combat" -> {
-                        val xpPerSkill = mutableMapOf<String, Long>()
-                        val its        = mutableMapOf<String, Int>()
-                        val kills      = mutableMapOf<String, Int>()
-                        val food   = mutableMapOf<String, Int>()
-                        val arrows = mutableMapOf<String, Int>()
-                        val runes  = mutableMapOf<String, Int>()
-                        val died   = frames.any { it.died }
-                        if (died) anyDied = true
-                        for (frame in frames) {
-                            for ((skill, xp) in frame.xpBySkill)      xpPerSkill[skill] = (xpPerSkill[skill] ?: 0L) + xp
-                            for ((item, qty) in frame.items)           its[item]         = (its[item] ?: 0) + qty
-                            for ((e, k) in frame.killsByEnemy)         kills[e]          = (kills[e] ?: 0) + k
-                            for ((f, q) in frame.foodConsumed)         food[f]           = (food[f] ?: 0) + q
-                            for ((a, q) in frame.arrowsConsumed)       arrows[a]         = (arrows[a] ?: 0) + q
-                            for ((r, q) in frame.runesConsumed)        runes[r]          = (runes[r] ?: 0) + q
-                        }
-                        for (skill in xpPerSkill.keys) {
-                            val mult = resolveCapeMultiplier(skill, equippedCape, inventory.keys, flags.townBuildingTiers, skillPrestige, gameData.equipment, flags.ironman)
-                            if (mult > 1f) {
-                                xpPerSkill[skill] = (xpPerSkill[skill]!! * mult.toDouble()).toLong()
-                            }
-                        }
-                        if (died) {
-                            xpPerSkill.replaceAll { _, xp -> maxOf(1L, (xp * 0.1).toLong()) }
-                            its.replaceAll { _, qty -> maxOf(0, (qty * 0.1).toInt()) }
-                            its.entries.removeIf { it.value == 0 }
-                        }
-                        val coins = its.remove("coins")?.toLong() ?: 0L
-                        val pets  = its.filterKeys { it in petIds }
-                        val loot  = its.filterKeys { it !in petIds }
-                        var slayerXp = 0L
-                        for ((enemy, k) in kills) slayerXp += slayerRepo.recordKills(enemy, k)
-                        if (slayerXp > 0L) xpPerSkill[Skills.SLAYER] = (xpPerSkill[Skills.SLAYER] ?: 0L) + slayerXp
-                        val combatStyle = detectCombatStyle(xpPerSkill)
-                        if (!grantXp) xpPerSkill.clear()
-                        awardedCapes += playerRepo.applyMultiSkillResults(xpPerSkill, loot, coins)
-                        for ((id, _) in pets) {
-                            val pd = gameData.pets[id] ?: continue
-                            if (playerRepo.addPetIfNew(id, pd.boostPercent))
-                                petFoundName = GameStrings.petName(context, pd.id)
-                        }
-                        if (!died) {
-                            questRepo.recordCombat(
-                                dungeonKey         = session.activityKey,
-                                killsByEnemy       = kills,
-                                loot               = loot,
-                                combatStyle        = combatStyle,
-                                foodConsumedTotal  = food.values.sum(),
-                            )
-                            playerRepo.incrementDungeonRun(session.activityKey)
-                            if (kills.isNotEmpty()) {
-                                for ((e, k) in kills) dailyKills[e] = (dailyKills[e] ?: 0) + k
-                                guildRepo.recordGuildCombat(kills, combatStyle)
-                                seasonalEventRepo.recordCombat(kills)
-                            }
-                            seasonalEventRepo.recordExpeditionCompletion(session.activityKey)
-                        }
-                        val skillLvls      = playerRepo.getSkillLevels()
-                        val arrowsReclaimed = arrows.mapValues { (_, qty) -> (qty * reclaimChance(skillLvls[Skills.RANGED] ?: 1)).toInt() }.filterValues { it > 0 }
-                        val runesReclaimed  = runes.mapValues  { (_, qty) -> (qty * reclaimChance(skillLvls[Skills.MAGIC]  ?: 1)).toInt() }.filterValues { it > 0 }
-                        if (food.isNotEmpty())          playerRepo.consumeItems(food)
-                        if (arrows.isNotEmpty())        playerRepo.consumeItems(arrows)
-                        if (arrowsReclaimed.isNotEmpty()) playerRepo.addItems(arrowsReclaimed)
-                        if (runesReclaimed.isNotEmpty())  playerRepo.addItems(runesReclaimed)
-                        val dungeonRunFlags = playerRepo.getFlags()
-                        playerRepo.updateFlags(dungeonRunFlags.copy(
-                            dungeonLastRunStats = dungeonRunFlags.dungeonLastRunStats + (session.activityKey to DungeonRunStats(
-                                foodConsumed = food.values.sum(),
-                                killCount    = kills.values.sum(),
-                                survived     = !died,
-                            ))
-                        ))
-                        for ((skill, xp) in xpPerSkill) {
-                            val prestigeLevel = skillPrestige[skill] ?: 0
-                            val withPrestige = if (prestigeLevel > 0) (xp * (1.0 + prestigeLevel * 0.10)).toLong() else xp
-                            combinedXpBySkill[skill] = (combinedXpBySkill[skill] ?: 0L) + withPrestige
-                        }
-                        for ((item, qty) in loot)        combinedItems[item]      = (combinedItems[item] ?: 0) + qty
-                        for ((e, k) in kills)            combinedKills[e]         = (combinedKills[e] ?: 0) + k
-                        for ((f, q) in food)             combinedFood[f]          = (combinedFood[f] ?: 0) + q
-                        for ((a, q) in arrows)           combinedArrows[a]         = (combinedArrows[a] ?: 0) + q
-                        for ((a, q) in arrowsReclaimed)  combinedArrowsReclaimed[a] = (combinedArrowsReclaimed[a] ?: 0) + q
-                        for ((r, q) in runes)            combinedRunes[r]          = (combinedRunes[r] ?: 0) + q
-                        for ((r, q) in runesReclaimed)   combinedRunesReclaimed[r] = (combinedRunesReclaimed[r] ?: 0) + q
-                        combinedCoins += coins
-                    }
-                    "expedition" -> {
-                        val result = collectExpeditionSession(
-                            session = session,
-                            frames = if (grantXp) frames else frames.map { it.copy(xpGain = 0, xpBySkill = emptyMap()) },
-                            petIds = petIds,
-                            awardedCapes = awardedCapes,
-                            combinedXpBySkill = combinedXpBySkill,
-                            combinedItems = combinedItems
-                        )
-                        if (result.petFoundName != null) petFoundName = result.petFoundName
-                        expeditionNoteLines = result.noteLines
-                        expeditionUnlockMessage = result.unlockMessage
-                    }
-                    Skills.MERCANTILE -> {
-                        val totalXp    = if (grantXp) frames.sumOf { it.xpGain.toLong() } else 0L
-                        val coinReturn = frames.sumOf { (it.items["_coins"] ?: 0).toLong() }
-                        val mercantileCapeMult    = resolveCapeMultiplier(Skills.MERCANTILE, equippedCape, inventory.keys, flags.townBuildingTiers, skillPrestige, gameData.equipment, flags.ironman)
-                        val mercantilePrestigeMult = 1f + (skillPrestige[Skills.MERCANTILE] ?: 0) * 0.10f
-                        // combinedCoins must stay pre-blessing here, like every other skill's coin
-                        // total below -- the summary popup applies blessingCoinMult to combinedCoins
-                        // once already (see displayedCoins), so baking blessing in twice inflated the
-                        // shown total without it ever landing in the real balance (issue #1192).
-                        val coinReturnPreBlessing = (coinReturn.toDouble() * mercantileCapeMult * mercantilePrestigeMult).toLong()
-                        val coinReturnBoosted = (coinReturnPreBlessing * blessingCoinMult).toLong()
-                        awardedCapes += playerRepo.applySessionResults(Skills.MERCANTILE, totalXp, emptyMap())
-                        playerRepo.addCoins(coinReturnBoosted)
-                        guildRepo.recordGuildTrade(session.activityKey, coinReturnBoosted)
-                        playerRepo.recordWeeklyProgress("mercantile", session.activityKey, frames.size)
-                        combinedXpBySkill[Skills.MERCANTILE] = (combinedXpBySkill[Skills.MERCANTILE] ?: 0L) + totalXp
-                        combinedCoins += coinReturnPreBlessing
-                    }
-                    Skills.PRAYER -> {
-                        val totalXp = if (grantXp) frames.sumOf { it.xpGain.toLong() } else 0L
-                        val its     = mutableMapOf<String, Int>()
-                        for (frame in frames) for ((item, qty) in frame.items) its[item] = (its[item] ?: 0) + qty
-                        val coinsFromItems = (its.remove("coins") ?: 0).toLong()
-                        if (coinsFromItems > 0) {
-                            playerRepo.addCoins(coinsFromItems)
-                            combinedCoins += coinsFromItems
-                        }
-                        val pets       = its.filterKeys { it in petIds }
-                        val rawRegular = its.filterKeys { it !in petIds }
-                        awardedCapes += playerRepo.applySessionResults(Skills.PRAYER,
-                            totalXp, rawRegular
-                        )
-                        val buried = frames.sumOf { it.kills }
-                        val isAshSession = gameData.bones[session.activityKey]?.isAsh == true
-                        if (!isAshSession) {
-                            questRepo.recordBuried(buried)
-                            guildRepo.recordGuildPrayer(buried)
-                            playerRepo.recordDailyPrayer(buried)
-                        }
-                        for ((id, _) in pets) {
-                            val pd = gameData.pets[id] ?: continue
-                            if (playerRepo.addPetIfNew(id, pd.boostPercent))
-                                petFoundName = GameStrings.petName(context, pd.id)
-                        }
-                        combinedXpBySkill[Skills.PRAYER] = (combinedXpBySkill[Skills.PRAYER] ?: 0L) + totalXp
-                        for ((item, qty) in rawRegular) combinedItems[item] = (combinedItems[item] ?: 0) + qty
-                        val count = frames.sumOf { it.kills }
-                        val name  = GameStrings.itemName(context, session.activityKey)
-                        combinedBones[name] = (combinedBones[name] ?: 0) + count
-                    }
-                    else -> {
-                        val totalXp = if (grantXp) frames.sumOf { it.xpGain.toLong() } else 0L
-                        val its     = mutableMapOf<String, Int>()
-                        for (frame in frames) for ((item, qty) in frame.items) its[item] = (its[item] ?: 0) + qty
-                        val coinsFromItems = (its.remove("coins") ?: 0).toLong()
-                        if (coinsFromItems > 0) {
-                            playerRepo.addCoins(coinsFromItems)
-                            combinedCoins += coinsFromItems
-                        }
-                        val pets       = its.filterKeys { it in petIds }
-                        val rawRegular = its.filterKeys { it !in petIds }
-                        val prestige   = skillPrestige[session.skillName] ?: 0
-                        val capeMult   = resolveCapeMultiplier(session.skillName, equippedCape, inventory.keys, flags.townBuildingTiers, skillPrestige, gameData.equipment, flags.ironman)
-                        val effectiveXp = if (capeMult > 1f && rawRegular.isEmpty()) (totalXp.toDouble() * capeMult).toLong() else totalXp
-                        val regular     = if (capeMult > 1f && rawRegular.isNotEmpty()) rawRegular.mapValues { (_, qty) -> (qty.toFloat() * capeMult).roundToInt() } else rawRegular
-                        awardedCapes += playerRepo.applySessionResults(session.skillName, effectiveXp, regular)
-                        when (session.skillName) {
-                            in gatheringSkills -> {
-                                questRepo.recordGathering(session.skillName, regular)
-                                playerRepo.recordDailyGathering(regular)
-                                seasonalEventRepo.recordGathering(regular)
-                                when (session.skillName) {
-                                    Skills.AGILITY      -> {
-                                        guildRepo.recordGuildSessions(session.activityKey)
-                                        playerRepo.recordWeeklyProgress("agility", session.activityKey, frames.size)
-                                    }
-                                    Skills.RUNECRAFTING -> guildRepo.recordGuildCrafting(session.skillName, regular)
-                                    else                -> guildRepo.recordGuildGathering(session.skillName, regular)
-                                }
-                            }
-                            in craftingSkills  -> {
-                                questRepo.recordCrafting(session.skillName, regular)
-                                playerRepo.recordDailyCrafting(regular)
-                                guildRepo.recordGuildCrafting(session.skillName, regular)
-                                seasonalEventRepo.recordCrafting(regular)
-                            }
-                            Skills.THIEVING    -> {
-                                val successCount = frames.count { it.success }
-                                questRepo.recordThieving(session.activityKey, successCount, regular.filterKeys { it != "coins" })
-                                guildRepo.recordGuildThieving(session.activityKey, successCount)
-                            }
-                            Skills.FARMING     -> guildRepo.recordGuildGathering(Skills.FARMING, regular)
-                        }
-                        for ((id, _) in pets) {
-                            val pd = gameData.pets[id] ?: continue
-                            if (playerRepo.addPetIfNew(id, pd.boostPercent))
-                                petFoundName = GameStrings.petName(context, pd.id)
-                        }
-                        combinedXpBySkill[session.skillName] = (combinedXpBySkill[session.skillName] ?: 0L) + totalXp
-                        for ((item, qty) in regular) combinedItems[item] = (combinedItems[item] ?: 0) + qty
-                    }
+                    "tower" -> collectTowerSession(frames, sessionAccumulator, session, grantXp)
+                    "boss" -> collectBossSession(frames, sessionAccumulator, session, sessionRunContext, grantXp)
+                    "combat" -> collectCombatSession(frames, sessionAccumulator, sessionRunContext, grantXp, session)
+                    "expedition" -> collectExpeditionSession(session, grantXp, frames, sessionRunContext, sessionAccumulator)
+                    Skills.MERCANTILE -> collectMercantileSession(grantXp, frames, sessionRunContext, sessionAccumulator, session)
+                    Skills.PRAYER -> collectPrayerSession(grantXp, frames, sessionAccumulator, sessionRunContext, session)
+                    else -> collectDefaultSkillSession(grantXp, frames, sessionAccumulator, sessionRunContext, session)
                 }
             }
 
             for (session in sessions) sessionRepo.deleteSession(session.sessionId)
             queuedSessionStarter.startNextQueued()
             reconcileTowerQueue()
-            if (dailyKills.isNotEmpty()) playerRepo.recordDailyKills(dailyKills)
+            if (sessionAccumulator.dailyKills.isNotEmpty()) playerRepo.recordDailyKills(sessionAccumulator.dailyKills)
 
             val rareItemsDisplayNames = mutableSetOf<String>()
             for (session in sessions) {
@@ -924,15 +581,15 @@ class HomeViewModel @Inject constructor(
 
             val title = when {
                 n > 1 -> context.withAppLocale().getString(R.string.home_sessions_complete_title, n)
-                last.sessionId in voidedSessionIds -> context.withAppLocale().getString(R.string.home_session_voided)
+                last.sessionId in sessionAccumulator.voidedSessionIds -> context.withAppLocale().getString(R.string.home_session_voided)
                 last.skillName == "boss" -> {
                     val bossName = GameStrings.bossName(context, last.activityKey)
-                    if (bossWon == true) context.withAppLocale().getString(R.string.home_boss_defeated_title, bossName)
+                    if (sessionAccumulator.bossWon == true) context.withAppLocale().getString(R.string.home_boss_defeated_title, bossName)
                     else context.withAppLocale().getString(R.string.home_boss_defeated_by_title, bossName)
                 }
                 last.skillName == "combat" -> {
                     val dungeonName = GameStrings.dungeonName(context, last.activityKey)
-                    if (anyDied) context.withAppLocale().getString(R.string.home_dungeon_died_title, dungeonName)
+                    if (sessionAccumulator.anyDied) context.withAppLocale().getString(R.string.home_dungeon_died_title, dungeonName)
                     else context.withAppLocale().getString(R.string.home_dungeon_complete_title, dungeonName)
                 }
                 last.skillName == "expedition" -> {
@@ -947,75 +604,659 @@ class HomeViewModel @Inject constructor(
             }
 
             // For single-skill non-combat sessions use the compact totalXpLabel
-            val useTotalLabel = n == 1 && combinedXpBySkill.size == 1 && combinedKills.isEmpty()
-            val singleXp      = combinedXpBySkill.values.firstOrNull() ?: 0L
-            val totalRawXp    = combinedXpBySkill.values.sum()
-            val boneBuriedLines = combinedBones.entries.map { (name, count) ->
+            val useTotalLabel = n == 1 && sessionAccumulator.xpBySkill.size == 1 && sessionAccumulator.kills.isEmpty()
+            val singleXp      = sessionAccumulator.xpBySkill.values.firstOrNull() ?: 0L
+            val totalRawXp    = sessionAccumulator.xpBySkill.values.sum()
+            val boneBuriedLines = sessionAccumulator.bones.entries.map { (name, count) ->
                 Pair(context.withAppLocale().getString(R.string.home_bones_buried_row, name), "×$count")
             }
 
-            val displayedCoins    = (combinedCoins.toDouble() * blessingCoinMult).toLong()
-            val coinBlessingBonus = displayedCoins - combinedCoins
-            val sortedXpEntries   = combinedXpBySkill.entries.sortedByDescending { it.value }
+            val displayedCoins    = (sessionAccumulator.coins.toDouble() * sessionRunContext.blessingCoinMult).toLong()
+            val coinBlessingBonus = displayedCoins - sessionAccumulator.coins
+            val sortedXpEntries   = sessionAccumulator.xpBySkill.entries.sortedByDescending { it.value }
             val xpLineBonuses     = sortedXpEntries.map { (_, xp) ->
-                val base = xp * xpMult
-                ((base.toDouble() * blessingXpMult).toLong() - base).coerceAtLeast(0L)
+                val base = xp * sessionRunContext.xpMult
+                ((base.toDouble() * sessionRunContext.blessingXpMult).toLong() - base).coerceAtLeast(0L)
             }
             val singleXpBonus = run {
-                val base = singleXp * xpMult
-                ((base.toDouble() * blessingXpMult).toLong() - base).coerceAtLeast(0L)
+                val base = singleXp * sessionRunContext.xpMult
+                ((base.toDouble() * sessionRunContext.blessingXpMult).toLong() - base).coerceAtLeast(0L)
             }
 
             val summary = SessionSummary(
                 title          = title,
-                died           = anyDied,
+                died           = sessionAccumulator.anyDied,
                 xpLines        = if (useTotalLabel) emptyList()
                                  else sortedXpEntries
-                                     .map { (skill, xp) -> Pair(GameStrings.skillName(context, skill), "+${((xp * xpMult).toDouble() * blessingXpMult).toLong().formatXp()} XP") },
+                                     .map { (skill, xp) -> Pair(GameStrings.skillName(context, skill), "+${((xp * sessionRunContext.xpMult).toDouble() * sessionRunContext.blessingXpMult).toLong().formatXp()} XP") },
                 xpLineValues   = if (useTotalLabel) emptyList()
                                  else sortedXpEntries
-                                     .map { (_, xp) -> ((xp * xpMult).toDouble() * blessingXpMult).toLong() },
-                totalXpLabel      = if (useTotalLabel) "+${((singleXp * xpMult).toDouble() * blessingXpMult).toLong().formatXp()} XP" else "",
+                                     .map { (_, xp) -> ((xp * sessionRunContext.xpMult).toDouble() * sessionRunContext.blessingXpMult).toLong() },
+                totalXpLabel      = if (useTotalLabel) "+${((singleXp * sessionRunContext.xpMult).toDouble() * sessionRunContext.blessingXpMult).toLong().formatXp()} XP" else "",
                 totalXpLabelBonus = if (useTotalLabel) singleXpBonus else 0L,
-                totalXpValue      = if (useTotalLabel) ((singleXp * xpMult).toDouble() * blessingXpMult).toLong() else 0L,
-                itemLines      = combinedItems.entries.sortedByDescending { it.value }
+                totalXpValue      = if (useTotalLabel) ((singleXp * sessionRunContext.xpMult).toDouble() * sessionRunContext.blessingXpMult).toLong() else 0L,
+                itemLines      = sessionAccumulator.items.entries.sortedByDescending { it.value }
                                      .map { (key, qty) -> Pair(GameStrings.itemName(context,key), "×$qty") },
                 coinsGained    = displayedCoins,
-                killLines      = combinedKills.entries.sortedByDescending { it.value }
+                killLines      = sessionAccumulator.kills.entries.sortedByDescending { it.value }
                                      .map { (enemy, kills) -> Pair(enemy, "×$kills") },
-                foodConsumedLines = combinedFood.entries.sortedByDescending { it.value }
+                foodConsumedLines = sessionAccumulator.food.entries.sortedByDescending { it.value }
                                      .map { (food, qty) -> Pair(GameStrings.itemName(context,food), "×$qty") },
-                arrowsConsumedLines  = combinedArrows.entries.sortedByDescending { it.value }
+                arrowsConsumedLines  = sessionAccumulator.arrows.entries.sortedByDescending { it.value }
                                          .map { (key, qty) -> Pair(GameStrings.itemName(context,key), "×$qty") },
-                arrowsReclaimedLines = combinedArrowsReclaimed.entries.sortedByDescending { it.value }
+                arrowsReclaimedLines = sessionAccumulator.arrowsReclaimed.entries.sortedByDescending { it.value }
                                          .map { (key, qty) -> Pair(GameStrings.itemName(context,key), "+$qty") },
-                runesConsumedLines   = combinedRunes.entries.sortedByDescending { it.value }
+                runesConsumedLines   = sessionAccumulator.runes.entries.sortedByDescending { it.value }
                                          .map { (key, qty) -> Pair(GameStrings.itemName(context,key), "×$qty") },
-                runesReclaimedLines  = combinedRunesReclaimed.entries.sortedByDescending { it.value }
+                runesReclaimedLines  = sessionAccumulator.runesReclaimed.entries.sortedByDescending { it.value }
                                          .map { (key, qty) -> Pair(GameStrings.itemName(context,key), "+$qty") },
                 boneBuriedLines  = boneBuriedLines,
-                boostWasActive   = boostActive,
+                boostWasActive   = sessionRunContext.boostActive,
                 xpLineBonuses    = xpLineBonuses,
                 coinBlessingBonus = coinBlessingBonus,
-                noteLines        = expeditionNoteLines +
-                                     (if (bossCoinsReduced) listOf(context.withAppLocale().getString(R.string.session_note_boss_coin_cap)) else emptyList()),
-                unlockMessage    = expeditionUnlockMessage,
+                noteLines        = sessionAccumulator.expeditionNoteLines +
+                                     (if (sessionAccumulator.bossCoinsReduced) listOf(context.withAppLocale().getString(R.string.session_note_boss_coin_cap)) else emptyList()),
+                unlockMessage    = sessionAccumulator.expeditionUnlockMessage,
                 rareItems        = rareItemsDisplayNames,
             )
 
-            val capeMessage = if (awardedCapes.isNotEmpty()) {
-                val names = awardedCapes.joinToString(", ") { GameStrings.itemName(context,it) }
+            val capeMessage = if (sessionAccumulator.awardedCapes.isNotEmpty()) {
+                val names = sessionAccumulator.awardedCapes.joinToString(", ") { GameStrings.itemName(context,it) }
                 context.withAppLocale().getString(R.string.home_congratulations_received, names)
             } else null
             _extra.update { it.copy(
                 sessionSummary  = summary,
                 snackbarMessage = capeMessage,
-                petFoundName    = petFoundName,
+                petFoundName    = sessionAccumulator.petFoundName,
             ) }
           } finally {
             _extra.update { it.copy(isCollecting = false) }
           }
         }
+    }
+
+    private suspend fun getSessionRunContext(): SessionRunContext {
+        val petIds = gameData.pets.keys
+        val player = playerRepo.getOrCreatePlayer()
+        val flags: PlayerFlags = json.decodeFromString(player.flags)
+        // Ironman characters play at pure base rates: every XP/yield/coin multiplier is inert.
+        val skillPrestige = if (flags.ironman) emptyMap() else flags.skillPrestige
+        val equipped: Map<String, String?> = json.decodeFromString(player.equipped)
+        val inventory: Map<String, Int> = json.decodeFromString(player.inventory)
+        val equippedCape = equipped[EquipSlot.CAPE]?.let { gameData.equipment[it] }
+        val boostActive = !flags.ironman && flags.xpBoostExpiresAt > System.currentTimeMillis()
+        val xpMult = if (boostActive) 2L else 1L
+        val blessingXpMult = if (flags.ironman) 1.0f else ChurchRepository.xpMultiplier(
+            flags,
+            equippedCape,
+            inventory.keys,
+            gameData.equipment
+        )
+        val blessingCoinMult = if (flags.ironman) 1.0f else ChurchRepository.coinMultiplier(
+            flags,
+            equippedCape,
+            inventory.keys,
+            gameData.equipment
+        ) *
+                PlayerRepository.gooseCoinMultiplier(json.decodeFromString<List<OwnedPet>>(player.pets))
+                    .toFloat()
+        return SessionRunContext(
+            petIds = petIds,
+            player = player,
+            flags = flags,
+            skillPrestige = skillPrestige,
+            equipped = equipped,
+            inventory = inventory,
+            equippedCape = equippedCape,
+            boostActive = boostActive,
+            xpMult = xpMult,
+            blessingXpMult = blessingXpMult,
+            blessingCoinMult = blessingCoinMult,
+        )
+    }
+
+    private suspend fun collectTowerSession(
+        frames: List<SessionFrame>,
+        sessionAccumulator: SessionAccumulator,
+        session: SkillSession,
+        grantXp: Boolean
+    ) {
+        val playerDied = frames.any { it.died }
+        if (playerDied) sessionAccumulator.anyDied = true
+        val towerXpPerSkill = mutableMapOf<String, Long>()
+        val towerAllItems = mutableMapOf<String, Int>()
+        val towerFood = mutableMapOf<String, Int>()
+        val towerKills = mutableMapOf<String, Int>()
+        val towerArrows = mutableMapOf<String, Int>()
+        val towerRunes = mutableMapOf<String, Int>()
+        for (frame in frames) {
+            for ((skill, xp) in frame.xpBySkill) towerXpPerSkill[skill] =
+                (towerXpPerSkill[skill] ?: 0L) + xp
+            for ((item, qty) in frame.items) towerAllItems[item] = (towerAllItems[item] ?: 0) + qty
+            for ((food, qty) in frame.foodConsumed) towerFood[food] = (towerFood[food] ?: 0) + qty
+            for ((e, k) in frame.killsByEnemy) towerKills[e] = (towerKills[e] ?: 0) + k
+            for ((arrow, qty) in frame.arrowsConsumed) towerArrows[arrow] =
+                (towerArrows[arrow] ?: 0) + qty
+            for ((rune, qty) in frame.runesConsumed) towerRunes[rune] =
+                (towerRunes[rune] ?: 0) + qty
+        }
+        if (playerDied) {
+            towerXpPerSkill.replaceAll { _, xp -> maxOf(1L, (xp * 0.1).toLong()) }
+            towerAllItems.replaceAll { _, qty -> maxOf(0, (qty * 0.1).toInt()) }
+            towerAllItems.entries.removeIf { it.value == 0 }
+        }
+
+        if (!playerDied && towerKills.isNotEmpty()) {
+            val style = detectCombatStyle(towerXpPerSkill)
+            questRepo.recordCombat(
+                dungeonKey = session.activityKey,
+                killsByEnemy = towerKills,
+                loot = towerAllItems,
+                combatStyle = style,
+                foodConsumedTotal = towerFood.values.sum(),
+            )
+            for ((e, k) in towerKills) sessionAccumulator.dailyKills[e] =
+                (sessionAccumulator.dailyKills[e] ?: 0) + k
+            guildRepo.recordGuildCombat(towerKills, style)
+            var towerSlayerXp = 0L
+            for ((enemy, k) in towerKills) towerSlayerXp += slayerRepo.recordKills(enemy, k)
+            if (towerSlayerXp > 0L) towerXpPerSkill[Skills.SLAYER] =
+                (towerXpPerSkill[Skills.SLAYER] ?: 0L) + towerSlayerXp
+        }
+
+        val towerCoinsRaw = towerAllItems.remove("coins")?.toLong() ?: 0L
+        val towerFlags = playerRepo.getFlags()
+        val towerXpMult = if (towerFlags.ironman) 1.0 else 1.0 + towerFlags.towerXpBonusPct / 100.0
+        val towerCoinMult =
+            if (towerFlags.ironman) 1.0 else 1.0 + towerFlags.towerCoinBonusPct / 100.0
+        val towerXpForRepo =
+            if (grantXp) towerXpPerSkill.mapValues { (_, xp) -> (xp * towerXpMult).toLong() } else emptyMap()
+        val towerCoinsGained = (towerCoinsRaw * towerCoinMult).toLong()
+
+        playerRepo.applyMultiSkillResults(towerXpForRepo, towerAllItems, towerCoinsGained)
+
+        val skillLvls = playerRepo.getSkillLevels()
+        val arrowsReclaimed = towerArrows.mapValues { (_, qty) ->
+            (qty * reclaimChance(
+                skillLvls[Skills.RANGED] ?: 1
+            )).toInt()
+        }.filterValues { it > 0 }
+        val runesReclaimed = towerRunes.mapValues { (_, qty) ->
+            (qty * reclaimChance(
+                skillLvls[Skills.MAGIC] ?: 1
+            )).toInt()
+        }.filterValues { it > 0 }
+        val finalTowerArrows = towerArrows.mapValues { (k, v) -> v - (arrowsReclaimed[k] ?: 0) }
+            .filterValues { it > 0 }
+        val finalTowerRunes =
+            towerRunes.mapValues { (k, v) -> v - (runesReclaimed[k] ?: 0) }.filterValues { it > 0 }
+
+        val totalConsumables = towerFood + finalTowerArrows + finalTowerRunes
+        if (totalConsumables.isNotEmpty()) playerRepo.consumeItems(totalConsumables)
+        val floor = session.activityKey.removePrefix("tower_floor_").toIntOrNull() ?: 1
+        val updatedTowerFlags = playerRepo.getFlags()
+        if (playerDied) {
+            // Death drops you back to your last checkpoint (every 25 floors of
+            // your best-ever progress), matching TowerViewModel.collectFloor() --
+            // this path had drifted to a flat reset to 0 (issue #1183).
+            val checkpointFloor =
+                (updatedTowerFlags.towerBestFloor / TowerViewModel.TOWER_CHECKPOINT_INTERVAL) * TowerViewModel.TOWER_CHECKPOINT_INTERVAL
+            playerRepo.updateFlags(updatedTowerFlags.copy(towerCurrentFloor = checkpointFloor))
+        } else {
+            playerRepo.updateFlags(
+                updatedTowerFlags.copy(
+                    towerCurrentFloor = floor,
+                    towerBestFloor = maxOf(updatedTowerFlags.towerBestFloor, floor),
+                )
+            )
+        }
+        for ((skill, xp) in towerXpForRepo) sessionAccumulator.xpBySkill[skill] =
+            (sessionAccumulator.xpBySkill[skill] ?: 0L) + xp
+        for ((item, qty) in towerAllItems) sessionAccumulator.items[item] =
+            (sessionAccumulator.items[item] ?: 0) + qty
+        sessionAccumulator.coins += towerCoinsGained
+    }
+
+    private suspend fun collectBossSession(
+        frames: List<SessionFrame>,
+        sessionAccumulator: SessionAccumulator,
+        session: SkillSession,
+        sessionRunContext: SessionRunContext,
+        grantXp: Boolean
+    ) {
+        val frame = frames.lastOrNull() ?: return
+        val won = frame.kills > 0
+        sessionAccumulator.bossWon = won
+        val its = frame.items.toMutableMap()
+        val coins = if (won) {
+            val base = its.remove("coins")?.toLong() ?: 0L
+            val mult = playerRepo.rollBossCoinSoftCap(session.activityKey)
+            if (mult < 1.0 && base > 0L) sessionAccumulator.bossCoinsReduced = true
+            (base * mult).toLong()
+        } else 0L
+        val pets = its.filterKeys { it in sessionRunContext.petIds }
+        val loot = if (won) its.filterKeys { it !in sessionRunContext.petIds } else emptyMap()
+        val allFoodConsumed = mutableMapOf<String, Int>()
+        val allArrowsConsumed = mutableMapOf<String, Int>()
+        val allRunesConsumed = mutableMapOf<String, Int>()
+        val bossXpBySkill = mutableMapOf<String, Long>()
+        for (f in frames) {
+            f.foodConsumed.forEach { (k, v) -> allFoodConsumed[k] = (allFoodConsumed[k] ?: 0) + v }
+            f.arrowsConsumed.forEach { (k, v) ->
+                allArrowsConsumed[k] = (allArrowsConsumed[k] ?: 0) + v
+            }
+            f.runesConsumed.forEach { (k, v) ->
+                allRunesConsumed[k] = (allRunesConsumed[k] ?: 0) + v
+            }
+            f.xpBySkill.forEach { (k, v) -> bossXpBySkill[k] = (bossXpBySkill[k] ?: 0L) + v }
+        }
+        for (skill in bossXpBySkill.keys) {
+            val mult = resolveCapeMultiplier(
+                skill,
+                sessionRunContext.equippedCape,
+                sessionRunContext.inventory.keys,
+                sessionRunContext.flags.townBuildingTiers,
+                sessionRunContext.skillPrestige,
+                gameData.equipment,
+                sessionRunContext.flags.ironman
+            )
+            if (mult > 1f) {
+                bossXpBySkill[skill] = (bossXpBySkill[skill]!! * mult.toDouble()).toLong()
+            }
+        }
+        if (!grantXp) bossXpBySkill.clear()
+        val bossSkillLvls = playerRepo.getSkillLevels()
+        val bossArrowsRec = allArrowsConsumed.mapValues { (_, qty) ->
+            (qty * reclaimChance(
+                bossSkillLvls[Skills.RANGED] ?: 1
+            )).toInt()
+        }.filterValues { it > 0 }
+        val bossRunesRec = allRunesConsumed.mapValues { (_, qty) ->
+            (qty * reclaimChance(
+                bossSkillLvls[Skills.MAGIC] ?: 1
+            )).toInt()
+        }.filterValues { it > 0 }
+        val ownedPets: List<OwnedPet> = if (sessionRunContext.flags.ironman) emptyList()
+        else try {
+            json.decodeFromString(sessionRunContext.player.pets)
+        } catch (_: Exception) {
+            emptyList()
+        }
+        val perSkillPetBoostPct = bossXpBySkill.keys.associateWith { skill ->
+            ownedPets.sumOf { ownedPet ->
+                val pd = gameData.pets[ownedPet.id]
+                if (pd == null) 0
+                else when {
+                    pd.boostedSkill == "all" -> pd.boostPercent
+                    pd.boostedSkill == skill -> pd.boostPercent
+                    pd.boostedSkill == "combat" && skill in Skills.COMBAT -> pd.boostPercent
+                    else -> 0
+                }
+            }
+        }.filterValues { it > 0 }
+        sessionAccumulator.awardedCapes += playerRepo.applyMultiSkillResults(
+            bossXpBySkill,
+            loot,
+            coins,
+            perSkillPetBoostPct = perSkillPetBoostPct
+        )
+        if (allFoodConsumed.isNotEmpty()) playerRepo.consumeItems(allFoodConsumed)
+        if (allArrowsConsumed.isNotEmpty()) playerRepo.consumeItems(allArrowsConsumed)
+        if (bossArrowsRec.isNotEmpty()) playerRepo.addItems(bossArrowsRec)
+        if (bossRunesRec.isNotEmpty()) playerRepo.addItems(bossRunesRec)
+        for ((f, q) in allFoodConsumed) sessionAccumulator.food[f] =
+            (sessionAccumulator.food[f] ?: 0) + q
+        for ((a, q) in allArrowsConsumed) sessionAccumulator.arrows[a] =
+            (sessionAccumulator.arrows[a] ?: 0) + q
+        for ((a, q) in bossArrowsRec) sessionAccumulator.arrowsReclaimed[a] =
+            (sessionAccumulator.arrowsReclaimed[a] ?: 0) + q
+        for ((r, q) in allRunesConsumed) sessionAccumulator.runes[r] =
+            (sessionAccumulator.runes[r] ?: 0) + q
+        for ((r, q) in bossRunesRec) sessionAccumulator.runesReclaimed[r] =
+            (sessionAccumulator.runesReclaimed[r] ?: 0) + q
+        if (won) {
+            for ((id, _) in pets) {
+                val pd = gameData.pets[id] ?: continue
+                if (playerRepo.addPetIfNew(id, pd.boostPercent))
+                    sessionAccumulator.petFoundName = GameStrings.petName(context, pd.id)
+            }
+            questRepo.recordCombat(
+                dungeonKey = session.activityKey,
+                killsByEnemy = mapOf(session.activityKey to 1),
+                loot = loot,
+            )
+            sessionAccumulator.dailyKills[session.activityKey] =
+                (sessionAccumulator.dailyKills[session.activityKey] ?: 0) + 1
+            playerRepo.recordWeeklyProgress("boss", session.activityKey, 1)
+            guildRepo.recordGuildCombat(
+                mapOf(session.activityKey to 1),
+                frames.lastOrNull()?.combatStyle?.ifEmpty { "melee" } ?: "melee")
+            seasonalEventRepo.recordCombat(mapOf(session.activityKey to 1))
+            seasonalEventRepo.recordBossDefeat(session.activityKey)
+            for ((item, qty) in loot) sessionAccumulator.items[item] =
+                (sessionAccumulator.items[item] ?: 0) + qty
+            sessionAccumulator.coins += coins
+        }
+        for ((skill, xp) in bossXpBySkill) {
+            val petPct = perSkillPetBoostPct[skill] ?: 0
+            val withPet = if (petPct > 0) (xp * (1.0 + petPct / 100.0)).toLong() else xp
+            val prestigeLevel = sessionRunContext.skillPrestige[skill] ?: 0
+            val withPrestige =
+                if (prestigeLevel > 0) (withPet * (1.0 + prestigeLevel * 0.10)).toLong() else withPet
+            sessionAccumulator.xpBySkill[skill] =
+                (sessionAccumulator.xpBySkill[skill] ?: 0L) + withPrestige
+        }
+    }
+
+    private suspend fun collectCombatSession(
+        frames: List<SessionFrame>,
+        sessionAccumulator: SessionAccumulator,
+        sessionRunContext: SessionRunContext,
+        grantXp: Boolean,
+        session: SkillSession
+    ) {
+        val xpPerSkill = mutableMapOf<String, Long>()
+        val its = mutableMapOf<String, Int>()
+        val kills = mutableMapOf<String, Int>()
+        val food = mutableMapOf<String, Int>()
+        val arrows = mutableMapOf<String, Int>()
+        val runes = mutableMapOf<String, Int>()
+        val died = frames.any { it.died }
+        if (died) sessionAccumulator.anyDied = true
+        for (frame in frames) {
+            for ((skill, xp) in frame.xpBySkill) xpPerSkill[skill] = (xpPerSkill[skill] ?: 0L) + xp
+            for ((item, qty) in frame.items) its[item] = (its[item] ?: 0) + qty
+            for ((e, k) in frame.killsByEnemy) kills[e] = (kills[e] ?: 0) + k
+            for ((f, q) in frame.foodConsumed) food[f] = (food[f] ?: 0) + q
+            for ((a, q) in frame.arrowsConsumed) arrows[a] = (arrows[a] ?: 0) + q
+            for ((r, q) in frame.runesConsumed) runes[r] = (runes[r] ?: 0) + q
+        }
+        for (skill in xpPerSkill.keys) {
+            val mult = resolveCapeMultiplier(
+                skill,
+                sessionRunContext.equippedCape,
+                sessionRunContext.inventory.keys,
+                sessionRunContext.flags.townBuildingTiers,
+                sessionRunContext.skillPrestige,
+                gameData.equipment,
+                sessionRunContext.flags.ironman
+            )
+            if (mult > 1f) {
+                xpPerSkill[skill] = (xpPerSkill[skill]!! * mult.toDouble()).toLong()
+            }
+        }
+        if (died) {
+            xpPerSkill.replaceAll { _, xp -> maxOf(1L, (xp * 0.1).toLong()) }
+            its.replaceAll { _, qty -> maxOf(0, (qty * 0.1).toInt()) }
+            its.entries.removeIf { it.value == 0 }
+        }
+        val coins = its.remove("coins")?.toLong() ?: 0L
+        val pets = its.filterKeys { it in sessionRunContext.petIds }
+        val loot = its.filterKeys { it !in sessionRunContext.petIds }
+        var slayerXp = 0L
+        for ((enemy, k) in kills) slayerXp += slayerRepo.recordKills(enemy, k)
+        if (slayerXp > 0L) xpPerSkill[Skills.SLAYER] = (xpPerSkill[Skills.SLAYER] ?: 0L) + slayerXp
+        val combatStyle = detectCombatStyle(xpPerSkill)
+        if (!grantXp) xpPerSkill.clear()
+        sessionAccumulator.awardedCapes += playerRepo.applyMultiSkillResults(
+            xpPerSkill,
+            loot,
+            coins
+        )
+        for ((id, _) in pets) {
+            val pd = gameData.pets[id] ?: continue
+            if (playerRepo.addPetIfNew(id, pd.boostPercent))
+                sessionAccumulator.petFoundName = GameStrings.petName(context, pd.id)
+        }
+        if (!died) {
+            questRepo.recordCombat(
+                dungeonKey = session.activityKey,
+                killsByEnemy = kills,
+                loot = loot,
+                combatStyle = combatStyle,
+                foodConsumedTotal = food.values.sum(),
+            )
+            playerRepo.incrementDungeonRun(session.activityKey)
+            if (kills.isNotEmpty()) {
+                for ((e, k) in kills) sessionAccumulator.dailyKills[e] =
+                    (sessionAccumulator.dailyKills[e] ?: 0) + k
+                guildRepo.recordGuildCombat(kills, combatStyle)
+                seasonalEventRepo.recordCombat(kills)
+            }
+            seasonalEventRepo.recordExpeditionCompletion(session.activityKey)
+        }
+        val skillLvls = playerRepo.getSkillLevels()
+        val arrowsReclaimed = arrows.mapValues { (_, qty) ->
+            (qty * reclaimChance(
+                skillLvls[Skills.RANGED] ?: 1
+            )).toInt()
+        }.filterValues { it > 0 }
+        val runesReclaimed = runes.mapValues { (_, qty) ->
+            (qty * reclaimChance(
+                skillLvls[Skills.MAGIC] ?: 1
+            )).toInt()
+        }.filterValues { it > 0 }
+        if (food.isNotEmpty()) playerRepo.consumeItems(food)
+        if (arrows.isNotEmpty()) playerRepo.consumeItems(arrows)
+        if (arrowsReclaimed.isNotEmpty()) playerRepo.addItems(arrowsReclaimed)
+        if (runesReclaimed.isNotEmpty()) playerRepo.addItems(runesReclaimed)
+        val dungeonRunFlags = playerRepo.getFlags()
+        playerRepo.updateFlags(
+            dungeonRunFlags.copy(
+                dungeonLastRunStats = dungeonRunFlags.dungeonLastRunStats + (session.activityKey to DungeonRunStats(
+                    foodConsumed = food.values.sum(),
+                    killCount = kills.values.sum(),
+                    survived = !died,
+                ))
+            )
+        )
+        for ((skill, xp) in xpPerSkill) {
+            val prestigeLevel = sessionRunContext.skillPrestige[skill] ?: 0
+            val withPrestige =
+                if (prestigeLevel > 0) (xp * (1.0 + prestigeLevel * 0.10)).toLong() else xp
+            sessionAccumulator.xpBySkill[skill] =
+                (sessionAccumulator.xpBySkill[skill] ?: 0L) + withPrestige
+        }
+        for ((item, qty) in loot) sessionAccumulator.items[item] =
+            (sessionAccumulator.items[item] ?: 0) + qty
+        for ((e, k) in kills) sessionAccumulator.kills[e] = (sessionAccumulator.kills[e] ?: 0) + k
+        for ((f, q) in food) sessionAccumulator.food[f] = (sessionAccumulator.food[f] ?: 0) + q
+        for ((a, q) in arrows) sessionAccumulator.arrows[a] =
+            (sessionAccumulator.arrows[a] ?: 0) + q
+        for ((a, q) in arrowsReclaimed) sessionAccumulator.arrowsReclaimed[a] =
+            (sessionAccumulator.arrowsReclaimed[a] ?: 0) + q
+        for ((r, q) in runes) sessionAccumulator.runes[r] = (sessionAccumulator.runes[r] ?: 0) + q
+        for ((r, q) in runesReclaimed) sessionAccumulator.runesReclaimed[r] =
+            (sessionAccumulator.runesReclaimed[r] ?: 0) + q
+        sessionAccumulator.coins += coins
+    }
+
+    private suspend fun collectExpeditionSession(
+        session: SkillSession,
+        grantXp: Boolean,
+        frames: List<SessionFrame>,
+        sessionRunContext: SessionRunContext,
+        sessionAccumulator: SessionAccumulator
+    ) {
+        val result = collectExpeditionSession(
+            session = session,
+            frames = if (grantXp) frames else frames.map {
+                it.copy(
+                    xpGain = 0,
+                    xpBySkill = emptyMap()
+                )
+            },
+            petIds = sessionRunContext.petIds,
+            awardedCapes = sessionAccumulator.awardedCapes,
+            combinedXpBySkill = sessionAccumulator.xpBySkill,
+            combinedItems = sessionAccumulator.items
+        )
+        if (result.petFoundName != null) sessionAccumulator.petFoundName = result.petFoundName
+        sessionAccumulator.expeditionNoteLines = result.noteLines
+        sessionAccumulator.expeditionUnlockMessage = result.unlockMessage
+    }
+
+    private suspend fun collectMercantileSession(
+        grantXp: Boolean,
+        frames: List<SessionFrame>,
+        sessionRunContext: SessionRunContext,
+        sessionAccumulator: SessionAccumulator,
+        session: SkillSession
+    ) {
+        val totalXp = if (grantXp) frames.sumOf { it.xpGain.toLong() } else 0L
+        val coinReturn = frames.sumOf { (it.items["_coins"] ?: 0).toLong() }
+        val mercantileCapeMult = resolveCapeMultiplier(
+            Skills.MERCANTILE,
+            sessionRunContext.equippedCape,
+            sessionRunContext.inventory.keys,
+            sessionRunContext.flags.townBuildingTiers,
+            sessionRunContext.skillPrestige,
+            gameData.equipment,
+            sessionRunContext.flags.ironman
+        )
+        val mercantilePrestigeMult =
+            1f + (sessionRunContext.skillPrestige[Skills.MERCANTILE] ?: 0) * 0.10f
+        // combinedCoins must stay pre-blessing here, like every other skill's coin
+        // total below -- the summary popup applies blessingCoinMult to combinedCoins
+        // once already (see displayedCoins), so baking blessing in twice inflated the
+        // shown total without it ever landing in the real balance (issue #1192).
+        val coinReturnPreBlessing =
+            (coinReturn.toDouble() * mercantileCapeMult * mercantilePrestigeMult).toLong()
+        val coinReturnBoosted =
+            (coinReturnPreBlessing * sessionRunContext.blessingCoinMult).toLong()
+        sessionAccumulator.awardedCapes += playerRepo.applySessionResults(
+            Skills.MERCANTILE,
+            totalXp,
+            emptyMap()
+        )
+        playerRepo.addCoins(coinReturnBoosted)
+        guildRepo.recordGuildTrade(session.activityKey, coinReturnBoosted)
+        playerRepo.recordWeeklyProgress("mercantile", session.activityKey, frames.size)
+        sessionAccumulator.xpBySkill[Skills.MERCANTILE] =
+            (sessionAccumulator.xpBySkill[Skills.MERCANTILE] ?: 0L) + totalXp
+        sessionAccumulator.coins += coinReturnPreBlessing
+    }
+
+    private suspend fun collectPrayerSession(
+        grantXp: Boolean,
+        frames: List<SessionFrame>,
+        sessionAccumulator: SessionAccumulator,
+        sessionRunContext: SessionRunContext,
+        session: SkillSession
+    ) {
+        val totalXp = if (grantXp) frames.sumOf { it.xpGain.toLong() } else 0L
+        val its = mutableMapOf<String, Int>()
+        for (frame in frames) for ((item, qty) in frame.items) its[item] = (its[item] ?: 0) + qty
+        val coinsFromItems = (its.remove("coins") ?: 0).toLong()
+        if (coinsFromItems > 0) {
+            playerRepo.addCoins(coinsFromItems)
+            sessionAccumulator.coins += coinsFromItems
+        }
+        val pets = its.filterKeys { it in sessionRunContext.petIds }
+        val rawRegular = its.filterKeys { it !in sessionRunContext.petIds }
+        sessionAccumulator.awardedCapes += playerRepo.applySessionResults(
+            Skills.PRAYER,
+            totalXp, rawRegular
+        )
+        val buried = frames.sumOf { it.kills }
+        val isAshSession = gameData.bones[session.activityKey]?.isAsh == true
+        if (!isAshSession) {
+            questRepo.recordBuried(buried)
+            guildRepo.recordGuildPrayer(buried)
+            playerRepo.recordDailyPrayer(buried)
+        }
+        for ((id, _) in pets) {
+            val pd = gameData.pets[id] ?: continue
+            if (playerRepo.addPetIfNew(id, pd.boostPercent))
+                sessionAccumulator.petFoundName = GameStrings.petName(context, pd.id)
+        }
+        sessionAccumulator.xpBySkill[Skills.PRAYER] =
+            (sessionAccumulator.xpBySkill[Skills.PRAYER] ?: 0L) + totalXp
+        for ((item, qty) in rawRegular) sessionAccumulator.items[item] =
+            (sessionAccumulator.items[item] ?: 0) + qty
+        val count = frames.sumOf { it.kills }
+        val name = GameStrings.itemName(context, session.activityKey)
+        sessionAccumulator.bones[name] = (sessionAccumulator.bones[name] ?: 0) + count
+    }
+
+    private suspend fun collectDefaultSkillSession(
+        grantXp: Boolean,
+        frames: List<SessionFrame>,
+        sessionAccumulator: SessionAccumulator,
+        sessionRunContext: SessionRunContext,
+        session: SkillSession
+    ) {
+        val totalXp = if (grantXp) frames.sumOf { it.xpGain.toLong() } else 0L
+        val its = mutableMapOf<String, Int>()
+        for (frame in frames) for ((item, qty) in frame.items) its[item] = (its[item] ?: 0) + qty
+        val coinsFromItems = (its.remove("coins") ?: 0).toLong()
+        if (coinsFromItems > 0) {
+            playerRepo.addCoins(coinsFromItems)
+            sessionAccumulator.coins += coinsFromItems
+        }
+        val pets = its.filterKeys { it in sessionRunContext.petIds }
+        val rawRegular = its.filterKeys { it !in sessionRunContext.petIds }
+        val capeMult = resolveCapeMultiplier(
+            session.skillName,
+            sessionRunContext.equippedCape,
+            sessionRunContext.inventory.keys,
+            sessionRunContext.flags.townBuildingTiers,
+            sessionRunContext.skillPrestige,
+            gameData.equipment,
+            sessionRunContext.flags.ironman
+        )
+        val effectiveXp =
+            if (capeMult > 1f && rawRegular.isEmpty()) (totalXp.toDouble() * capeMult).toLong() else totalXp
+        val regular =
+            if (capeMult > 1f && rawRegular.isNotEmpty()) rawRegular.mapValues { (_, qty) -> (qty.toFloat() * capeMult).roundToInt() } else rawRegular
+        sessionAccumulator.awardedCapes += playerRepo.applySessionResults(
+            session.skillName,
+            effectiveXp,
+            regular
+        )
+        when (session.skillName) {
+            in sessionRunContext.gatheringSkills -> {
+                questRepo.recordGathering(session.skillName, regular)
+                playerRepo.recordDailyGathering(regular)
+                seasonalEventRepo.recordGathering(regular)
+                when (session.skillName) {
+                    Skills.AGILITY -> {
+                        guildRepo.recordGuildSessions(session.activityKey)
+                        playerRepo.recordWeeklyProgress("agility", session.activityKey, frames.size)
+                    }
+
+                    Skills.RUNECRAFTING -> guildRepo.recordGuildCrafting(session.skillName, regular)
+                    else -> guildRepo.recordGuildGathering(session.skillName, regular)
+                }
+            }
+
+            in sessionRunContext.craftingSkills -> {
+                questRepo.recordCrafting(session.skillName, regular)
+                playerRepo.recordDailyCrafting(regular)
+                guildRepo.recordGuildCrafting(session.skillName, regular)
+                seasonalEventRepo.recordCrafting(regular)
+            }
+
+            Skills.THIEVING -> {
+                val successCount = frames.count { it.success }
+                questRepo.recordThieving(
+                    session.activityKey,
+                    successCount,
+                    regular.filterKeys { it != "coins" })
+                guildRepo.recordGuildThieving(session.activityKey, successCount)
+            }
+
+            Skills.FARMING -> guildRepo.recordGuildGathering(Skills.FARMING, regular)
+        }
+        for ((id, _) in pets) {
+            val pd = gameData.pets[id] ?: continue
+            if (playerRepo.addPetIfNew(id, pd.boostPercent))
+                sessionAccumulator.petFoundName = GameStrings.petName(context, pd.id)
+        }
+        sessionAccumulator.xpBySkill[session.skillName] =
+            (sessionAccumulator.xpBySkill[session.skillName] ?: 0L) + totalXp
+        for ((item, qty) in regular) sessionAccumulator.items[item] =
+            (sessionAccumulator.items[item] ?: 0) + qty
     }
 
     fun onSessionExpiredLocally(sessionId: String) {

--- a/app/src/main/kotlin/com/fantasyidler/ui/viewmodel/InventoryViewModel.kt
+++ b/app/src/main/kotlin/com/fantasyidler/ui/viewmodel/InventoryViewModel.kt
@@ -46,6 +46,7 @@ import kotlinx.coroutines.launch
 import kotlinx.serialization.json.Json
 import javax.inject.Inject
 import com.fantasyidler.R
+import com.fantasyidler.repository.resolveCapeMultiplier
 import dagger.hilt.android.qualifiers.ApplicationContext
 
 /** One row on the Profile Banners tab — either an earned banner or a locked placeholder for a known event. */
@@ -99,6 +100,7 @@ class InventoryViewModel @Inject constructor(
         val ironman: Boolean = false,
         val activeBlessingKey: String = "",
         val activeBlessingExpiresAt: Long = 0L,
+        val prayerCapeMult: Float = 1f,
         val activeBlessingXpPct: Int = 0,
         val towerXpBonusPct: Int = 0,
         val towerCoinBonusPct: Int = 0,
@@ -160,6 +162,8 @@ class InventoryViewModel @Inject constructor(
         } else {
             val inventory: Map<String, Int> = json.decodeFromString(player.inventory)
             val pets: List<com.fantasyidler.data.model.OwnedPet> = json.decodeFromString(player.pets)
+            val equipped: Map<String, String?> = json.decodeFromString(player.equipped)
+            val equippedCape = equipped[EquipSlot.CAPE]?.let { gameData.equipment[it] }
             val flags: PlayerFlags = json.decodeFromString(player.flags)
             extra.copy(
                 coins       = player.coins,
@@ -188,8 +192,12 @@ class InventoryViewModel @Inject constructor(
                 activeBlessingExpiresAt = flags.activeBlessingExpiresAt,
                 activeBlessingXpPct     = run {
                     val b = ChurchRepository.activeBlessing(flags) ?: return@run 0
-                    if (b.type == BlessingType.XP) ((b.magnitude - 1f) * 100 + 0.5f).toInt() else 0
+                    if (b.type == BlessingType.XP) {
+                        val churchMult = ChurchRepository.xpMultiplier(flags, equipped, inventory.keys, gameData.equipment)
+                        ((churchMult - 1f) * 100 + 0.5f).toInt()
+                    } else 0
                 },
+                prayerCapeMult = resolveCapeMultiplier(Skills.PRAYER, equippedCape, inventory.keys, flags.townBuildingTiers, flags.skillPrestige, gameData.equipment, flags.ironman),
                 towerXpBonusPct         = flags.towerXpBonusPct,
                 towerCoinBonusPct       = flags.towerCoinBonusPct,
                 towerHpBonus            = flags.towerHpBonus,

--- a/app/src/main/kotlin/com/fantasyidler/ui/viewmodel/MercantileViewModel.kt
+++ b/app/src/main/kotlin/com/fantasyidler/ui/viewmodel/MercantileViewModel.kt
@@ -96,7 +96,7 @@ class MercantileViewModel @Inject constructor(
             val equippedCape = equipped[EquipSlot.CAPE]?.let { gameData.equipment[it] }
             val capeMult     = resolveCapeMultiplier(Skills.MERCANTILE, equippedCape, inventory.keys, flags.townBuildingTiers, flags.skillPrestige, gameData.equipment, flags.ironman)
             val prestigeMult = if (flags.ironman) 1f else 1f + (flags.skillPrestige[Skills.MERCANTILE] ?: 0) * 0.10f
-            val blessingCoinMult = if (flags.ironman) 1.0f else ChurchRepository.coinMultiplier(flags) *
+            val blessingCoinMult = if (flags.ironman) 1.0f else ChurchRepository.coinMultiplier(flags, equippedCape, inventory.keys, gameData.equipment) *
                 PlayerRepository.gooseCoinMultiplier(json.decodeFromString<List<OwnedPet>>(player.pets)).toFloat()
             extra.copy(
                 isLoading        = false,
@@ -141,8 +141,11 @@ class MercantileViewModel @Inject constructor(
                 val matchedKey = sortedKeys.lastOrNull { it <= currentLevel } ?: sortedKeys.firstOrNull()
                 val xpRange = matchedKey?.let { route.xpRanges[it.toString()] } ?: XpRange(1, 1)
 
+                val equipped: Map<String, String?> = json.decodeFromString(player.equipped)
+                val inventory: Map<String, Int> = json.decodeFromString(player.inventory)
+
                 val expectedRawXp = (xpRange.min + xpRange.max) * 30L
-                val xpQueueMult = if (mercFlags.ironman) 1.0 else (if (mercFlags.xpBoostExpiresAt > System.currentTimeMillis()) 2.0 else 1.0) * ChurchRepository.xpMultiplier(mercFlags)
+                val xpQueueMult = if (mercFlags.ironman) 1.0 else (if (mercFlags.xpBoostExpiresAt > System.currentTimeMillis()) 2.0 else 1.0) * ChurchRepository.xpMultiplier(mercFlags, equipped, inventory.keys, gameData.equipment)
                 val prestigeLevel = mercFlags.skillPrestige[Skills.MERCANTILE] ?: 0
                 val prestigeMult = 1.0 + prestigeLevel * 0.10
                 val estimatedXpGain = (expectedRawXp * xpQueueMult * prestigeMult).toLong()

--- a/app/src/main/kotlin/com/fantasyidler/ui/viewmodel/SkillsViewModel.kt
+++ b/app/src/main/kotlin/com/fantasyidler/ui/viewmodel/SkillsViewModel.kt
@@ -210,7 +210,7 @@ class SkillsViewModel @Inject constructor(
                 thievingEfficiency    = gameData.toolEfficiency(equipped[EquipSlot.LOCKPICK],       EquipSlot.LOCKPICK,       0),
                 cookingEfficiency     = gameData.toolEfficiency(equipped[EquipSlot.FRYING_PAN],     EquipSlot.FRYING_PAN,     0),
                 xpBonusMult           = if (flags.ironman) 1.0f
-                                        else (if (flags.xpBoostExpiresAt > System.currentTimeMillis()) 2.0f else 1.0f) * ChurchRepository.xpMultiplier(flags),
+                                        else (if (flags.xpBoostExpiresAt > System.currentTimeMillis()) 2.0f else 1.0f) * ChurchRepository.xpMultiplier(flags, equipped, inv.keys, gameData.equipment),
                 petBoosts             = listOf(Skills.MINING, Skills.WOODCUTTING, Skills.FISHING, Skills.AGILITY)
                     .associateWith { if (flags.ironman) 0 else petBoostFor(player.pets, it) },
                 sessionDurationMs     = SkillSimulator.sessionDurationMs(levels[Skills.AGILITY] ?: 1, flags.skillPrestige[Skills.AGILITY] ?: 0, townRepo.playerSessionDurationMultiplier(flags)),
@@ -451,7 +451,7 @@ class SkillsViewModel @Inject constructor(
             val toolEff = gameData.toolEfficiency(equipped[EquipSlot.TINDERBOX], EquipSlot.TINDERBOX, logData?.levelRequired ?: 0)
             val perLogMs = (SkillSimulator.sessionDurationMs(agility, flags.skillPrestige[Skills.AGILITY] ?: 0, townRepo.playerSessionDurationMultiplier(flags)) / 60L / toolEff).toLong()
             val logXp = logData?.xpPerLog?.toLong() ?: 0L
-            val xpQueueMult = if (flags.ironman) 1.0 else (if (flags.xpBoostExpiresAt > System.currentTimeMillis()) 2.0 else 1.0) * ChurchRepository.xpMultiplier(flags)
+            val xpQueueMult = if (flags.ironman) 1.0 else (if (flags.xpBoostExpiresAt > System.currentTimeMillis()) 2.0 else 1.0) * ChurchRepository.xpMultiplier(flags, equipped, inv.keys, gameData.equipment)
             val action = QueuedAction(
                 skillName           = Skills.FIREMAKING,
                 activityKey         = logKey,
@@ -510,7 +510,8 @@ class SkillsViewModel @Inject constructor(
                 val perItemMs  = SkillSimulator.sessionDurationMs(agility, rcFlags.skillPrestige[Skills.AGILITY] ?: 0, townRepo.playerSessionDurationMultiplier(rcFlags)) / 60
                 val ashBon     = catalystKey?.let { ashRuneBonusForKey(it) } ?: 0
                 val mult       = when { rcLevel >= 75 -> 3; rcLevel >= 50 -> 2; else -> 1 } + ashBon
-                val xpQueueMult = if (rcFlags.ironman) 1.0 else (if (rcFlags.xpBoostExpiresAt > System.currentTimeMillis()) 2.0 else 1.0) * ChurchRepository.xpMultiplier(rcFlags)
+                val equipped   = json.decodeFromString<Map<String, String?>>(player.equipped)
+                val xpQueueMult = if (rcFlags.ironman) 1.0 else (if (rcFlags.xpBoostExpiresAt > System.currentTimeMillis()) 2.0 else 1.0) * ChurchRepository.xpMultiplier(rcFlags, equipped, inv.keys, gameData.equipment)
                 val ashCost = if (catalystKey != null) (qty + 9) / 10 else 0
                 val saveChance = townRepo.secondaryMaterialSaveChance(rcFlags)
                 val consumedAshCost = if (catalystKey != null) applyQtyPreservation(ashCost, saveChance) else 0
@@ -625,7 +626,8 @@ class SkillsViewModel @Inject constructor(
                 val agility   = (json.decodeFromString<Map<String, Int>>(player.skillLevels))[Skills.AGILITY] ?: 1
                 val prayerFlags = try { json.decodeFromString<PlayerFlags>(player.flags) } catch (_: Exception) { PlayerFlags() }
                 val perBoneMs = SkillSimulator.sessionDurationMs(agility, prayerFlags.skillPrestige[Skills.AGILITY] ?: 0, townRepo.playerSessionDurationMultiplier(prayerFlags)) / 60
-                val xpQueueMult = if (prayerFlags.ironman) 1.0 else (if (prayerFlags.xpBoostExpiresAt > System.currentTimeMillis()) 2.0 else 1.0) * ChurchRepository.xpMultiplier(prayerFlags)
+                val equipped = json.decodeFromString<Map<String, String?>>(player.equipped)
+                val xpQueueMult = if (prayerFlags.ironman) 1.0 else (if (prayerFlags.xpBoostExpiresAt > System.currentTimeMillis()) 2.0 else 1.0) * ChurchRepository.xpMultiplier(prayerFlags, equipped, inv.keys, gameData.equipment)
                 val enqueued = playerRepo.enqueueAction(
                     QueuedAction(
                         skillName           = Skills.PRAYER,
@@ -733,7 +735,8 @@ class SkillsViewModel @Inject constructor(
                 val petBoostPct = petBoostFor(player.pets, Skills.THIEVING, thievingFlags.ironman)
                 val petBoostedXp = if (petBoostPct > 0) (npc.baseXp * (1.0 + petBoostPct / 100.0)).toInt() else npc.baseXp
                 val expectedXp = 60.0 * (successChance / (2.0 - successChance)) * petBoostedXp
-                val xpQueueMult = if (thievingFlags.ironman) 1.0 else (if (thievingFlags.xpBoostExpiresAt > System.currentTimeMillis()) 2.0 else 1.0) * ChurchRepository.xpMultiplier(thievingFlags)
+                val inventory: Map<String, Int> = json.decodeFromString(player.inventory)
+                val xpQueueMult = if (thievingFlags.ironman) 1.0 else (if (thievingFlags.xpBoostExpiresAt > System.currentTimeMillis()) 2.0 else 1.0) * ChurchRepository.xpMultiplier(thievingFlags, equipped, inventory.keys, gameData.equipment)
                 val prestigeLevel = thievingFlags.skillPrestige[Skills.THIEVING] ?: 0
                 val prestigeMult = 1.0 + prestigeLevel * 0.10
                 val estimatedXpGain = (expectedXp * xpQueueMult * prestigeMult).toLong()
@@ -841,8 +844,9 @@ class SkillsViewModel @Inject constructor(
             val player       = playerRepo.getOrCreatePlayer()
             val agility      = (json.decodeFromString<Map<String, Int>>(player.skillLevels))[Skills.AGILITY] ?: 1
             val gatherFlags = try { json.decodeFromString<PlayerFlags>(player.flags) } catch (_: Exception) { PlayerFlags() }
-            val xpQueueMult = if (gatherFlags.ironman) 1.0 else (if (gatherFlags.xpBoostExpiresAt > System.currentTimeMillis()) 2.0 else 1.0) * ChurchRepository.xpMultiplier(gatherFlags)
             val equipped: Map<String, String?> = json.decodeFromString(player.equipped)
+            val inventory: Map<String, Int> = json.decodeFromString(player.inventory)
+            val xpQueueMult = if (gatherFlags.ironman) 1.0 else (if (gatherFlags.xpBoostExpiresAt > System.currentTimeMillis()) 2.0 else 1.0) * ChurchRepository.xpMultiplier(gatherFlags, equipped, inventory.keys, gameData.equipment)
             val petBoostPct = petBoostFor(player.pets, skillName, gatherFlags.ironman)
             val rawXp = when (skillName) {
                 Skills.MINING      -> SkillSimulator.estimateGatheringXp(

--- a/app/src/main/kotlin/com/fantasyidler/ui/viewmodel/TowerViewModel.kt
+++ b/app/src/main/kotlin/com/fantasyidler/ui/viewmodel/TowerViewModel.kt
@@ -391,7 +391,7 @@ class TowerViewModel @Inject constructor(
                     playerAttack        = (levels[Skills.ATTACK]    ?: 1) + (prestigeMap[Skills.ATTACK]    ?: 0) * 5,
                     playerStrength      = (levels[Skills.STRENGTH]  ?: 1) + (prestigeMap[Skills.STRENGTH]  ?: 0) * 5,
                     playerDefence       = (levels[Skills.DEFENSE]   ?: 1) + totalDefenseBonus + (prestigeMap[Skills.DEFENSE] ?: 0) * 5,
-                    blessingDefBonus    = ChurchRepository.defBonus(flags),
+                    blessingDefBonus    = ChurchRepository.defBonus(flags, equipped, inventory.keys, gameData.equipment),
                     playerHp            = (levels[Skills.HITPOINTS] ?: 1) + (prestigeMap[Skills.HITPOINTS] ?: 0) * 5 + towerHpBonus,
                     weaponAttackBonus   = totalAttackBonus,
                     weaponStrengthBonus = totalStrengthBonus,


### PR DESCRIPTION
## Before submitting

- [x] I've tested any changes with the appropriate tests (eg. Unit tests, validation scripts)
- [x] I've pulled and merged the latest changes from the repository

## Summary

This PR makes the prayer cape bonus apply consistently to the church blessing calculations, centralizing it in ChurchRepository instead of relying on callers multiplying the blessing by the cape bonus (which previously was only done in some cases and only for the defense blessing).
I believe this change makes it worthwhile to prestige the prayer skill, as there's little reason to do it otherwise.

## Related issue(s) or discussion(s)


## Changelog

- Make prayer cape consistently boost church blessings
- Update xp multiplier format in home and profile screens to be in line with church formatting


## Anything else?

The changes make prayer prestige potentially influence more strongly the xp gained in the bone altar when the prayer cape is equipped and the xp blessing is active. However, I think this should be the intended behaviour, the same way that for other skills the prestige would interact with the church blessing (and thus with the prayer prestige).

Closes #1491 

