### PR TITLE
Add guild daily quests and prestige link to Slayer screen

### DIFF
--- a/app/src/main/kotlin/com/fantasyidler/ui/navigation/AppNavigation.kt
+++ b/app/src/main/kotlin/com/fantasyidler/ui/navigation/AppNavigation.kt
@@ -374,6 +374,7 @@ fun AppNavigation(
             paneComposable(Screen.Slayer.route) { entry ->
                 SlayerScreen(
                     onBack = { if (navController.currentBackStackEntry == entry) navController.popBackStack() },
+                    onNavigateToPrestige = { skill -> navController.navigate(Screen.PrestigeDetail.createRoute(skill)) },
                 )
             }
             paneComposable(Screen.BoneAltar.route) { entry ->

--- a/app/src/main/kotlin/com/fantasyidler/ui/screen/SlayerScreen.kt
+++ b/app/src/main/kotlin/com/fantasyidler/ui/screen/SlayerScreen.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -22,6 +23,7 @@ import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.WindowInsetsSides
 import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.safeDrawing
+import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.BottomSheetDefaults
 import androidx.compose.material3.Button
 import androidx.compose.material3.CircularProgressIndicator
@@ -43,7 +45,9 @@ import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
@@ -53,9 +57,11 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.compose.ui.platform.LocalContext
 import com.fantasyidler.R
 import com.fantasyidler.data.json.EquipmentData
+import com.fantasyidler.data.model.Skills
 import com.fantasyidler.data.model.SlayerTask
 import com.fantasyidler.util.GameStrings
 import com.fantasyidler.ui.components.LampSkillDialog
+import com.fantasyidler.ui.viewmodel.SheetQuestSource
 import com.fantasyidler.ui.viewmodel.SlayerViewModel
 import com.fantasyidler.ui.viewmodel.xpProgressFraction
 import com.fantasyidler.ui.theme.ScaledSheetContent
@@ -84,14 +90,19 @@ private val SHOP_ITEMS = listOf(
 @Composable
 fun SlayerScreen(
     onBack: () -> Unit = {},
+    onNavigateToPrestige: (String) -> Unit = {},
     viewModel: SlayerViewModel = hiltViewModel(),
 ) {
     val state by viewModel.uiState.collectAsState()
+    val context = LocalContext.current
+    val quests = state.slayerQuests
+    val guildMaxed = quests.any { it.source == SheetQuestSource.GUILD && it.guildMaxed }
+    val anyOpen = quests.any { !it.claimed && !(it.source == SheetQuestSource.GUILD && it.guildMaxed) }
+    var showQuestsDialog by remember { mutableStateOf(false) }
 
     AppBannerEffect(state.snackbarMessage, viewModel::snackbarConsumed)
 
     state.pendingSlayerDungeonKey?.let { dungeonKey ->
-        val context = LocalContext.current
         val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
         val dungeonName = GameStrings.dungeonName(context, dungeonKey)
         ModalBottomSheet(
@@ -112,6 +123,84 @@ fun SlayerScreen(
             )
             }
         }
+    }
+
+    if (showQuestsDialog) {
+        val sections = listOf(
+            SheetQuestSource.GUILD  to R.string.guild_daily_button,
+            SheetQuestSource.DAILY  to R.string.label_daily,
+            SheetQuestSource.WEEKLY to R.string.label_weekly,
+        ).mapNotNull { (source, labelRes) ->
+            quests.filter { it.source == source }.takeIf { it.isNotEmpty() }?.let { labelRes to it }
+        }
+        AlertDialog(
+            onDismissRequest = { showQuestsDialog = false },
+            title = { Text(stringResource(R.string.nav_quests)) },
+            text = {
+                Column(Modifier.verticalScroll(rememberScrollState())) {
+                    sections.forEachIndexed { sectionIndex, (labelRes, sectionQuests) ->
+                        if (sectionIndex > 0) {
+                            Spacer(Modifier.height(12.dp))
+                        }
+                        Text(
+                            text       = stringResource(labelRes),
+                            style      = MaterialTheme.typography.labelMedium,
+                            fontWeight = FontWeight.Bold,
+                            color      = MaterialTheme.colorScheme.primary,
+                        )
+                        Spacer(Modifier.height(4.dp))
+                        sectionQuests.forEachIndexed { index, quest ->
+                            if (index > 0) {
+                                Spacer(Modifier.height(8.dp))
+                                HorizontalDivider()
+                                Spacer(Modifier.height(8.dp))
+                            }
+                            Column {
+                                Text(
+                                    text       = GameStrings.questName(context, quest.questId, quest.questName),
+                                    style      = MaterialTheme.typography.bodyMedium,
+                                    fontWeight = FontWeight.SemiBold,
+                                )
+                                Spacer(Modifier.height(2.dp))
+                                Text(
+                                    text  = when (quest.source) {
+                                        SheetQuestSource.GUILD  -> localizedQuestDesc(quest.type, quest.target, quest.amount, quest.guild)
+                                        SheetQuestSource.DAILY  -> buildDailyObjective(context, quest.guild, quest.target, quest.amount, quest.description)
+                                        SheetQuestSource.WEEKLY -> GameStrings.questDesc(context, quest.questId)
+                                            .takeIf { it.isNotBlank() } ?: quest.description
+                                    },
+                                    style = MaterialTheme.typography.bodySmall,
+                                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                )
+                                Spacer(Modifier.height(4.dp))
+                                Text(
+                                    text  = when {
+                                        quest.claimed                  -> stringResource(R.string.guild_daily_banner_claimed)
+                                        quest.progress >= quest.amount -> stringResource(R.string.guild_daily_banner_claimable)
+                                        else                            -> "${quest.progress} / ${quest.amount}"
+                                    },
+                                    style = MaterialTheme.typography.labelMedium,
+                                    color = MaterialTheme.colorScheme.primary,
+                                )
+                            }
+                        }
+                    }
+                    if (guildMaxed) {
+                        Spacer(Modifier.height(8.dp))
+                        Text(
+                            text  = stringResource(R.string.guild_daily_rank_maxed),
+                            style = MaterialTheme.typography.labelSmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                    }
+                }
+            },
+            confirmButton = {
+                TextButton(onClick = { showQuestsDialog = false }) {
+                    Text(stringResource(R.string.btn_close))
+                }
+            },
+        )
     }
 
     Scaffold(
@@ -136,6 +225,7 @@ fun SlayerScreen(
             return@Scaffold
         }
 
+
         Column(
             modifier = Modifier
                 .fillMaxSize()
@@ -150,6 +240,49 @@ fun SlayerScreen(
                 xp           = state.slayerXp,
                 slayerPoints = state.slayerPoints,
             )
+
+
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 8.dp),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.SpaceBetween,
+            ) {
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    TextButton(
+                        onClick        = { showQuestsDialog = true },
+                        enabled        = quests.isNotEmpty(),
+                        contentPadding = PaddingValues(horizontal = 8.dp, vertical = 0.dp),
+                        modifier       = Modifier.height(24.dp)
+                    ) {
+                        Text(
+                            text  = stringResource(R.string.nav_quests),
+                            style = MaterialTheme.typography.labelMedium,
+                            color = if (anyOpen) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                    }
+                    if (guildMaxed) {
+                        Text(
+                            text     = stringResource(R.string.guild_daily_rank_maxed),
+                            style    = MaterialTheme.typography.labelSmall,
+                            color    = MaterialTheme.colorScheme.onSurfaceVariant,
+                            modifier = Modifier.padding(start = 8.dp),
+                        )
+                    }
+                }
+                TextButton(
+                    onClick = { onNavigateToPrestige(Skills.SLAYER) },
+                    contentPadding = PaddingValues(horizontal = 8.dp, vertical = 0.dp),
+                    modifier       = Modifier.height(24.dp)
+                ) {
+                    Text(
+                        text  = stringResource(R.string.prestige_skill_tree),
+                        style = MaterialTheme.typography.labelMedium,
+                        color = MaterialTheme.colorScheme.primary,
+                    )
+                }
+            }
 
             HorizontalDivider()
 

--- a/app/src/main/kotlin/com/fantasyidler/ui/viewmodel/SlayerViewModel.kt
+++ b/app/src/main/kotlin/com/fantasyidler/ui/viewmodel/SlayerViewModel.kt
@@ -11,12 +11,16 @@ import com.fantasyidler.data.model.Skills
 import com.fantasyidler.data.model.SlayerTask
 import com.fantasyidler.simulator.SkillSimulator
 import com.fantasyidler.repository.BoostRepository
+import com.fantasyidler.repository.DailyQuestRepository
 import com.fantasyidler.repository.ForetelResult
 import com.fantasyidler.repository.GameDataRepository
+import com.fantasyidler.repository.GuildRepository
 import com.fantasyidler.repository.PlayerRepository
+import com.fantasyidler.repository.QuestRepository
 import com.fantasyidler.repository.QueuedSessionStarter
 import com.fantasyidler.repository.SlayerRepository
 import com.fantasyidler.repository.TownRepository
+import com.fantasyidler.repository.WeeklyQuestRepository
 import com.fantasyidler.util.GameStrings
 import com.fantasyidler.util.formatXp
 import com.fantasyidler.util.withAppLocale
@@ -71,6 +75,8 @@ data class SlayerUiState(
     val nextForetelCostUnits: Int = 10,
     /** Foretell queue capacity: base 3, extended by Foresight prestige nodes. */
     val maxForetellSlots: Int = 3,
+    /** Guild daily / daily / weekly quests tied to the Slayer guild, for the "Quests" button. */
+    val slayerQuests: List<SheetQuestSummary> = emptyList(),
 )
 
 @HiltViewModel
@@ -82,6 +88,10 @@ class SlayerViewModel @Inject constructor(
     private val queuedSessionStarter: QueuedSessionStarter,
     @ApplicationContext private val context: Context,
     private val townRepo: TownRepository,
+    private val questRepo: QuestRepository,
+    private val guildRepo: GuildRepository,
+    private val dailyQuestRepo: DailyQuestRepository,
+    private val weeklyQuestRepo: WeeklyQuestRepository,
     private val json: Json,
 ) : ViewModel() {
 
@@ -97,7 +107,8 @@ class SlayerViewModel @Inject constructor(
     val uiState: StateFlow<SlayerUiState> = combine(
         playerRepo.playerFlow,
         _extra,
-    ) { player, extra ->
+        questRepo.observeProgress(),
+    ) { player, extra, questProgress ->
         if (player == null) extra.copy(isLoading = true)
         else {
             val levels:    Map<String, Int>  = json.decodeFromString(player.skillLevels)
@@ -152,9 +163,73 @@ class SlayerViewModel @Inject constructor(
                 foretelledTasks       = flags.foretelledTasks,
                 nextForetelCostUnits  = nextForetelCost,
                 maxForetellSlots      = slayerRepo.maxForetellSlots(flags),
+                slayerQuests          = computeSlayerQuests(questProgress, flags),
             )
         }
     }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), SlayerUiState())
+
+    /** Retrieve guild daily / daily / weekly quests tied to the Slayer guild, for the "Quests" button. */
+    private fun computeSlayerQuests(
+        questProgress: List<com.fantasyidler.data.model.QuestProgress>,
+        flags: PlayerFlags,
+    ): List<SheetQuestSummary> {
+        val completedIds = questProgress.filter { it.completed }.map { it.questId }.toSet()
+        val result = mutableListOf<SheetQuestSummary>()
+
+        val dailies = guildRepo.getGuildDailiesWithProgress(Skills.SLAYER, flags)
+        if (dailies.isNotEmpty()) {
+            val level = guildRepo.guildLevel(Skills.SLAYER, flags.guildDailyTierCounts, completedIds)
+            val maxed = level >= GuildRepository.DAILIES_REQUIRED_PER_TIER.size
+            result += dailies.map { daily ->
+                SheetQuestSummary(
+                    questId    = daily.template.id,
+                    questName  = daily.template.name,
+                    guild      = Skills.SLAYER,
+                    type       = daily.template.type,
+                    target     = daily.template.target,
+                    progress   = daily.progress.coerceAtMost(daily.template.amount),
+                    amount     = daily.template.amount,
+                    claimed    = daily.claimed,
+                    source     = SheetQuestSource.GUILD,
+                    guildMaxed = maxed,
+                )
+            }
+        }
+
+        for (dq in dailyQuestRepo.getActiveDailyQuests(flags)) {
+            if (dq.template.skill != Skills.SLAYER) continue
+            result += SheetQuestSummary(
+                questId     = dq.template.id,
+                questName   = dq.template.displayName,
+                guild       = Skills.SLAYER,
+                type        = dq.template.type,
+                target      = dq.template.target,
+                progress    = dq.progress.coerceAtMost(dq.template.amount),
+                amount      = dq.template.amount,
+                claimed     = dq.claimed,
+                source      = SheetQuestSource.DAILY,
+                description = dq.template.description,
+            )
+        }
+
+        for (wq in weeklyQuestRepo.getActiveWeeklyQuests(flags)) {
+            if (wq.template.skill != Skills.SLAYER) continue
+            result += SheetQuestSummary(
+                questId     = wq.template.id,
+                questName   = wq.template.displayName,
+                guild       = Skills.SLAYER,
+                type        = wq.template.type,
+                target      = wq.template.target,
+                progress    = wq.progress.coerceAtMost(wq.template.amount),
+                amount      = wq.template.amount,
+                claimed     = wq.claimed,
+                source      = SheetQuestSource.WEEKLY,
+                description = wq.template.description,
+            )
+        }
+
+        return result
+    }
 
     fun getNewTask() {
         viewModelScope.launch {


### PR DESCRIPTION
## Before submitting

- [x] I've tested the final changes (with unit tests) to ensure the feature works
- [x] I have pulled and merged the latest changes from the repository

## Related discussion/issue(s)


## Summary

Add Slayer guild's daily/weekly quest banner and prestige tree link on the Slayer screen.

<img width="393" height="330" alt="image" src="https://github.com/user-attachments/assets/771ab283-403a-45f3-a91e-8542ec05c2e6" />


## Changelog

- SlayerScreen shows a "Quests" and a "Prestige skill tree" button

## Additional work



## Anything else?