### PR TITLE
fix back, improve wiki

### DIFF
--- a/app/src/main/kotlin/com/fantasyidler/ui/screen/SkillsScreen.kt
+++ b/app/src/main/kotlin/com/fantasyidler/ui/screen/SkillsScreen.kt
@@ -43,6 +43,7 @@ import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.ModalBottomSheetProperties
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Switch
@@ -299,6 +300,7 @@ fun SkillActivitySheet(
             },
             sheetState = sheetState,
             dragHandle = { BottomSheetDefaults.DragHandle() },
+            properties = ModalBottomSheetProperties(shouldDismissOnBackPress = false),
         ) {
             // Rendered by each sheet under its skill description; only the sheets without
             // a description header (Mercantile, Farming) show it above their content.

--- a/app/src/main/kotlin/com/fantasyidler/ui/screen/WorkerSkillsScreen.kt
+++ b/app/src/main/kotlin/com/fantasyidler/ui/screen/WorkerSkillsScreen.kt
@@ -36,6 +36,7 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.ModalBottomSheetProperties
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Surface
@@ -269,6 +270,7 @@ fun WorkerSkillsScreen(
             },
             sheetState       = sheetState,
             dragHandle       = { BottomSheetDefaults.DragHandle() },
+            properties       = ModalBottomSheetProperties(shouldDismissOnBackPress = false),
         ) {
             // Dialog-based sheets (material3 1.3+) deliver back presses to in-content handlers;
             // the onDismissRequest interception above covers the older popup-based sheet.
@@ -505,7 +507,8 @@ private fun WorkerCraftSkillSheet(
     val categoryFiltered = if (selectedCategory == null) allRecipes
                            else allRecipes.filter { it.category == selectedCategory }
     val tiers = remember(categoryFiltered) {
-        categoryFiltered.map { it.tier }.filter { it.isNotEmpty() }.distinct().sorted()
+        categoryFiltered.map { it.tier }.filter { it.isNotEmpty() }.distinct()
+            .sortedBy { tier -> categoryFiltered.filter { it.tier == tier }.minOf { it.levelRequired } }
     }
     val recipes = categoryFiltered
         .filter { selectedTier == null || it.tier == selectedTier }

--- a/wiki/src/pages.py
+++ b/wiki/src/pages.py
@@ -933,6 +933,7 @@ def gen_thieving() -> str:
     return get_template("skills/gathering/thieving").format(
         icon=html_image(skill_icon_path("thieving"), "", "text"),
         npc_table=table(["NPC", "Level", "XP / Steal", "Coins", "Possible Loot"], rows),
+        lockpick_table=_tool_table("lockpick", "thieving_efficiency"),
     )
 
 
@@ -1104,7 +1105,7 @@ def gen_equipment() -> str:
     assert isinstance(equip, dict)
     slot_order = ["weapon", "head", "body", "legs", "boots", "cape", "ring", "necklace",
                   "shield", "pickaxe", "axe", "fishing_rod", "hoe",
-                  "hammer", "tinderbox", "grappling_hook", "frying_pan"]
+                  "hammer", "tinderbox", "grappling_hook", "frying_pan", "lockpick"]
     # Todo: Categories are currently hardcoded in InventoryViewModel and should instead be handled in json files instead (eg. in equipment.json)
     slot_names = {
         "weapon": "Weapons", "head": "Helmets", "body": "Chestplates", "legs": "Legs",
@@ -1113,6 +1114,7 @@ def gen_equipment() -> str:
         "fishing_rod": "Fishing Rods", "hoe": "Hoes",
         "hammer": "Hammers", "tinderbox": "Tinderboxes",
         "grappling_hook": "Grappling Hooks", "frying_pan": "Frying Pans",
+        "lockpick": "Lockpicks",
     }
     by_slot: dict[str, list] = {s: [] for s in slot_order}
     for item in equip.values():
@@ -1127,7 +1129,8 @@ def gen_equipment() -> str:
                 item.get("mining_efficiency") or item.get("woodcutting_efficiency") or
                 item.get("fishing_efficiency") or item.get("farming_efficiency") or
                 item.get("smithing_efficiency") or item.get("firemaking_efficiency") or
-                item.get("agility_efficiency") or item.get("cooking_efficiency") or "—",
+                item.get("agility_efficiency") or item.get("cooking_efficiency") or
+                item.get("thieving_efficiency") or "—",
                 reqs,
             ])
 

--- a/wiki/templates/skills/gathering/thieving.md
+++ b/wiki/templates/skills/gathering/thieving.md
@@ -2,4 +2,10 @@
 
 Pickpocket NPCs found in the Town for coins and loot. Higher-level NPCs require a higher Thieving level but yield more XP and better rewards per steal.
 
+## Lockpicks
+
+Equip a lockpick to improve your chance of a successful steal. Higher-tier lockpicks require a higher Thieving level.
+
+{lockpick_table}
+
 {npc_table}


### PR DESCRIPTION
## Before submitting

- [x] I've tested any changes with the appropriate tests (eg. Unit tests, validation scripts)
- [x] I've pulled and merged the latest changes from the repository

## Summary

Three small fixes:

1. **Wiki: lockpick tables missing** — the Thieving and Equipment wiki pages now show all 10 lockpicks with level requirement and efficiency, matching the other gathering-tool tables (pickaxes, axes, fishing rods, etc).
2. **Laborer smithing: ores ordered by name instead of rank** — the tier filter chips in the smithing-with-laborer sheet were sorted alphabetically; now sorted by level like the regular smithing sheet (bronze, iron, silver, ...).
3. **Predictive back closes the whole skill sheet** — on Android 13+ devices back was handled by the bottom sheet's own callback, so pressing back from a quantity/pick page closed the entire sheet instead of returning to the recipe list. The sheet now defers back handling to the in-content handlers on all devices.

## Related issue(s) or discussion(s)

Fixes #1469, Fixes #1468

## Changelog

- Added lockpick tables to the Thieving and Equipment wiki pages (`wiki/src/pages.py`, `wiki/templates/skills/gathering/thieving.md`)
- Sort laborer smithing tier chips by recipe level, matching the regular smithing sheet (`WorkerSkillsScreen.kt`)
- Stop material3 skill sheets from owning back presses on predictive-back devices so in-content handlers restore the recipe-list step-back (`SkillsScreen.kt`, `WorkerSkillsScreen.kt`)

## Anything else?

The predictive-back fix needs on-device verification on Android 13+ (back gesture + system bar): from a sheet's inner page, back should step to the recipe list; with no inner page open, back should close the sheet. Manual QA only — the OnBackInvoked path is not covered by unit tests.   