### PR TITLE
Add quest icons to farm crop picker

### DIFF
--- a/app/src/main/kotlin/com/fantasyidler/ui/screen/FarmingScreen.kt
+++ b/app/src/main/kotlin/com/fantasyidler/ui/screen/FarmingScreen.kt
@@ -70,6 +70,7 @@ import com.fantasyidler.simulator.XpTable
 import com.fantasyidler.ui.theme.ScaledSheetContent
 import com.fantasyidler.ui.viewmodel.FarmingUiState
 import com.fantasyidler.ui.viewmodel.FarmingViewModel
+import com.fantasyidler.ui.viewmodel.QuestIndicator
 import com.fantasyidler.ui.viewmodel.remainingMs
 import com.fantasyidler.util.GameStrings
 import com.fantasyidler.util.formatDurationMs
@@ -156,11 +157,12 @@ fun FarmingScreen(
         ) {
             ScaledSheetContent {
             PlantSheet(
-                crops          = state.availableCrops,
-                inventory      = state.inventory,
-                onPlant        = { crop, ashKey -> viewModel.plantCrop(patchNum, crop, ashKey) },
-                onDismiss      = viewModel::closePlantSheet,
-                initialAshKey  = state.lastFertilizerKey,
+                crops           = state.availableCrops,
+                inventory       = state.inventory,
+                questIndicators = state.questIndicators,
+                onPlant         = { crop, ashKey -> viewModel.plantCrop(patchNum, crop, ashKey) },
+                onDismiss       = viewModel::closePlantSheet,
+                initialAshKey   = state.lastFertilizerKey,
             )
             }
         }
@@ -291,11 +293,12 @@ fun FarmingSheetContent(
         ) {
             ScaledSheetContent {
             PlantSheet(
-                crops          = state.availableCrops,
-                inventory      = state.inventory,
-                onPlant        = { crop, ashKey -> viewModel.plantCrop(patchNum, crop, ashKey) },
-                onDismiss      = viewModel::closePlantSheet,
-                initialAshKey  = state.lastFertilizerKey,
+                crops           = state.availableCrops,
+                inventory       = state.inventory,
+                questIndicators = state.questIndicators,
+                onPlant         = { crop, ashKey -> viewModel.plantCrop(patchNum, crop, ashKey) },
+                onDismiss       = viewModel::closePlantSheet,
+                initialAshKey   = state.lastFertilizerKey,
             )
             }
         }
@@ -609,6 +612,7 @@ private fun PatchCard(
 private fun PlantSheet(
     crops: List<CropData>,
     inventory: Map<String, Int>,
+    questIndicators: Map<String, List<QuestIndicator>> = emptyMap(),
     onPlant: (CropData, String?) -> Unit,
     onDismiss: () -> Unit,
     initialAshKey: String? = null,
@@ -672,12 +676,15 @@ private fun PlantSheet(
                     verticalAlignment     = Alignment.CenterVertically,
                 ) {
                     Column(Modifier.weight(1f)) {
-                        Text(
-                            text  = "${crop.emoji} ${GameStrings.cropName(context, crop.id)}",
-                            style = MaterialTheme.typography.bodyLarge,
-                            color = if (enabled) MaterialTheme.colorScheme.onSurface
-                                    else MaterialTheme.colorScheme.onSurface.copy(alpha = 0.38f),
-                        )
+                        Row(verticalAlignment = Alignment.CenterVertically) {
+                            Text(
+                                text  = "${crop.emoji} ${GameStrings.cropName(context, crop.id)}",
+                                style = MaterialTheme.typography.bodyLarge,
+                                color = if (enabled) MaterialTheme.colorScheme.onSurface
+                                        else MaterialTheme.colorScheme.onSurface.copy(alpha = 0.38f),
+                            )
+                            QuestIndicatorIcons(questIndicators[crop.id] ?: emptyList())
+                        }
                         Text(
                             text  = if (crop.id == "magic_bean") stringResource(R.string.farming_bean_picker_stats)
                                     else stringResource(R.string.farming_crop_picker_stats, crop.levelRequired, (crop.growthTimeHours * 3_600_000L).formatDurationMs(context), crop.harvestXp),

--- a/app/src/main/kotlin/com/fantasyidler/ui/viewmodel/FarmingViewModel.kt
+++ b/app/src/main/kotlin/com/fantasyidler/ui/viewmodel/FarmingViewModel.kt
@@ -5,15 +5,14 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.fantasyidler.R
 import com.fantasyidler.data.json.CropData
-import com.fantasyidler.data.model.EquipSlot
 import com.fantasyidler.data.model.FarmingPatch
 import com.fantasyidler.data.model.Skills
 import com.fantasyidler.repository.FarmingRepository
 import com.fantasyidler.repository.GameDataRepository
 import com.fantasyidler.repository.GuildRepository
 import com.fantasyidler.repository.PlayerRepository
+import com.fantasyidler.repository.QuestRepository
 import com.fantasyidler.repository.TownRepository
-import com.fantasyidler.simulator.XpTable
 import dagger.hilt.android.lifecycle.HiltViewModel
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.Dispatchers
@@ -46,6 +45,7 @@ data class FarmingUiState(
     val fertilizer:     Map<String, String>    = emptyMap(),
     val availableCrops: List<CropData>         = emptyList(),
     val allCrops:       Map<String, CropData>  = emptyMap(),
+    val questIndicators: Map<String, List<QuestIndicator>> = emptyMap(),
     /** Epoch-ms "now" updated every 10 seconds for time-remaining calculations. */
     val now:            Long                   = System.currentTimeMillis(),
     val snackbarMessage: String?               = null,
@@ -81,6 +81,7 @@ class FarmingViewModel @Inject constructor(
     private val guildRepo: GuildRepository,
     private val gameData: GameDataRepository,
     private val townRepo: TownRepository,
+    private val questRepo: QuestRepository,
     private val json: Json,
 ) : ViewModel() {
 
@@ -99,7 +100,8 @@ class FarmingViewModel @Inject constructor(
         farmingRepo.observePatches(),
         nowFlow,
         _extra,
-    ) { player, patches, now, extra ->
+        questRepo.observeProgress(),
+    ) { player, patches, now, extra, questProgress ->
         if (player == null) return@combine extra.copy(isLoading = true, now = now)
 
         val levels: Map<String, Int>  = json.decodeFromString(player.skillLevels)
@@ -125,6 +127,7 @@ class FarmingViewModel @Inject constructor(
             inventory        = inv,
             availableCrops   = availableCrops,
             allCrops         = gameData.crops,
+            questIndicators  = computeQuestIndicators(questProgress, flags),
             fertilizer       = flags.farmingFertilizer,
             lastFertilizerKey = flags.lastFertilizerKey,
             magicBeanPlanted = flags.magicBeanPlanted,
@@ -252,6 +255,42 @@ class FarmingViewModel @Inject constructor(
 
     fun harvestResultConsumed() = _extra.update { it.copy(harvestResult = null) }
     fun snackbarConsumed()      = _extra.update { it.copy(snackbarMessage = null) }
+
+    private fun computeQuestIndicators(
+        questProgress: List<com.fantasyidler.data.model.QuestProgress>,
+        flags: com.fantasyidler.data.model.PlayerFlags,
+    ): Map<String, List<QuestIndicator>> {
+        val result = mutableMapOf<String, MutableList<QuestIndicator>>()
+        val progressById = questProgress.associateBy { it.questId }
+        val completedIds = progressById.entries.filter { it.value.completed }.map { it.key }.toSet()
+        val guildPool = gameData.guildDailyPool.associateBy { it.id }
+        val activeGuildDailyIds = flags.guildDailyIds.filter { it !in flags.guildDailyClaimed }
+
+        fun addIndicator(cropId: String, category: QuestCategory, questId: String) {
+            result.getOrPut(cropId) { mutableListOf() }.add(QuestIndicator(category, isCompletable = true, questId = questId))
+        }
+
+        for ((id, quest) in gameData.guildQuests) {
+            if (quest.guild != Skills.FARMING || quest.type != "gather") continue
+            val prog = progressById[id]
+            if (prog?.completed == true) continue
+            if (guildRepo.guildLevel(quest.guild, flags.guildDailyTierCounts, completedIds) < quest.guildLevelRequired) continue
+
+            val effectiveAmount = guildRepo.effectiveQuestAmountFromFlags(quest, flags)
+            if (effectiveAmount - (prog?.progress ?: 0) <= 0) continue
+            addIndicator(quest.target, QuestCategory.GUILD, id)
+        }
+
+        for (id in activeGuildDailyIds) {
+            val template = guildPool[id] ?: continue
+            if (template.guild != Skills.FARMING || template.type != "gather") continue
+            val progress = flags.guildDailyProgress[id] ?: 0
+            if (template.amount - progress <= 0) continue
+            addIndicator(template.target, QuestCategory.GUILD_DAILY, id)
+        }
+
+        return result
+    }
 }
 
 /** Remaining ms until a patch is ready. Negative means ready. */


### PR DESCRIPTION
## Before submitting

- [x] I've tested the final changes (with unit tests) to ensure the feature works
- [x] I have pulled and merged the latest changes from the repository

## Related discussion/issue(s)

Implements #1474

## Summary

Adds quest indicator icons on the Farming screen, so players can see which crops are currently wanted by an open farming guild/guild-daily quest without leaving the screen to check Quests first.

<img width="407" height="798" alt="image" src="https://github.com/user-attachments/assets/f44b2b81-00b2-4f9c-aeb5-553bb4a71fbc" />


## Changelog

- Adds `QuestIndicatorIcons` badge next to each crop's name in for farming

