### PR TITLE
 Update docs & wiki with v1.14 features: mercenaries, housing, prestige

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,9 +28,15 @@ Train **23 skills** at your own pace:
 
 Better equipment means faster gathering and surviving tougher dungeons. Craft your own gear or buy it from the Shop. The **Mercantile** skill levels through trade routes and unlocks better prices. **Slayer** tasks are assigned by the Slayer Master in town and are completed by fighting specific enemies in dungeons.
 
+At level 99 a skill can be **prestiged**: it resets to level 1 in exchange for prestige points, which buy permanent upgrades in that skill's tree, including bonuses exclusive to your character's race.
+
 ## Combat and dungeons
 
 Explore **29 dungeons** from the starter Farm all the way to late-game Fortress Ruins and beyond. Each dungeon has its own enemy roster, difficulty rating, and potential drops. Before you go in, the game tells you how your current gear stacks up. Choose from Melee, Ranged, or Magic; each style levels its own combat skills.
+
+## Raid bosses and mercenaries
+
+Some foes are beyond one hero. Raid bosses spread their attacks across your whole party, so hire up to three mercenaries from the daily rotating camp to soak damage and deal it back. Contracts last until the next daily reset, and the live combat view shows every party member's health while the fight runs.
 
 ## Infinite Tower
 
@@ -51,6 +57,10 @@ Over **189 quests** span all skills. Daily quests reset every morning for a quic
 ## Builder's Workshop
 
 Spend Construction materials to upgrade various town buildings, unlocking better worker slots, guild perks, and more.
+
+## Player housing
+
+Buy rooms on a personal plot off the Town screen, expand them cell by cell, and furnish the result as your Construction level grows. Removing a placed piece always returns it to storage, and the finished house can be rendered to a shareable image.
 
 ## Church
 

--- a/docs/gen/templates/readme.md
+++ b/docs/gen/templates/readme.md
@@ -25,9 +25,15 @@ Train **{skill_count} skills** at your own pace:
 
 Better equipment means faster gathering and surviving tougher dungeons. Craft your own gear or buy it from the Shop. The **Mercantile** skill levels through trade routes and unlocks better prices. **Slayer** tasks are assigned by the Slayer Master in town and are completed by fighting specific enemies in dungeons.
 
+At level 99 a skill can be **prestiged**: it resets to level 1 in exchange for prestige points, which buy permanent upgrades in that skill's tree, including bonuses exclusive to your character's race.
+
 ## Combat and dungeons
 
 Explore **{dungeon_count} dungeons** from the starter Farm all the way to late-game Fortress Ruins and beyond. Each dungeon has its own enemy roster, difficulty rating, and potential drops. Before you go in, the game tells you how your current gear stacks up. Choose from Melee, Ranged, or Magic; each style levels its own combat skills.
+
+## Raid bosses and mercenaries
+
+Some foes are beyond one hero. Raid bosses spread their attacks across your whole party, so hire up to three mercenaries from the daily rotating camp to soak damage and deal it back. Contracts last until the next daily reset, and the live combat view shows every party member's health while the fight runs.
 
 ## Infinite Tower
 
@@ -48,6 +54,10 @@ Over **{quest_count} quests** span all skills. Daily quests reset every morning 
 ## Builder's Workshop
 
 Spend Construction materials to upgrade various town buildings, unlocking better worker slots, guild perks, and more.
+
+## Player housing
+
+Buy rooms on a personal plot off the Town screen, expand them cell by cell, and furnish the result as your Construction level grows. Removing a placed piece always returns it to storage, and the finished house can be rendered to a shareable image.
 
 ## Church
 

--- a/wiki/src/pages.py
+++ b/wiki/src/pages.py
@@ -94,6 +94,7 @@ def add_static_pages():
             ("dungeons", PageInfo("Dungeons", "Dungeons.md", gen_dungeons)),
             ("enemies", PageInfo("Enemies", "Enemies.md", gen_enemies)),
             ("spells", PageInfo("Spells", "Spells.md", gen_spells)),
+            ("mercenaries", PageInfo("Mercenary Camp", "Mercenaries.md", gen_mercenaries)),
         ]],
         ["Town", False, [
             ("shop", PageInfo("Shop", "Shop.md", gen_shop)),
@@ -101,6 +102,7 @@ def add_static_pages():
             ("guilds", PageInfo("Guilds", "Guilds.md", gen_guilds)),
             ("buildings", PageInfo("Buildings", "Buildings.md", gen_buildings)),
             ("carnival", PageInfo("Carnival", "Carnival.md", gen_carnival)),
+            ("housing", PageInfo("Housing", "Housing.md", gen_housing)),
         ]],
         ["Miscellaneous", False, [
             ("expeditions", PageInfo("Expeditions", "Expeditions.md", gen_expeditions, skill_icon_path("expedition"))),
@@ -1245,6 +1247,7 @@ def gen_bosses() -> str:
     return get_template("combat/bosses").format(
         boss_table=table(header, rows_for(raid=False)),
         raid_table=table(header, rows_for(raid=True)),
+        mercenaries_link=link("mercenaries"),
         combat_footer=gen_combat_footer(),
     )
 
@@ -1877,6 +1880,71 @@ def gen_boss(boss: dict) -> str:
         loot_table=table(["Item", "Min", "Max"], common_loot_rows) if common_loot_rows else "_No loot defined._",
         rare_drops_table=table(["Item", "Chance"], rare_loot_rows) if rare_loot_rows else "_No rare drops._",
         combat_footer=gen_combat_footer(),
+    )
+
+def _merc_tier_label(tier: str) -> str:
+    key = f"merc_tier_{tier}"
+    return STRINGS.get_string(key) if key in STRINGS else title(tier)
+
+
+_MERC_TIER_ORDER = {"cheap": 0, "seasoned": 1, "elite": 2}
+
+
+def gen_mercenaries() -> str:
+    mercs = load("mercenaries.json")
+    assert isinstance(mercs, list)
+    ordered = sorted(mercs, key=lambda m: (_MERC_TIER_ORDER.get(m["tier"], 99), m["display_name"]))
+    rows = [
+        [
+            f"{merc['emoji']} {merc['display_name']}",
+            _merc_tier_label(merc["tier"]),
+            merc["combat_style"].title(),
+            f"{merc['attack_level']} (+{merc['attack_bonus']})",
+            f"{merc['strength_level']} (+{merc['strength_bonus']})",
+            merc["defense_level"],
+            merc["hp"],
+            fmt_amount(merc["hire_cost"]),
+        ]
+        for merc in ordered
+    ]
+    return get_template("combat/mercenaries").format(
+        merc_table=table(["Mercenary", "Tier", "Style", "Attack", "Strength", "Defence", "HP", "Cost per Day"], rows),
+        bosses_link=link("bosses"),
+    )
+
+
+def gen_housing() -> str:
+    data = load("house_tiles.json")
+    assert isinstance(data, dict)
+    room_rows = [
+        [f"Room {i + 2}", room["level"], fmt_amount(room["coins"]), fmt_materials(room["materials"]), fmt_amount(room["xp"])]
+        for i, room in enumerate(data["rooms"])
+    ]
+    expansion_rows = [
+        [f"Room {i + 1}", fmt_amount(tier["coins"]), fmt_materials(tier["materials"]), fmt_amount(tier["xp"])]
+        for i, tier in enumerate(data["expansion"])
+    ]
+    catalogue = {item_id: item for item_id, item in data["items"].items() if not item.get("hidden")}
+    furniture_rows = sorted(
+        (
+            [
+                item_name(item.get("name_key") or item_id),
+                item.get("category", "").replace("_", " ").title(),
+                item["level_required"],
+                fmt_amount(item["coin_cost"]),
+                fmt_materials(item.get("materials", {})),
+                fmt_amount(item["xp"]),
+            ]
+            for item_id, item in catalogue.items()
+        ),
+        key=lambda row: (row[2], row[0]),
+    )
+    return get_template("town/housing").format(
+        room_table=table(["Room", "Construction Level", "Coins", "Materials", "XP"], room_rows),
+        expansion_table=table(["Room Tier", "Coins per Cell", "Materials per Cell", "XP per Cell"], expansion_rows),
+        furniture_count=len(catalogue),
+        furniture_table=table(["Item", "Category", "Level", "Coins", "Materials", "XP"], furniture_rows),
+        grounds_count=len(data["grounds"]),
     )
 
 # ---------------------------------------------------------------------------

--- a/wiki/templates/combat/bosses.md
+++ b/wiki/templates/combat/bosses.md
@@ -12,7 +12,7 @@ More information about specific bosses can be found on their particular pages
 
 ## Raid Bosses
 
-Raid bosses are a tier above: they cannot be beaten alone, even in the best gear. Hire up to three mercenaries from the daily rotating pool to bring them down, and the boss will spread its attacks across your whole party.
+Raid bosses are a tier above: they cannot be beaten alone, even in the best gear. Hire up to three mercenaries from the daily rotating pool to bring them down, and the boss will spread its attacks across your whole party. The {mercenaries_link} page lists hiring costs and combat stats.
 
 {raid_table}
 

--- a/wiki/templates/combat/mercenaries.md
+++ b/wiki/templates/combat/mercenaries.md
@@ -1,0 +1,21 @@
+# Mercenary Camp
+
+Raid bosses cannot be beaten alone. The Mercenary Camp hires fighters who join your party for the length of a contract, which lasts until your next daily reset. Find it through the Raid section of the combat screen, next to the raid bosses themselves.
+
+{merc_table}
+
+## Hiring
+
+Each day brings a fresh pool of six candidates, two per tier, rotating at your daily reset. You can bring up to **three mercenaries** into a raid at once. Hiring again after a contract expires means paying the day's price again, and dismissing a mercenary early refunds nothing.
+
+A red warning on the boss sheet reminds you when you are about to fight solo. Raid bosses never gate on combat level, so nothing stops you from walking in unprepared except the outcome.
+
+## In combat
+
+Mercenaries fight as full party members on their own attack rhythm, independent of your weapon speed. Their hits roll accuracy against the boss's matching defence stat. In combat a mercenary brings ten times their listed health, following the same scaling as your own.
+
+The boss spreads its attacks randomly across every living party member, so each mercenary you hire soaks damage that would otherwise land on you. A mercenary reduced to zero health sits out the rest of the fight, but if you die, the raid ends regardless of who is still standing.
+
+During the session, the live view shows every party member's health bar, their stats, and a counter for allies down. Queued raids check contracts when the session starts, so make sure nobody's contract lapses before the fight begins.
+
+See {bosses_link} for the raid roster itself.

--- a/wiki/templates/town/housing.md
+++ b/wiki/templates/town/housing.md
@@ -1,0 +1,41 @@
+# Housing
+
+Your house is a personal plot off the Town screen where you buy rooms, expand them cell by cell, and furnish the result. Rooms and furniture carry a coin and materials price, usually gated by your **Construction** level. Prices throughout are base rates, before any Builder's Workshop discount.
+
+The first visit hands you a free 4×4 starter room on an 18×18 plot. From there the house is yours to shape: pan and zoom around the grid, drag rooms to new positions, and place furniture wherever it fits.
+
+## Rooms
+
+You can own up to six rooms. New rooms arrive as 3×3 plots that must touch an existing room's edge, and each one costs more than the last:
+
+{room_table}
+
+## Expanding and reshaping
+
+Expand a room one row or column at a time. Each new cell costs the expansion price for that room's tier — the free starter room bills at the Room 1 rate:
+
+{expansion_table}
+
+Shrinking a room refunds today's per-cell price for the cells you give up. Moving a room — contents included — is free. Demolishing refunds nothing but returns every furnishing to storage, and your last room can never be demolished.
+
+## Furniture
+
+The catalogue holds {furniture_count} pieces across furniture, wall decor, and pure wealth display:
+
+{furniture_table}
+
+Placing a piece from the catalogue pays its coins and materials once; after that, taking it out of storage again is free, and removing a placed piece always sends it back to storage with its materials intact. Paying for a placement also grants Construction XP for every cell it covers.
+
+A few placement rules worth knowing:
+
+- Wall decor hangs on the northernmost wall of its column.
+- Table-only items need full table coverage underneath them.
+- Pieces may straddle two adjacent rooms, or overhang half a cell above a room's north wall.
+- Only pieces sharing a collision layer block each other: floor furniture, wall decor, and the two divider orientations are separate layers.
+- The brick floor style requires Construction level 10; the {grounds_count} outdoor ground styles are free cosmetics.
+
+Seasonal events award exclusive banners that hang as wall trophies, one of each, at no cost.
+
+## Showing off
+
+The share button renders your house to an image you can send anywhere you like.


### PR DESCRIPTION
## Before submitting

- [x] I've tested any changes with the appropriate tests (eg. Unit tests, validation scripts)
- [x] I've pulled and merged the latest changes from the repository

## Summary

Documentation-only follow-up to v1.14.0 that brings the README and the game wiki up to date with the new prestige, raid mercenaries, and player housing features.

- **README** (`README.md` + generator source of truth `docs/gen/templates/readme.md`, kept in sync): adds sections explaining skill prestiging at level 99, raid bosses with hired mercenaries, and the player housing system.
- **New wiki pages**: `Mercenary Camp` (hire pool rotation, contract rules, combat behaviour) and `Housing` (rooms, expansion pricing, furniture catalogue, placement rules), each backed by a data-driven generator (`gen_mercenaries`, `gen_housing`) in `wiki/src/pages.py`.
- **Bosses page**: cross-link to the new Mercenaries page listing hire costs and combat stats.

Verified with `python3 -m wiki.src validity` (clean) and `python3 -m wiki.src write`; all generated tables render fully populated with no unfilled placeholders.



## Changelog

- Documented prestige skill trees in README (level 99 reset, racial bonuses)
- Added "Raid bosses and mercenaries" section to README and generated wiki templates
- Added "Player housing" section covering plots, room expansion, and furniture
- Added wiki generators `gen_mercenaries` and `gen_housing` rendering live game data into new Mercenary Camp and Housing pages
- Linked the new Mercenary Camp page from the Raid Bosses page