### PR TITLE
Fix Guild Hall text layout for longer-language locales

### DIFF
--- a/app/src/main/kotlin/com/fantasyidler/ui/screen/GuildHallScreen.kt
+++ b/app/src/main/kotlin/com/fantasyidler/ui/screen/GuildHallScreen.kt
@@ -6,6 +6,8 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsets
@@ -19,6 +21,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.safeDrawing
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.CircleShape
@@ -50,6 +53,7 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.hilt.navigation.compose.hiltViewModel
@@ -163,6 +167,7 @@ fun GuildHallScreen(
     }
 }
 
+@OptIn(ExperimentalLayoutApi::class)
 @Composable
 private fun GuildCard(
     summary: GuildSummary,
@@ -208,11 +213,12 @@ private fun GuildCard(
             Row(
                 modifier              = Modifier.fillMaxWidth(),
                 verticalAlignment     = Alignment.CenterVertically,
-                horizontalArrangement = Arrangement.SpaceBetween,
+                horizontalArrangement = Arrangement.spacedBy(16.dp),
             ) {
-                Row(
-                    verticalAlignment      = Alignment.CenterVertically,
+                FlowRow(
+                    verticalArrangement    = Arrangement.spacedBy(2.dp),
                     horizontalArrangement  = Arrangement.spacedBy(8.dp),
+                    modifier               = Modifier.weight(1f),
                 ) {
                     Text(
                         text       = GameStrings.guildName(context, summary.guildKey),
@@ -280,9 +286,11 @@ private fun DailyStatusIndicator(summary: GuildSummary) {
             modifier           = Modifier.height(20.dp).width(20.dp),
         )
         summary.dailiesTodayTotal > 0 -> Text(
-            text  = stringResource(R.string.guild_dailies_remaining_today, summary.dailiesTodayRemaining),
-            style = MaterialTheme.typography.labelSmall,
-            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            text      = stringResource(R.string.guild_dailies_remaining_today, summary.dailiesTodayRemaining),
+            style     = MaterialTheme.typography.labelSmall,
+            color     = MaterialTheme.colorScheme.onSurfaceVariant,
+            textAlign = TextAlign.End,
+            modifier  = Modifier.widthIn(max = 84.dp),
         )
     }
 }
@@ -319,6 +327,8 @@ private fun LevelBadge(level: Int) {
             style    = MaterialTheme.typography.labelSmall,
             color    = if (level > 0) MaterialTheme.colorScheme.onPrimaryContainer
                        else MaterialTheme.colorScheme.onSurfaceVariant,
+            maxLines = 1,
+            softWrap = false,
             modifier = Modifier.padding(horizontal = 6.dp, vertical = 2.dp),
         )
     }


### PR DESCRIPTION
## Before submitting

- [x] I've tested any changes with the appropriate tests (eg. Unit tests, validation scripts)
- [x] I've pulled and merged the latest changes from the repository

## Summary

Fixes a Guild Hall list-row layout bug where longer translated strings (e.g. French) could squeeze the level badge chip until its text wrapped one character per line, and crowded the "N left today" status text against the guild name/level badge.

**French**
<img width="409" height="808" alt="image" src="https://github.com/user-attachments/assets/f38c9f35-d649-42a8-93a4-d7a0680b8535" />

**German**
<img width="416" height="799" alt="image" src="https://github.com/user-attachments/assets/9e11d7f3-bcbd-4d43-8467-66b860d3ef26" />

## Related issue(s) or discussion(s)

Relates to #1459

## Changelog

- Fix bug with different languages with guild hall UI refresh.

## Anything else?

Closes https://github.com/tristinbaker/IdleFantasy/issues/1487 