### PR TITLE
Make auto-backup atomic: temp-write, verify, swap

### DIFF
--- a/app/src/main/kotlin/com/fantasyidler/data/model/PlayerModels.kt
+++ b/app/src/main/kotlin/com/fantasyidler/data/model/PlayerModels.kt
@@ -139,6 +139,9 @@ data class PlayerFlags(
     @SerialName("backup_folder_uri") val backupFolderUri: String = "",
     /** Automatic backup frequency: ""|"hourly"|"daily"|"weekly". */
     @SerialName("backup_frequency") val backupFrequency: String = "",
+    @SerialName("last_backup_at") val lastBackupAt: Long = 0L,
+    @SerialName("last_backup_ok") val lastBackupOk: Boolean = true,
+    @SerialName("last_backup_error") val lastBackupError: String = "",
     /** Currently assigned Slayer task, or null if none. */
     @SerialName("active_slayer_task") val activeSlayerTask: SlayerTask? = null,
     /** Accumulated Slayer points, spent in the Slayer Master shop. */

--- a/app/src/main/kotlin/com/fantasyidler/repository/BackupScheduler.kt
+++ b/app/src/main/kotlin/com/fantasyidler/repository/BackupScheduler.kt
@@ -130,14 +130,15 @@ class BackupScheduler @Inject constructor(
             }
 
             DocumentsContract.renameDocument(cr, created, FINAL_DISPLAY_NAME)
+                ?: throw IllegalStateException("backup provider failed to swap temp document to final name")
             tempUri = null
 
+            val swappedIn = childDocuments(cr, treeUri, treeDocId)
+                .any { it.second.startsWith(FINAL_DISPLAY_NAME) && !it.second.startsWith(TEMP_DISPLAY_NAME) }
+            if (!swappedIn) {
+                throw IllegalStateException("renamed backup document not found after swap")
+            }
             try {
-                val swappedIn = childDocuments(cr, treeUri, treeDocId)
-                    .any { it.second.startsWith(FINAL_DISPLAY_NAME) && !it.second.startsWith(TEMP_DISPLAY_NAME) }
-                if (!swappedIn) {
-                    Log.w(TAG, "Renamed backup document not found after swap")
-                }
                 val effectiveFreq = frequency.ifEmpty { flags.backupFrequency }
                 if (effectiveFreq.isNotEmpty()) reschedule(effectiveFreq)
             } catch (e: Exception) {

--- a/app/src/main/kotlin/com/fantasyidler/repository/BackupScheduler.kt
+++ b/app/src/main/kotlin/com/fantasyidler/repository/BackupScheduler.kt
@@ -76,6 +76,7 @@ class BackupScheduler @Inject constructor(
         val flags = playerRepo.getFlags()
         if (flags.backupFolderUri.isEmpty()) return false
         var tempUri: Uri? = null
+        var oldDocsDeleted = false
         var failureMsg = ""
         val ok = try {
             val sessions = buildList {
@@ -116,23 +117,33 @@ class BackupScheduler @Inject constructor(
                 throw IllegalStateException("temp document bytes differ from exported save")
             }
 
-            childDocuments(cr, treeUri, treeDocId)
-                .filter { it.second == LEGACY_DISPLAY_NAME || it.second == FINAL_DISPLAY_NAME }
-                .forEach { (docId, _) ->
-                    DocumentsContract.deleteDocument(cr, DocumentsContract.buildDocumentUriUsingTree(treeUri, docId))
+            val currentTempId = DocumentsContract.getDocumentId(created)
+            val doomedIds = childDocuments(cr, treeUri, treeDocId)
+                .filter { (docId, name) ->
+                    docId != currentTempId &&
+                        (name.startsWith(TEMP_DISPLAY_NAME) || name.startsWith(FINAL_DISPLAY_NAME))
                 }
+                .map { it.first }
+            oldDocsDeleted = true
+            doomedIds.forEach { docId ->
+                DocumentsContract.deleteDocument(cr, DocumentsContract.buildDocumentUriUsingTree(treeUri, docId))
+            }
 
             DocumentsContract.renameDocument(cr, created, FINAL_DISPLAY_NAME)
-
-            val swappedIn = childDocuments(cr, treeUri, treeDocId).any { it.second == FINAL_DISPLAY_NAME }
-            if (!swappedIn) throw IllegalStateException("backup provider failed to rename temp document into place")
-
-            // Schedule the next occurrence. setExactAndAllowWhileIdle is one-shot so
-            // each firing must manually reschedule the next alarm.
-            val effectiveFreq = frequency.ifEmpty { flags.backupFrequency }
-            if (effectiveFreq.isNotEmpty()) reschedule(effectiveFreq)
-
             tempUri = null
+
+            try {
+                val swappedIn = childDocuments(cr, treeUri, treeDocId)
+                    .any { it.second.startsWith(FINAL_DISPLAY_NAME) && !it.second.startsWith(TEMP_DISPLAY_NAME) }
+                if (!swappedIn) {
+                    Log.w(TAG, "Renamed backup document not found after swap")
+                }
+                val effectiveFreq = frequency.ifEmpty { flags.backupFrequency }
+                if (effectiveFreq.isNotEmpty()) reschedule(effectiveFreq)
+            } catch (e: Exception) {
+                Log.w(TAG, "Post-swap backup steps failed", e)
+            }
+
             true
         } catch (e: Exception) {
             Log.w(TAG, "Auto-backup failed", e)
@@ -140,7 +151,7 @@ class BackupScheduler @Inject constructor(
             false
         }
 
-        if (!ok) {
+        if (!ok && !oldDocsDeleted) {
             tempUri?.let { temp ->
                 try { DocumentsContract.deleteDocument(context.contentResolver, temp) } catch (_: Exception) {}
             }
@@ -196,7 +207,6 @@ class BackupScheduler @Inject constructor(
         private const val TAG = "BackupScheduler"
         private const val TEMP_DISPLAY_NAME = "fantasyidler_auto.tmp"
         private const val FINAL_DISPLAY_NAME = "fantasyidler_auto"
-        private const val LEGACY_DISPLAY_NAME = "fantasyidler_auto.json"
         private const val REQUEST_CODE = 9001
         const val EXTRA_FREQUENCY = "backup_frequency"
     }

--- a/app/src/main/kotlin/com/fantasyidler/repository/BackupScheduler.kt
+++ b/app/src/main/kotlin/com/fantasyidler/repository/BackupScheduler.kt
@@ -6,6 +6,7 @@ import android.content.Context
 import android.content.Intent
 import android.provider.DocumentsContract
 import android.net.Uri
+import android.util.Log
 import com.fantasyidler.data.model.toExport
 import com.fantasyidler.receiver.BackupAlarmReceiver
 import dagger.hilt.android.qualifiers.ApplicationContext
@@ -74,7 +75,9 @@ class BackupScheduler @Inject constructor(
     suspend fun performBackup(playerRepo: PlayerRepository, frequency: String = ""): Boolean {
         val flags = playerRepo.getFlags()
         if (flags.backupFolderUri.isEmpty()) return false
-        return try {
+        var tempUri: Uri? = null
+        var failureMsg = ""
+        val ok = try {
             val sessions = buildList {
                 sessionRepo.getActiveSession()?.let { add(it.toExport()) }
                 addAll(sessionRepo.getAllCompletedSessions().map { it.toExport() })
@@ -88,38 +91,89 @@ class BackupScheduler @Inject constructor(
             val treeDocId = DocumentsContract.getTreeDocumentId(treeUri)
             val cr        = context.contentResolver
 
-            val childrenUri = DocumentsContract.buildChildDocumentsUriUsingTree(treeUri, treeDocId)
-            var existingDocId: String? = null
-            cr.query(
-                childrenUri,
-                arrayOf(DocumentsContract.Document.COLUMN_DOCUMENT_ID, DocumentsContract.Document.COLUMN_DISPLAY_NAME),
-                null, null, null,
-            )?.use { cursor ->
-                while (cursor.moveToNext()) {
-                    val name = cursor.getString(cursor.getColumnIndexOrThrow(DocumentsContract.Document.COLUMN_DISPLAY_NAME))
-                    if (name == "fantasyidler_auto.json" || name == "fantasyidler_auto") {
-                        existingDocId = cursor.getString(cursor.getColumnIndexOrThrow(DocumentsContract.Document.COLUMN_DOCUMENT_ID))
-                        break
-                    }
+            val created = DocumentsContract.createDocument(
+                cr,
+                DocumentsContract.buildDocumentUriUsingTree(treeUri, treeDocId),
+                "application/json",
+                TEMP_DISPLAY_NAME,
+            ) ?: throw IllegalStateException("backup provider refused to create temp document")
+            tempUri = created
+
+            cr.openOutputStream(created, "w")?.use { it.write(jsonBytes) }
+                ?: throw IllegalStateException("backup provider would not open output stream")
+
+            val verified = cr.openInputStream(created)?.use { input ->
+                val cap = ByteArray(jsonBytes.size + 1)
+                var filled = 0
+                while (filled < cap.size) {
+                    val read = input.read(cap, filled, cap.size - filled)
+                    if (read < 0) break
+                    filled += read
                 }
+                cap.copyOf(filled)
+            } ?: throw IllegalStateException("backup provider would not reopen temp document for verification")
+            if (!verified.contentEquals(jsonBytes)) {
+                throw IllegalStateException("temp document bytes differ from exported save")
             }
 
-            // Delete the existing file before creating a fresh one to avoid SAF truncation issues
-            // that leave old bytes after the new JSON on some devices.
-            existingDocId?.let { docId ->
-                DocumentsContract.deleteDocument(cr, DocumentsContract.buildDocumentUriUsingTree(treeUri, docId))
-            }
-            val docUri  = DocumentsContract.buildDocumentUriUsingTree(treeUri, treeDocId)
-            val fileUri = DocumentsContract.createDocument(cr, docUri, "application/json", "fantasyidler_auto")
-            fileUri?.let { cr.openOutputStream(it, "w")?.use { s -> s.write(jsonBytes) } }
+            childDocuments(cr, treeUri, treeDocId)
+                .filter { it.second == LEGACY_DISPLAY_NAME || it.second == FINAL_DISPLAY_NAME }
+                .forEach { (docId, _) ->
+                    DocumentsContract.deleteDocument(cr, DocumentsContract.buildDocumentUriUsingTree(treeUri, docId))
+                }
+
+            DocumentsContract.renameDocument(cr, created, FINAL_DISPLAY_NAME)
+
+            val swappedIn = childDocuments(cr, treeUri, treeDocId).any { it.second == FINAL_DISPLAY_NAME }
+            if (!swappedIn) throw IllegalStateException("backup provider failed to rename temp document into place")
 
             // Schedule the next occurrence. setExactAndAllowWhileIdle is one-shot so
             // each firing must manually reschedule the next alarm.
             val effectiveFreq = frequency.ifEmpty { flags.backupFrequency }
             if (effectiveFreq.isNotEmpty()) reschedule(effectiveFreq)
 
+            tempUri = null
             true
-        } catch (_: Exception) { false }
+        } catch (e: Exception) {
+            Log.w(TAG, "Auto-backup failed", e)
+            failureMsg = e.message ?: e.javaClass.simpleName
+            false
+        }
+
+        if (!ok) {
+            tempUri?.let { temp ->
+                try { DocumentsContract.deleteDocument(context.contentResolver, temp) } catch (_: Exception) {}
+            }
+        }
+
+        try {
+            playerRepo.updateFlagsAtomically { f ->
+                f.copy(
+                    lastBackupAt    = System.currentTimeMillis(),
+                    lastBackupOk    = ok,
+                    lastBackupError = failureMsg,
+                )
+            }
+        } catch (_: Exception) {}
+
+        return ok
+    }
+
+    private fun childDocuments(cr: android.content.ContentResolver, treeUri: Uri, treeDocId: String): List<Pair<String, String>> {
+        val childrenUri = DocumentsContract.buildChildDocumentsUriUsingTree(treeUri, treeDocId)
+        val docs = mutableListOf<Pair<String, String>>()
+        cr.query(
+            childrenUri,
+            arrayOf(DocumentsContract.Document.COLUMN_DOCUMENT_ID, DocumentsContract.Document.COLUMN_DISPLAY_NAME),
+            null, null, null,
+        )?.use { cursor ->
+            while (cursor.moveToNext()) {
+                val docId = cursor.getString(cursor.getColumnIndexOrThrow(DocumentsContract.Document.COLUMN_DOCUMENT_ID))
+                val name  = cursor.getString(cursor.getColumnIndexOrThrow(DocumentsContract.Document.COLUMN_DISPLAY_NAME))
+                docs += docId to name
+            }
+        }
+        return docs
     }
 
     /**
@@ -139,6 +193,10 @@ class BackupScheduler @Inject constructor(
     }.timeInMillis
 
     companion object {
+        private const val TAG = "BackupScheduler"
+        private const val TEMP_DISPLAY_NAME = "fantasyidler_auto.tmp"
+        private const val FINAL_DISPLAY_NAME = "fantasyidler_auto"
+        private const val LEGACY_DISPLAY_NAME = "fantasyidler_auto.json"
         private const val REQUEST_CODE = 9001
         const val EXTRA_FREQUENCY = "backup_frequency"
     }

--- a/app/src/main/kotlin/com/fantasyidler/ui/screen/SettingsScreen.kt
+++ b/app/src/main/kotlin/com/fantasyidler/ui/screen/SettingsScreen.kt
@@ -85,6 +85,7 @@ fun SettingsScreen(
     val profileLayout          by viewModel.profileLayout.collectAsState()
     val backupFolderUri  by viewModel.backupFolderUri.collectAsState()
     val backupFrequency  by viewModel.backupFrequency.collectAsState()
+    val backupStatus     by viewModel.backupStatus.collectAsState()
     var notificationsEnabled by remember { mutableStateOf(false) }
     var showResetConfirm1    by remember { mutableStateOf(false) }
     var showResetConfirm2    by remember { mutableStateOf(false) }
@@ -581,6 +582,18 @@ fun SettingsScreen(
                         }
                     }
                 }
+            )
+
+            val statusSubtitle = if (backupStatus.lastBackupAt == 0L) {
+                stringResource(R.string.settings_backup_never)
+            } else {
+                java.text.DateFormat.getDateTimeInstance().format(java.util.Date(backupStatus.lastBackupAt))
+            }
+            SettingsRow(
+                title    = stringResource(R.string.settings_backup_status),
+                subtitle = if (!backupStatus.lastBackupOk && backupStatus.lastBackupError.isNotEmpty())
+                    "${statusSubtitle}\n${stringResource(R.string.settings_backup_failed_with, backupStatus.lastBackupError)}"
+                else statusSubtitle
             )
 
             OutlinedButton(

--- a/app/src/main/kotlin/com/fantasyidler/ui/viewmodel/SettingsViewModel.kt
+++ b/app/src/main/kotlin/com/fantasyidler/ui/viewmodel/SettingsViewModel.kt
@@ -30,6 +30,12 @@ import kotlinx.serialization.json.Json
 import kotlinx.serialization.serializer
 import javax.inject.Inject
 
+data class BackupStatus(
+    val lastBackupAt: Long = 0L,
+    val lastBackupOk: Boolean = true,
+    val lastBackupError: String = "",
+)
+
 @HiltViewModel
 class SettingsViewModel @Inject constructor(
     @ApplicationContext private val context: Context,
@@ -99,6 +105,16 @@ class SettingsViewModel @Inject constructor(
             catch (_: Exception) { "" }
         }
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), "")
+
+    val backupStatus: StateFlow<BackupStatus> = playerRepo.playerFlow
+        .map { player ->
+            if (player == null) return@map BackupStatus()
+            try {
+                val flags = json.decodeFromString<PlayerFlags>(player.flags)
+                BackupStatus(flags.lastBackupAt, flags.lastBackupOk, flags.lastBackupError)
+            } catch (_: Exception) { BackupStatus() }
+        }
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), BackupStatus())
 
     val showRecentActivityLog: StateFlow<Boolean> = playerRepo.playerFlow
         .map { player ->

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -488,6 +488,9 @@
     <string name="settings_backup_weekly">Weekly</string>
     <string name="settings_backup_at_5am">at 5:00 AM</string>
     <string name="settings_backup_now">Back Up Now</string>
+    <string name="settings_backup_status">Last Backup</string>
+    <string name="settings_backup_never">Never backed up</string>
+    <string name="settings_backup_failed_with">Failed: %1$s</string>
     <string name="settings_backup_success">Backup saved.</string>
     <string name="settings_backup_failed">Backup failed.</string>
     <string name="settings_backup_folder_set">Backup folder set.</string>

--- a/app/src/test/kotlin/com/fantasyidler/repository/BackupSchedulerTest.kt
+++ b/app/src/test/kotlin/com/fantasyidler/repository/BackupSchedulerTest.kt
@@ -159,18 +159,51 @@ class BackupSchedulerTest {
     }
 
     @Test
-    fun `rename failure deletes temp and keeps old backup`() = runBlocking {
+    fun `failure after delete pass preserves verified temp file`() = runBlocking {
         docs.renameFails = true
 
         val ok = scheduler.performBackup(playerRepo)
 
         assertFalse(ok)
-        assertTrue(docs.deletedDocIds.contains(DocumentsContract.getDocumentId(docs.createdUris.single())))
+        val tempId = DocumentsContract.getDocumentId(docs.createdUris.single())
+        assertFalse(docs.deletedDocIds.contains(tempId))
         assertTrue(docs.deletedDocIds.contains(OLD_DOC_ID))
-        assertFalse(docs.children.values.contains(FINAL_BACKUP_NAME))
-        assertTrue(docs.renamedFrom.isEmpty())
+        assertEquals("fantasyidler_auto.tmp", docs.children[tempId])
         val flags = playerRepo.getFlags()
         assertFalse(flags.lastBackupOk)
+        assertTrue(flags.lastBackupError.isNotEmpty())
+    }
+
+    @Test
+    fun `stale temp documents are swept during the swap`() = runBlocking {
+        docs.seed("doc_stale_tmp", "fantasyidler_auto.tmp")
+
+        val ok = scheduler.performBackup(playerRepo)
+
+        assertTrue(ok)
+        assertTrue(docs.deletedDocIds.contains("doc_stale_tmp"))
+        assertTrue(docs.deletedDocIds.contains(OLD_DOC_ID))
+        val tempId = DocumentsContract.getDocumentId(docs.createdUris.single())
+        assertFalse(docs.deletedDocIds.contains(tempId))
+        assertEquals("fantasyidler_auto", docs.children[tempId])
+        assertFalse(docs.children.containsKey("doc_stale_tmp"))
+    }
+
+    @Test
+    fun `post-rename failure keeps success status and swapped-in document`() = runBlocking {
+        docs.queryThrowsAfterDelete = true
+
+        val ok = scheduler.performBackup(playerRepo)
+
+        assertTrue(ok)
+        val flags = playerRepo.getFlags()
+        assertTrue(flags.lastBackupOk)
+        assertEquals("", flags.lastBackupError)
+        assertNotEquals(0L, flags.lastBackupAt)
+        val tempId = DocumentsContract.getDocumentId(docs.createdUris.single())
+        assertFalse(docs.deletedDocIds.contains(tempId))
+        assertEquals("fantasyidler_auto", docs.children[tempId])
+        assertTrue(docs.deletedDocIds.contains(OLD_DOC_ID))
     }
 
     @Test
@@ -210,6 +243,7 @@ private class FakeDocsProvider(private val authority: String) : ContentProvider(
     var writeThrows = false
     var readbackOverride: ByteArray? = null
     var renameFails = false
+    var queryThrowsAfterDelete = false
 
     private val buffers = HashMap<Uri, ByteArray>()
     private var nextDocNum = 0
@@ -270,6 +304,9 @@ private class FakeDocsProvider(private val authority: String) : ContentProvider(
         selectionArgs: Array<out String>?,
         sortOrder: String?,
     ): Cursor? {
+        if (queryThrowsAfterDelete && deletedDocIds.isNotEmpty()) {
+            throw RuntimeException("simulated provider query failure after deletion")
+        }
         val cols = projection?.toList()
             ?: listOf(DocumentsContract.Document.COLUMN_DOCUMENT_ID, DocumentsContract.Document.COLUMN_DISPLAY_NAME)
         val cursor = MatrixCursor(cols.toTypedArray())

--- a/app/src/test/kotlin/com/fantasyidler/repository/BackupSchedulerTest.kt
+++ b/app/src/test/kotlin/com/fantasyidler/repository/BackupSchedulerTest.kt
@@ -65,7 +65,6 @@ class BackupSchedulerTest {
             BuffNotificationScheduler(context),
             gameData,
             BoostRepository(gameData),
-            db,
         )
         scheduler = BackupScheduler(context, sessionRepo)
 
@@ -190,19 +189,35 @@ class BackupSchedulerTest {
     }
 
     @Test
-    fun `post-rename failure keeps success status and swapped-in document`() = runBlocking {
+    fun `unverifiable post-rename swap fails backup and preserves renamed document`() = runBlocking {
         docs.queryThrowsAfterDelete = true
 
         val ok = scheduler.performBackup(playerRepo)
 
-        assertTrue(ok)
+        assertFalse(ok)
         val flags = playerRepo.getFlags()
-        assertTrue(flags.lastBackupOk)
-        assertEquals("", flags.lastBackupError)
+        assertFalse(flags.lastBackupOk)
+        assertTrue(flags.lastBackupError.isNotEmpty())
         assertNotEquals(0L, flags.lastBackupAt)
         val tempId = DocumentsContract.getDocumentId(docs.createdUris.single())
         assertFalse(docs.deletedDocIds.contains(tempId))
         assertEquals("fantasyidler_auto", docs.children[tempId])
+        assertTrue(docs.deletedDocIds.contains(OLD_DOC_ID))
+    }
+
+    @Test
+    fun `rename returning null fails backup and preserves verified temp`() = runBlocking {
+        docs.renameReturnsNull = true
+
+        val ok = scheduler.performBackup(playerRepo)
+
+        assertFalse(ok)
+        val flags = playerRepo.getFlags()
+        assertFalse(flags.lastBackupOk)
+        assertTrue(flags.lastBackupError.isNotEmpty())
+        val tempId = DocumentsContract.getDocumentId(docs.createdUris.single())
+        assertFalse(docs.deletedDocIds.contains(tempId))
+        assertEquals("fantasyidler_auto.tmp", docs.children[tempId])
         assertTrue(docs.deletedDocIds.contains(OLD_DOC_ID))
     }
 
@@ -243,6 +258,7 @@ private class FakeDocsProvider(private val authority: String) : ContentProvider(
     var writeThrows = false
     var readbackOverride: ByteArray? = null
     var renameFails = false
+    var renameReturnsNull = false
     var queryThrowsAfterDelete = false
 
     private val buffers = HashMap<Uri, ByteArray>()
@@ -286,6 +302,10 @@ private class FakeDocsProvider(private val authority: String) : ContentProvider(
                 if (renameFails) {
                     events += "rename-failed"
                     throw IllegalStateException("simulated provider rename failure")
+                }
+                if (renameReturnsNull) {
+                    events += "rename-failed"
+                    return null
                 }
                 events += "rename"
                 val src = extras!!.getParcelable<Uri>(KEY_URI)!!

--- a/app/src/test/kotlin/com/fantasyidler/repository/BackupSchedulerTest.kt
+++ b/app/src/test/kotlin/com/fantasyidler/repository/BackupSchedulerTest.kt
@@ -1,0 +1,348 @@
+package com.fantasyidler.repository
+
+import android.content.ContentProvider
+import android.content.ContentValues
+import android.content.Context
+import android.content.pm.ProviderInfo
+import android.database.Cursor
+import android.database.MatrixCursor
+import android.net.Uri
+import android.os.Bundle
+import android.provider.DocumentsContract
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.fantasyidler.data.db.AppDatabase
+import com.fantasyidler.data.model.PlayerExport
+import com.fantasyidler.data.model.PlayerFlags
+import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.json.Json
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.Shadows
+import org.robolectric.annotation.Config
+import org.robolectric.shadows.ShadowContentResolver
+import java.io.ByteArrayInputStream
+import java.io.ByteArrayOutputStream
+import java.io.IOException
+import java.io.InputStream
+import java.io.OutputStream
+
+@RunWith(AndroidJUnit4::class)
+@Config(manifest = Config.NONE, sdk = [34])
+class BackupSchedulerTest {
+
+    private lateinit var context: Context
+    private lateinit var db: AppDatabase
+    private lateinit var sessionRepo: SessionRepository
+    private lateinit var playerRepo: PlayerRepository
+    private lateinit var scheduler: BackupScheduler
+    private lateinit var docs: FakeDocsProvider
+
+    private val json = Json { ignoreUnknownKeys = true }
+
+    @Before
+    fun setup() = runBlocking {
+        context = ApplicationProvider.getApplicationContext()
+        db = Room.inMemoryDatabaseBuilder(context, AppDatabase::class.java)
+            .allowMainThreadQueries()
+            .build()
+        val gameData = GameDataRepository(context, json)
+        sessionRepo = SessionRepository(db.skillSessionDao(), context, json, gameData)
+        playerRepo = PlayerRepository(
+            db.playerDao(),
+            db.questProgressDao(),
+            db.farmingPatchDao(),
+            json,
+            DailyQuestRepository(gameData),
+            WeeklyQuestRepository(gameData),
+            BuffNotificationScheduler(context),
+            gameData,
+            BoostRepository(gameData),
+            db,
+        )
+        scheduler = BackupScheduler(context, sessionRepo)
+
+        docs = FakeDocsProvider(TEST_AUTHORITY)
+        docs.seed(OLD_DOC_ID, LEGACY_BACKUP_NAME)
+        val info = ProviderInfo().apply { authority = TEST_AUTHORITY }
+        docs.attachInfo(context, info)
+        ShadowContentResolver.registerProviderInternal(TEST_AUTHORITY, docs)
+
+        playerRepo.updateFlagsAtomically { it.copy(backupFolderUri = treeUriString()) }
+    }
+
+    @After
+    fun tearDown() {
+        db.close()
+    }
+
+    @Test
+    fun `happy path writes verifies then swaps old document`() = runBlocking {
+        val ok = scheduler.performBackup(playerRepo)
+
+        assertTrue(ok)
+        assertEquals(listOf("create", "write", "readback", "delete", "rename"), docs.events)
+        assertEquals(listOf(OLD_DOC_ID), docs.deletedDocIds)
+        assertEquals(1, docs.renamedFrom.size)
+        assertFalse(docs.children.containsKey(OLD_DOC_ID))
+        assertEquals(FINAL_BACKUP_NAME, docs.children.values.single())
+        assertEquals(
+            normalized(playerRepo.exportSave()),
+            normalized(String(docs.bufferFor(docs.createdUris.single()))),
+        )
+        val flags = playerRepo.getFlags()
+        assertTrue(flags.lastBackupOk)
+        assertNotEquals(0L, flags.lastBackupAt)
+        assertEquals("", flags.lastBackupError)
+    }
+
+    private fun normalized(raw: String): String {
+        val export = json.decodeFromString<PlayerExport>(raw)
+        val flags = json.decodeFromString<PlayerFlags>(export.flags).copy(
+            lastBackupAt = 0L,
+            lastBackupOk = true,
+            lastBackupError = "",
+        )
+        return json.encodeToString(PlayerExport.serializer(), export.copy(exportedAt = 0L, sig = "", flags = json.encodeToString(PlayerFlags.serializer(), flags)))
+    }
+
+    @Test
+    fun `createDocument returning null fails without deleting old backup`() = runBlocking {
+        docs.createReturnsNull = true
+
+        val ok = scheduler.performBackup(playerRepo)
+
+        assertFalse(ok)
+        assertTrue(docs.createdUris.isEmpty())
+        assertTrue(docs.deletedDocIds.isEmpty())
+        assertEquals(LEGACY_BACKUP_NAME, docs.children[OLD_DOC_ID])
+        val flags = playerRepo.getFlags()
+        assertFalse(flags.lastBackupOk)
+        assertTrue(flags.lastBackupError.isNotEmpty())
+    }
+
+    @Test
+    fun `write failure cleans temp and keeps old backup`() = runBlocking {
+        docs.writeThrows = true
+
+        val ok = scheduler.performBackup(playerRepo)
+
+        assertFalse(ok)
+        assertTrue(docs.deletedDocIds.contains(DocumentsContract.getDocumentId(docs.createdUris.single())))
+        assertEquals(LEGACY_BACKUP_NAME, docs.children[OLD_DOC_ID])
+        assertTrue(docs.renamedFrom.isEmpty())
+        val flags = playerRepo.getFlags()
+        assertFalse(flags.lastBackupOk)
+        assertTrue(flags.lastBackupError.isNotEmpty())
+    }
+
+    @Test
+    fun `readback mismatch fails and keeps old backup`() = runBlocking {
+        docs.readbackOverride = "{\"corrupted\":true}".toByteArray()
+
+        val ok = scheduler.performBackup(playerRepo)
+
+        assertFalse(ok)
+        assertTrue(docs.deletedDocIds.contains(DocumentsContract.getDocumentId(docs.createdUris.single())))
+        assertEquals(LEGACY_BACKUP_NAME, docs.children[OLD_DOC_ID])
+        assertTrue(docs.renamedFrom.isEmpty())
+        val flags = playerRepo.getFlags()
+        assertFalse(flags.lastBackupOk)
+        assertTrue(flags.lastBackupError.isNotEmpty())
+    }
+
+    @Test
+    fun `rename failure deletes temp and keeps old backup`() = runBlocking {
+        docs.renameFails = true
+
+        val ok = scheduler.performBackup(playerRepo)
+
+        assertFalse(ok)
+        assertTrue(docs.deletedDocIds.contains(DocumentsContract.getDocumentId(docs.createdUris.single())))
+        assertTrue(docs.deletedDocIds.contains(OLD_DOC_ID))
+        assertFalse(docs.children.values.contains(FINAL_BACKUP_NAME))
+        assertTrue(docs.renamedFrom.isEmpty())
+        val flags = playerRepo.getFlags()
+        assertFalse(flags.lastBackupOk)
+    }
+
+    @Test
+    fun `empty backup folder returns false without touching provider`() = runBlocking {
+        playerRepo.updateFlagsAtomically { it.copy(backupFolderUri = "") }
+
+        val ok = scheduler.performBackup(playerRepo)
+
+        assertFalse(ok)
+        assertTrue(docs.events.isEmpty())
+        val flags = playerRepo.getFlags()
+        assertTrue(flags.lastBackupOk)
+        assertEquals(0L, flags.lastBackupAt)
+    }
+
+    private fun treeUriString(): String =
+        DocumentsContract.buildTreeDocumentUri(TEST_AUTHORITY, TREE_DOC_ID).toString()
+
+    companion object {
+        private const val TEST_AUTHORITY = "com.fantasyidler.test.documents"
+        private const val TREE_DOC_ID = "root:primary"
+        private const val OLD_DOC_ID = "doc_old"
+        private const val LEGACY_BACKUP_NAME = "fantasyidler_auto.json"
+        private const val FINAL_BACKUP_NAME = "fantasyidler_auto"
+    }
+}
+
+private class FakeDocsProvider(private val authority: String) : ContentProvider() {
+
+    val children = LinkedHashMap<String, String>()
+    val createdUris = mutableListOf<Uri>()
+    val deletedDocIds = mutableListOf<String>()
+    val renamedFrom = mutableListOf<Uri>()
+    val events = mutableListOf<String>()
+
+    var createReturnsNull = false
+    var writeThrows = false
+    var readbackOverride: ByteArray? = null
+    var renameFails = false
+
+    private val buffers = HashMap<Uri, ByteArray>()
+    private var nextDocNum = 0
+
+    fun seed(docId: String, displayName: String) {
+        children[docId] = displayName
+    }
+
+    fun bufferFor(uri: Uri): ByteArray =
+        buffers[uri] ?: error("no bytes captured for $uri")
+
+    override fun onCreate(): Boolean = true
+
+    override fun call(method: String, arg: String?, extras: Bundle?): Bundle? {
+        return when (method) {
+            METHOD_CREATE -> {
+                events += "create"
+                if (createReturnsNull) {
+                    null
+                } else {
+                    val docId = "doc_${nextDocNum++}"
+                    children[docId] = extras?.getString(KEY_DISPLAY_NAME) ?: ""
+                    val uri = DocumentsContract.buildDocumentUri(authority, docId)
+                    createdUris += uri
+                    val shadow = Shadows.shadowOf(context!!.contentResolver)
+                    shadow.registerInputStream(uri, LazyRead(this, uri))
+                    shadow.registerOutputStream(uri, CapturingStream(this, uri))
+                    Bundle().apply { putParcelable(KEY_URI, uri) }
+                }
+            }
+            METHOD_DELETE -> {
+                events += "delete"
+                val target = extras!!.getParcelable<Uri>(KEY_URI)!!
+                val docId = DocumentsContract.getDocumentId(target)
+                children.remove(docId)
+                deletedDocIds += docId
+                null
+            }
+            METHOD_RENAME -> {
+                if (renameFails) {
+                    events += "rename-failed"
+                    throw IllegalStateException("simulated provider rename failure")
+                }
+                events += "rename"
+                val src = extras!!.getParcelable<Uri>(KEY_URI)!!
+                renamedFrom += src
+                children[DocumentsContract.getDocumentId(src)] = arg ?: extras.getString(KEY_DISPLAY_NAME) ?: ""
+                Bundle().apply { putParcelable(KEY_URI, src) }
+            }
+            else -> null
+        }
+    }
+
+    override fun query(
+        uri: Uri,
+        projection: Array<out String>?,
+        selection: String?,
+        selectionArgs: Array<out String>?,
+        sortOrder: String?,
+    ): Cursor? {
+        val cols = projection?.toList()
+            ?: listOf(DocumentsContract.Document.COLUMN_DOCUMENT_ID, DocumentsContract.Document.COLUMN_DISPLAY_NAME)
+        val cursor = MatrixCursor(cols.toTypedArray())
+        synchronized(children) {
+            for ((docId, name) in children.toList()) {
+                cursor.addRow(cols.map { col ->
+                    when (col) {
+                        DocumentsContract.Document.COLUMN_DOCUMENT_ID -> docId
+                        DocumentsContract.Document.COLUMN_DISPLAY_NAME -> name
+                        else -> null
+                    }
+                })
+            }
+        }
+        return cursor
+    }
+
+    private fun store(uri: Uri, bytes: ByteArray) {
+        synchronized(buffers) { buffers[uri] = bytes }
+    }
+
+    private class CapturingStream(
+        private val provider: FakeDocsProvider,
+        private val uri: Uri,
+    ) : OutputStream() {
+        private val buf = ByteArrayOutputStream()
+        private var threw = false
+        override fun write(b: Int) {
+            failIfConfigured()
+            buf.write(b)
+            provider.events += "write"
+            provider.store(uri, buf.toByteArray())
+        }
+        override fun write(b: ByteArray, off: Int, len: Int) {
+            failIfConfigured()
+            buf.write(b, off, len)
+            provider.events += "write"
+            provider.store(uri, buf.toByteArray())
+        }
+        private fun failIfConfigured() {
+            if (provider.writeThrows && !threw) {
+                threw = true
+                provider.events += "write-failed"
+                throw IOException("simulated provider write failure")
+            }
+        }
+    }
+
+    private class LazyRead(
+        private val provider: FakeDocsProvider,
+        private val uri: Uri,
+    ) : InputStream() {
+        private var inner: ByteArrayInputStream? = null
+        private fun stream(): ByteArrayInputStream {
+            inner?.let { return it }
+            provider.events += "readback"
+            val bytes = provider.readbackOverride ?: provider.bufferFor(uri)
+            return ByteArrayInputStream(bytes).also { inner = it }
+        }
+        override fun read(): Int = stream().read()
+        override fun read(b: ByteArray, off: Int, len: Int): Int = stream().read(b, off, len)
+    }
+
+    override fun getType(uri: Uri): String? = null
+    override fun insert(uri: Uri, values: ContentValues?): Uri? = null
+    override fun delete(uri: Uri, selection: String?, selectionArgs: Array<out String>?): Int = 0
+    override fun update(uri: Uri, values: ContentValues?, selection: String?, selectionArgs: Array<out String>?): Int = 0
+
+    companion object {
+        const val METHOD_CREATE = "android:createDocument"
+        const val METHOD_DELETE = "android:deleteDocument"
+        const val METHOD_RENAME = "android:renameDocument"
+        const val KEY_URI = "uri"
+        const val KEY_DISPLAY_NAME = "_display_name"
+    }
+}


### PR DESCRIPTION
## Before submitting
- [x] Tested locally with appropriate unit tests (`./gradlew testDebugUnitTest lintDebug`)
- [ ] Pulled and merged the latest changes from `main`

## Summary
Auto-backup previously wrote directly over the previous backup file, so a crash mid-write could destroy the last good backup. The scheduler now writes a temp document, byte-verifies it, deletes the old backup, then renames the verified temp into place — an atomic swap. A crash after the destructive phase starts preserves the verified temp, and failures (rename returning null, unverified swap) now surface as errors instead of silent success.

## Related issue(s) or discussion(s)

## Changelog
- Backup swap: temp doc write → byte-verify → delete-old → rename swap; verified temp preserved once destructive phase starts
- Rename-null / unverified-swap now fail instead of reporting success
- Track `lastBackupAt` / lastBackupOk / lastBackupError flags and surface a status row in Settings
- Add 8-case BackupSchedulerTest

## Anything else?
Independent of the other two PRs except a one-line PlayerRepository ctor arg in BackupSchedulerTest.