### PR TITLE
fix: 'Coin Drake' pet drops for mercantile trade routes

### DIFF
--- a/app/src/main/kotlin/com/fantasyidler/ui/viewmodel/MercantileViewModel.kt
+++ b/app/src/main/kotlin/com/fantasyidler/ui/viewmodel/MercantileViewModel.kt
@@ -182,6 +182,8 @@ class MercantileViewModel @Inject constructor(
                     route, startXp, agilityLevel,
                     agilityPrestige = mercFlags.skillPrestige[Skills.AGILITY] ?: 0,
                     chronosMultiplier = townRepo.playerSessionDurationMultiplier(mercFlags),
+                    petDropKey = "coin_drake",
+                    petDropChance = 1.0 / 1000.0
                 )
                 val framesJson = json.encodeToString(
                     json.serializersModule.serializer<List<SessionFrame>>(),


### PR DESCRIPTION
## Before submitting

- [x] I've tested any changes with the appropriate tests (eg. Unit tests, validation scripts)
- [x] I've pulled and merged the latest changes from the repository

## Summary

Fixes Coin Drake drops for Mercantile trade routes started directly.

Directly started routes did not pass the Mercantile pet ID or drop
chance to `MercantileSimulator`. Queued routes already passed these
values correctly.

## Related issue(s) or discussion(s)

Might relate to #1496


## Changelog

- Fixed Coin Drake drops for directly started Mercantile trade routes


