### PR TITLE
feat: Add Skill Tree button to skill detail sheets

### DIFF
--- a/app/src/main/kotlin/com/fantasyidler/ui/screen/SkillsScreen.kt
+++ b/app/src/main/kotlin/com/fantasyidler/ui/screen/SkillsScreen.kt
@@ -11,7 +11,6 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
@@ -19,7 +18,6 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
-import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.WindowInsetsSides
 import androidx.compose.foundation.layout.only
@@ -35,8 +33,6 @@ import androidx.compose.material3.Badge
 import androidx.compose.material3.BottomSheetDefaults
 import androidx.compose.material3.Tab
 import androidx.compose.material3.TabRow
-import androidx.compose.material3.Button
-import androidx.compose.material3.FilterChip
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
@@ -47,7 +43,6 @@ import androidx.activity.compose.BackHandler
 import androidx.compose.material3.ModalBottomSheetProperties
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Surface
-import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar
@@ -56,9 +51,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
-import androidx.compose.foundation.text.KeyboardActions
-import androidx.compose.foundation.text.KeyboardOptions
-import androidx.compose.material3.OutlinedTextField
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableLongStateOf
 import androidx.compose.runtime.mutableStateOf
@@ -67,8 +59,6 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import kotlinx.coroutines.launch
-import androidx.compose.ui.text.input.ImeAction
-import androidx.compose.ui.text.input.KeyboardType
 import kotlinx.coroutines.delay
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -84,44 +74,28 @@ import androidx.lifecycle.compose.dropUnlessResumed
 import com.fantasyidler.BuildConfig
 import com.fantasyidler.R
 import com.fantasyidler.ui.viewmodel.ExpeditionsViewModel
-import com.fantasyidler.data.json.AgilityCourseData
-import com.fantasyidler.data.json.BoneData
-import com.fantasyidler.data.json.FishData
-import com.fantasyidler.data.json.LogData
-import com.fantasyidler.data.json.OreData
-import com.fantasyidler.data.json.ThievingNpcData
-import com.fantasyidler.data.json.TreeData
 import com.fantasyidler.data.model.Skills
 import com.fantasyidler.ui.theme.ScaledSheetContent
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
-import androidx.compose.material.icons.filled.Remove
 import androidx.compose.material.icons.outlined.Info
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
-import androidx.compose.ui.text.style.TextAlign
-import com.fantasyidler.ui.viewmodel.CraftableRecipe
-import com.fantasyidler.ui.viewmodel.CraftingUiState
 import com.fantasyidler.ui.viewmodel.CraftingViewModel
 import com.fantasyidler.ui.viewmodel.SheetQuestSource
 import com.fantasyidler.ui.viewmodel.SheetQuestSummary
 import com.fantasyidler.ui.viewmodel.SheetState
-import com.fantasyidler.ui.viewmodel.levelDisplay
 import com.fantasyidler.ui.viewmodel.SkillsUiState
 import com.fantasyidler.ui.viewmodel.SkillsViewModel
 import com.fantasyidler.ui.viewmodel.xpProgressFraction
 import com.fantasyidler.ui.viewmodel.nextLevelThreshold
 import com.fantasyidler.ui.viewmodel.xpToNextLevel
-import com.fantasyidler.simulator.SkillSimulator
-import com.fantasyidler.simulator.XpTable
 import com.fantasyidler.util.GameStrings
 import com.fantasyidler.util.toTitleCase
-import com.fantasyidler.util.formatDurationMs
 import com.fantasyidler.util.formatXp
 import com.fantasyidler.util.toCountdown
 import java.util.Locale
 import com.fantasyidler.ui.viewmodel.QuestCategory
-import com.fantasyidler.ui.viewmodel.QuestFillSuggestion
 import com.fantasyidler.ui.viewmodel.QuestIndicator
 
 private val NON_COMBAT_PRESTIGE_SKILLS = Skills.GATHERING + Skills.CRAFTING_SKILLS + Skills.SUPPORT + listOf(Skills.SLAYER)
@@ -253,6 +227,7 @@ fun SkillsScreen(
         viewModel             = viewModel,
         craftingViewModel     = craftingViewModel,
         onNavigateToBoneAltar = onNavigateToBoneAltar,
+        onNavigateToPrestige  = onNavigateToPrestige,
     )
 
     state.petFoundName?.let { petName ->
@@ -280,6 +255,7 @@ fun SkillActivitySheet(
     viewModel: SkillsViewModel,
     craftingViewModel: CraftingViewModel,
     onNavigateToBoneAltar: () -> Unit = {},
+    onNavigateToPrestige: (String) -> Unit = {},
 ) {
     val state by viewModel.uiState.collectAsState()
     val context = LocalContext.current
@@ -318,18 +294,27 @@ fun SkillActivitySheet(
             // Rendered by each sheet under its skill description; only the sheets without
             // a description header (Mercantile, Farming) show it above their content.
             val dailyBanner: @Composable () -> Unit = {
-                GuildDailySheetBanner(sheet, state.sheetQuests) { daily ->
-                    val remaining = (daily.amount - daily.progress).coerceAtLeast(1)
-                    val craftGuilds = setOf(
-                        Skills.SMITHING, Skills.COOKING, Skills.FLETCHING,
-                        Skills.CRAFTING, Skills.HERBLORE, Skills.CONSTRUCTION,
-                    )
-                    if (daily.type == "craft" && daily.guild in craftGuilds) {
-                        craftingViewModel.queueCraftForDaily(daily.target, remaining)
-                    } else {
-                        viewModel.queueDailySession(daily)
-                    }
-                }
+                GuildDailySheetBanner(
+                    sheet             = sheet,
+                    guildDailies      = state.sheetQuests,
+                    onOpenPrestige    = { skill ->
+                        viewModel.dismissSheet()
+                        craftingViewModel.dismissRecipe()
+                        onNavigateToPrestige(skill)
+                    },
+                    onQueueDaily      = { daily ->
+                        val remaining = (daily.amount - daily.progress).coerceAtLeast(1)
+                        val craftGuilds = setOf(
+                            Skills.SMITHING, Skills.COOKING, Skills.FLETCHING,
+                            Skills.CRAFTING, Skills.HERBLORE, Skills.CONSTRUCTION,
+                        )
+                        if (daily.type == "craft" && daily.guild in craftGuilds) {
+                            craftingViewModel.queueCraftForDaily(daily.target, remaining)
+                        } else {
+                            viewModel.queueDailySession(daily)
+                        }
+                    },
+                )
             }
             if (sheet is SheetState.Mercantile || sheet is SheetState.Farming) {
                 ScaledSheetContent { dailyBanner() }
@@ -501,6 +486,7 @@ private fun SheetQuestSummary.canQueue(): Boolean = when {
 private fun GuildDailySheetBanner(
     sheet: SheetState,
     guildDailies: Map<String, List<SheetQuestSummary>>,
+    onOpenPrestige: (String) -> Unit,
     onQueueDaily: (SheetQuestSummary) -> Unit,
 ) {
     val skillKey = when (sheet) {
@@ -517,7 +503,7 @@ private fun GuildDailySheetBanner(
         SheetState.Farming         -> Skills.FARMING
         SheetState.ComingSoon      -> null
     } ?: return
-    val quests = guildDailies[skillKey]?.takeIf { it.isNotEmpty() } ?: return
+    val quests = guildDailies[skillKey] ?: emptyList()
     val context = LocalContext.current
     val guildMaxed = quests.any { it.source == SheetQuestSource.GUILD && it.guildMaxed }
     val anyOpen = quests.any { !it.claimed && !(it.source == SheetQuestSource.GUILD && it.guildMaxed) }
@@ -618,19 +604,28 @@ private fun GuildDailySheetBanner(
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.SpaceBetween,
     ) {
-        TextButton(onClick = { showDialog = true }) {
-            Text(
-                text  = stringResource(R.string.nav_quests),
-                style = MaterialTheme.typography.labelMedium,
-                color = if (anyOpen) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onSurfaceVariant,
-            )
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            TextButton(onClick = { showDialog = true }, enabled = quests.isNotEmpty()) {
+                Text(
+                    text  = stringResource(R.string.nav_quests),
+                    style = MaterialTheme.typography.labelMedium,
+                    color = if (anyOpen) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+            if (guildMaxed) {
+                Text(
+                    text     = stringResource(R.string.guild_daily_rank_maxed),
+                    style    = MaterialTheme.typography.labelSmall,
+                    color    = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.padding(start = 8.dp),
+                )
+            }
         }
-        if (guildMaxed) {
+        TextButton(onClick = { onOpenPrestige(skillKey) }) {
             Text(
-                text     = stringResource(R.string.guild_daily_rank_maxed),
-                style    = MaterialTheme.typography.labelSmall,
-                color    = MaterialTheme.colorScheme.onSurfaceVariant,
-                modifier = Modifier.padding(end = 8.dp),
+                text  = stringResource(R.string.prestige_skill_tree),
+                style = MaterialTheme.typography.labelMedium,
+                color = MaterialTheme.colorScheme.primary,
             )
         }
     }

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -1057,6 +1057,7 @@
     <string name="slayer_foretell_btn">Foretell Next Task (%1$d bones)</string> <!-- untranslated -->
     <string name="slayer_foretell_slot">Slot %1$d: %2$s</string> <!-- untranslated -->
     <string name="prestige">Prestige</string> <!-- untranslated -->
+    <string name="prestige_skill_tree">Skill Tree</string> <!-- untranslated -->
     <string name="prestige_max">Max Prestige</string> <!-- untranslated -->
     <string name="prestige_confirm_title" formatted="false">Prestige %s?</string> <!-- untranslated -->
     <string name="prestige_confirm_message_xp">Your %1$s level will reset to 1, but you\'ll earn a permanent +%2$d%% XP bonus for this skill.</string> <!-- untranslated -->

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -1323,6 +1323,7 @@
 
     <!-- Prestige system -->
     <string name="prestige">Prestige</string> <!-- untranslated -->
+    <string name="prestige_skill_tree">Skill Tree</string> <!-- untranslated -->
     <string name="prestige_max">Max Prestige</string> <!-- untranslated -->
     <string name="prestige_confirm_title" formatted="false">Prestige %s?</string> <!-- untranslated -->
     <string name="prestige_confirm_message_xp">Your %1$s level will reset to 1, but you\'ll earn a permanent +%2$d%% XP bonus for this skill.</string> <!-- untranslated -->

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -1319,6 +1319,7 @@
 
     <!-- Prestige system -->
     <string name="prestige">Prestige</string>
+    <string name="prestige_skill_tree">Skill Tree</string> <!-- untranslated -->
     <string name="prestige_max">Max. Prestige</string>
     <string name="prestige_confirm_title" formatted="false">Prestige %s?</string>
     <string name="prestige_confirm_message_xp">Euer %1$s-Level wird auf 1 zurückgesetzt, Ihr werdet allerdings dauerhaft +%2$d%% EP-Bonus für diese Fähigkeit erhalten.</string>

--- a/app/src/main/res/values-es-rES/strings.xml
+++ b/app/src/main/res/values-es-rES/strings.xml
@@ -1313,6 +1313,7 @@
 
     <!-- Prestige system -->
     <string name="prestige">Prestige</string> <!-- untranslated -->
+    <string name="prestige_skill_tree">Skill Tree</string> <!-- untranslated -->
     <string name="prestige_max">Max Prestige</string> <!-- untranslated -->
     <string name="prestige_confirm_title" formatted="false">Prestige %s?</string> <!-- untranslated -->
     <string name="prestige_confirm_message_xp">Your %1$s level will reset to 1, but you\'ll earn a permanent +%2$d%% XP bonus for this skill.</string> <!-- untranslated -->

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -1319,6 +1319,7 @@
 
     <!-- Prestige system -->
     <string name="prestige">Prestige</string> <!-- untranslated -->
+    <string name="prestige_skill_tree">Skill Tree</string> <!-- untranslated -->
     <string name="prestige_max">Max Prestige</string> <!-- untranslated -->
     <string name="prestige_confirm_title" formatted="false">Prestige %s?</string> <!-- untranslated -->
     <string name="prestige_confirm_message_xp">Your %1$s level will reset to 1, but you\'ll earn a permanent +%2$d%% XP bonus for this skill.</string> <!-- untranslated -->

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -1320,6 +1320,7 @@
 
     <!-- Prestige system -->
     <string name="prestige">Prestige</string>
+    <string name="prestige_skill_tree">Skill Tree</string> <!-- untranslated -->
     <string name="prestige_max">Prestige max</string>
     <string name="prestige_confirm_title" formatted="false">Prestige %s ?</string>
     <string name="prestige_confirm_message_xp">Votre niveau %1$s sera réinitialisé à 1, mais vous gagnerez un bonus permanent de +%2$d%% XP pour cette aptitude.</string>

--- a/app/src/main/res/values-ga/strings.xml
+++ b/app/src/main/res/values-ga/strings.xml
@@ -1347,6 +1347,7 @@
 
     <!-- Prestige system -->
     <string name="prestige">Prestige</string> <!-- untranslated -->
+    <string name="prestige_skill_tree">Skill Tree</string> <!-- untranslated -->
     <string name="prestige_max">Max Prestige</string> <!-- untranslated -->
     <string name="prestige_confirm_title" formatted="false">Prestige %s?</string> <!-- untranslated -->
     <string name="prestige_confirm_message_xp">Your %1$s level will reset to 1, but you\'ll earn a permanent +%2$d%% XP bonus for this skill.</string> <!-- untranslated -->

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -1311,6 +1311,7 @@
 
     <!-- Prestige system -->
     <string name="prestige">Prestise</string>
+    <string name="prestige_skill_tree">Skill Tree</string> <!-- untranslated -->
     <string name="prestige_max">Prestise Maksimum</string>
     <string name="prestige_confirm_title" formatted="false">Prestise %s?</string>
     <string name="prestige_confirm_message_xp">Your %1$s level will reset to 1, but you\'ll earn a permanent +%2$d%% XP bonus for this skill.</string> <!-- untranslated -->

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -1319,6 +1319,7 @@
 
     <!-- Prestige system -->
     <string name="prestige">Onore</string>
+    <string name="prestige_skill_tree">Skill Tree</string> <!-- untranslated -->
     <string name="prestige_max">Onore Massimo</string>
     <string name="prestige_confirm_title" formatted="false">Onora %s?</string>
     <string name="prestige_confirm_message_xp">Il livello di %1$s tornerà a 1, ma otterrai un bonus permanente di +%2$d%% XP per questa abilità.</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -1319,6 +1319,7 @@
 
     <!-- Prestige system -->
     <string name="prestige">名声</string>
+    <string name="prestige_skill_tree">Skill Tree</string> <!-- untranslated -->
     <string name="prestige_max">最大名声</string>
     <string name="prestige_confirm_title" formatted="false">%s の名声を獲得しますか？</string>
     <string name="prestige_confirm_message_xp">%1$s のレベルは 1 にリセットされますが、このスキルの獲得経験値に永続的な +%2$d%% ボーナスが得られます。</string>

--- a/app/src/main/res/values-lt/strings.xml
+++ b/app/src/main/res/values-lt/strings.xml
@@ -1319,6 +1319,7 @@
 
     <!-- Prestige system -->
     <string name="prestige">Prestige</string> <!-- untranslated -->
+    <string name="prestige_skill_tree">Skill Tree</string> <!-- untranslated -->
     <string name="prestige_max">Max Prestige</string> <!-- untranslated -->
     <string name="prestige_confirm_title" formatted="false">Prestige %s?</string> <!-- untranslated -->
     <string name="prestige_confirm_message_xp">Your %1$s level will reset to 1, but you\'ll earn a permanent +%2$d%% XP bonus for this skill.</string> <!-- untranslated -->

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -1319,6 +1319,7 @@
 
     <!-- Prestige system -->
     <string name="prestige">Prestige</string> <!-- untranslated -->
+    <string name="prestige_skill_tree">Skill Tree</string> <!-- untranslated -->
     <string name="prestige_max">Max Prestige</string> <!-- untranslated -->
     <string name="prestige_confirm_title" formatted="false">Prestige %s?</string> <!-- untranslated -->
     <string name="prestige_confirm_message_xp">Your %1$s level will reset to 1, but you\'ll earn a permanent +%2$d%% XP bonus for this skill.</string> <!-- untranslated -->

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -1335,6 +1335,7 @@
 
     <!-- Prestige system -->
     <string name="prestige">Prestiż</string>
+    <string name="prestige_skill_tree">Skill Tree</string> <!-- untranslated -->
     <string name="prestige_max">Maks. prestiż</string>
     <string name="prestige_confirm_title" formatted="false">Prestiż %s?</string>
     <string name="prestige_confirm_message_xp">Twój poziom %1$s zresetuje się do 1, ale zdobędziesz stały bonus +%2$d%% XP dla tej umiejętności.</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -1319,6 +1319,7 @@
 
     <!-- Prestige system -->
     <string name="prestige">Prestígio</string>
+    <string name="prestige_skill_tree">Skill Tree</string> <!-- untranslated -->
     <string name="prestige_max">Prestígio Máximo</string>
     <string name="prestige_confirm_title" formatted="false">Dar Prestígio em %s?</string>
     <string name="prestige_confirm_message_xp">Seu nível de %1$s vai voltar para 1, mas você vai ganhar um bônus permanente de +%2$d%% de XP nessa habilidade.</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -1335,6 +1335,7 @@
 
     <!-- Prestige system -->
     <string name="prestige">Престиж</string>
+    <string name="prestige_skill_tree">Skill Tree</string> <!-- untranslated -->
     <string name="prestige_max">Макс. престиж</string>
     <string name="prestige_confirm_title" formatted="false">Престиж %s?</string>
     <string name="prestige_confirm_message_xp">Ваш уровень %1$s сбросится до 1, но вы получите постоянный бонус +%2$d%% опыта для этого навыка.</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -1319,6 +1319,7 @@
 
     <!-- Prestige system -->
     <string name="prestige">Prestige</string> <!-- untranslated -->
+    <string name="prestige_skill_tree">Skill Tree</string> <!-- untranslated -->
     <string name="prestige_max">Max Prestige</string> <!-- untranslated -->
     <string name="prestige_confirm_title" formatted="false">Prestige %s?</string> <!-- untranslated -->
     <string name="prestige_confirm_message_xp">Your %1$s level will reset to 1, but you\'ll earn a permanent +%2$d%% XP bonus for this skill.</string> <!-- untranslated -->

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -1319,6 +1319,7 @@
 
     <!-- Prestige system -->
     <string name="prestige">转生</string>
+    <string name="prestige_skill_tree">Skill Tree</string> <!-- untranslated -->
     <string name="prestige_max">满转生</string>
     <string name="prestige_confirm_title" formatted="false">Prestige %s?</string> <!-- untranslated -->
     <string name="prestige_confirm_message_xp">你的 %1$s 等级将重置为1级，但你将获得该技能永久 +%2$d%% 经验加成。</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1319,6 +1319,7 @@
 
     <!-- Prestige system -->
     <string name="prestige">Prestige</string>
+    <string name="prestige_skill_tree">Skill Tree</string>
     <string name="prestige_max">Max Prestige</string>
     <string name="prestige_confirm_title" formatted="false">Prestige %s?</string>
     <string name="prestige_confirm_message_xp">Your %1$s level will reset to 1, but you\'ll earn a permanent +%2$d%% XP bonus for this skill.</string>


### PR DESCRIPTION
## Before submitting

- [x] I've tested any changes with the appropriate tests (eg. Unit tests, validation scripts)
- [x] I've pulled and merged the latest changes from the repository

## Summary

Adds direct navigation from each skill's activity bottom sheet to its Prestige/Skill Tree screen, instead of requiring the player to close the sheet and tap Prestige from the skill list row.

<img width="885" height="647" alt="image" src="https://github.com/user-attachments/assets/f16f7e2e-ee85-48cc-a91e-822b2b3f35ac" />


## Related issue(s) or discussion(s)



## Changelog

- Added a row to each skill's activity bottom sheet with Quests (left) and a new "Skill Tree" button (right) which navigates to the Prestige Skill Tree.

## Anything else?