### PR TITLE
Adjust some visual bugs relating to mercenaries with some additional features

### DIFF
--- a/app/src/main/kotlin/com/fantasyidler/ui/screen/CombatScreen.kt
+++ b/app/src/main/kotlin/com/fantasyidler/ui/screen/CombatScreen.kt
@@ -398,7 +398,6 @@ fun CombatScreen(
                 MercenaryCampSheet(
                     pool           = state.mercPool,
                     hiredMercs     = state.hiredMercs,
-                    dailyResetHour = state.dailyResetHour,
                     maxParty       = MercenaryRepository.MAX_PARTY,
                     onHire         = viewModel::hireMercenary,
                     onDismissMerc  = viewModel::dismissMercenary,

--- a/app/src/main/kotlin/com/fantasyidler/ui/screen/MercenaryCampSheet.kt
+++ b/app/src/main/kotlin/com/fantasyidler/ui/screen/MercenaryCampSheet.kt
@@ -36,7 +36,6 @@ import com.fantasyidler.util.formatCoins
 internal fun MercenaryCampSheet(
     pool: List<MercenaryData>,
     hiredMercs: List<MercContract>,
-    dailyResetHour: Int,
     maxParty: Int,
     onHire: (String) -> Unit,
     onDismissMerc: (String) -> Unit,
@@ -57,7 +56,7 @@ internal fun MercenaryCampSheet(
             fontWeight = FontWeight.Bold,
         )
         Text(
-            text  = stringResource(R.string.merc_camp_desc, dailyResetClockTime(context, dailyResetHour)),
+            text  = stringResource(R.string.merc_camp_desc),
             style = MaterialTheme.typography.bodySmall,
             color = MaterialTheme.colorScheme.onSurfaceVariant,
         )
@@ -69,7 +68,7 @@ internal fun MercenaryCampSheet(
             fontWeight = FontWeight.SemiBold,
         )
         Spacer(Modifier.height(8.dp))
-        pool.forEach { merc ->
+        pool.sortedBy { it.hireCost }.forEach { merc ->
             val hired = merc.id in hiredIds
             Row(
                 modifier              = Modifier.fillMaxWidth().padding(vertical = 6.dp),

--- a/app/src/main/kotlin/com/fantasyidler/ui/viewmodel/CombatViewModel.kt
+++ b/app/src/main/kotlin/com/fantasyidler/ui/viewmodel/CombatViewModel.kt
@@ -125,7 +125,6 @@ data class CombatUiState(
     val mercPool: List<MercenaryData> = emptyList(),
     /** Mercenaries currently under contract (max 3). */
     val hiredMercs: List<MercContract> = emptyList(),
-    val dailyResetHour: Int = 6,
 )
 
 /** A hired mercenary resolved for display: roster data plus contract expiry. */
@@ -310,7 +309,6 @@ class CombatViewModel @Inject constructor(
                 isQueueFull             = flags.sessionQueue.size >= playerRepo.maxQueueSize(flags),
                 mercPool                = mercRepo.dailyPool(flags),
                 hiredMercs              = mercRepo.activeContracts(flags).map { (m, h) -> MercContract(m, h.expiresAt) },
-                dailyResetHour          = flags.dailyResetHour,
             )
         }
     }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), CombatUiState())

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -1531,7 +1531,7 @@
     <string name="raid_no_mercs">No mercenaries under contract.</string> <!-- untranslated -->
     <string name="merc_camp_open">Hire Mercenaries</string> <!-- untranslated -->
     <string name="merc_camp_title">Mercenary Camp</string> <!-- untranslated -->
-    <string name="merc_camp_desc">Contracts last until the daily reset at %1$s. A new pool of mercenaries arrives each day.</string> <!-- untranslated -->
+    <string name="merc_camp_desc">Contracts last for 24 hours after hiring. A new pool of mercenaries arrives each day.</string> <!-- untranslated -->
     <string name="merc_hire">Hire</string> <!-- untranslated -->
     <string name="merc_dismiss">Dismiss</string> <!-- untranslated -->
     <string name="merc_hired">%1$s joins your party until the daily reset.</string> <!-- untranslated -->
@@ -1540,13 +1540,13 @@
     <string name="merc_not_enough_coins">Not enough coins to hire %1$s.</string> <!-- untranslated -->
     <string name="merc_not_available">%1$s is not available today.</string> <!-- untranslated -->
     <string name="merc_contract_remaining">Contract: %1$s left</string> <!-- untranslated -->
-    <string name="combat_log_ally_hit">Your mercenaries hit %1$s for %2$d</string> <!-- untranslated -->
+    <string name="combat_log_ally_hit">→ Your mercenaries hit %1$s: %2$d dmg</string> <!-- untranslated -->
     <string name="raid_allies_down">Mercenaries down: %1$d</string> <!-- untranslated -->
     <string name="merc_tier_cheap">Sellsword</string> <!-- untranslated -->
     <string name="merc_tier_seasoned">Veteran</string> <!-- untranslated -->
     <string name="merc_tier_elite">Champion</string> <!-- untranslated -->
     <string name="merc_stats">Atk %1$d  Str %2$d  Def %3$d  HP %4$d</string> <!-- untranslated -->
-    <string name="merc_cost_per_day">%1$s coins per day</string> <!-- untranslated -->
+    <string name="merc_cost_per_day">%1$s coins</string> <!-- untranslated -->
     <string name="merc_bran_the_sellsword_name">Bran the Sellsword</string> <!-- untranslated -->
     <string name="merc_wren_the_stray_name">Wren the Stray</string> <!-- untranslated -->
     <string name="merc_tam_the_grey_name">Tam the Grey</string> <!-- untranslated -->

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -1851,7 +1851,7 @@
     <string name="raid_no_mercs">No mercenaries under contract.</string> <!-- untranslated -->
     <string name="merc_camp_open">Hire Mercenaries</string> <!-- untranslated -->
     <string name="merc_camp_title">Mercenary Camp</string> <!-- untranslated -->
-    <string name="merc_camp_desc">Contracts last until the daily reset at %1$s. A new pool of mercenaries arrives each day.</string> <!-- untranslated -->
+    <string name="merc_camp_desc">Contracts last for 24 hours after hiring. A new pool of mercenaries arrives each day.</string> <!-- untranslated -->
     <string name="merc_hire">Hire</string> <!-- untranslated -->
     <string name="merc_dismiss">Dismiss</string> <!-- untranslated -->
     <string name="merc_hired">%1$s joins your party until the daily reset.</string> <!-- untranslated -->
@@ -1860,13 +1860,13 @@
     <string name="merc_not_enough_coins">Not enough coins to hire %1$s.</string> <!-- untranslated -->
     <string name="merc_not_available">%1$s is not available today.</string> <!-- untranslated -->
     <string name="merc_contract_remaining">Contract: %1$s left</string> <!-- untranslated -->
-    <string name="combat_log_ally_hit">Your mercenaries hit %1$s for %2$d</string> <!-- untranslated -->
+    <string name="combat_log_ally_hit">→ Your mercenaries hit %1$s: %2$d dmg</string> <!-- untranslated -->
     <string name="raid_allies_down">Mercenaries down: %1$d</string> <!-- untranslated -->
     <string name="merc_tier_cheap">Sellsword</string> <!-- untranslated -->
     <string name="merc_tier_seasoned">Veteran</string> <!-- untranslated -->
     <string name="merc_tier_elite">Champion</string> <!-- untranslated -->
     <string name="merc_stats">Atk %1$d  Str %2$d  Def %3$d  HP %4$d</string> <!-- untranslated -->
-    <string name="merc_cost_per_day">%1$s coins per day</string> <!-- untranslated -->
+    <string name="merc_cost_per_day">%1$s coins</string> <!-- untranslated -->
     <string name="merc_bran_the_sellsword_name">Bran the Sellsword</string> <!-- untranslated -->
     <string name="merc_wren_the_stray_name">Wren the Stray</string> <!-- untranslated -->
     <string name="merc_tam_the_grey_name">Tam the Grey</string> <!-- untranslated -->

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -1847,7 +1847,7 @@
     <string name="raid_no_mercs">No mercenaries under contract.</string> <!-- untranslated -->
     <string name="merc_camp_open">Söldner anheuern</string>
     <string name="merc_camp_title">Söldnerlager</string>
-    <string name="merc_camp_desc">Verträge gelten bis zum täglichen Reset um %1$s. Jeden Tag trifft eine neue Gruppe von Söldnern ein.</string>
+    <string name="merc_camp_desc">Contracts last for 24 hours after hiring. Jeden Tag trifft eine neue Gruppe von Söldnern ein.</string> <!-- untranslated -->
     <string name="merc_hire">Anheuern</string>
     <string name="merc_dismiss">Abbrechen</string>
     <string name="merc_hired">%1$s schließt sich deiner Gruppe bis zum täglichen Reset an.</string>
@@ -1856,13 +1856,13 @@
     <string name="merc_not_enough_coins">Nicht genügend Münzen, um %1$s anzuheuern.</string>
     <string name="merc_not_available">%1$s ist heute nicht verfügbar.</string>
     <string name="merc_contract_remaining">Vertrag: Noch %1$s übrig</string>
-    <string name="combat_log_ally_hit">Deine Söldner haben %1$s für %2$d getroffen</string>
+    <string name="combat_log_ally_hit">→ Your mercenaries hit %1$s: %2$d dmg</string> <!-- untranslated -->
     <string name="raid_allies_down">Söldern am Boden: %1$d</string>
     <string name="merc_tier_cheap">Söldner</string>
     <string name="merc_tier_seasoned">Veteran</string> <!-- untranslated -->
     <string name="merc_tier_elite">Champion</string> <!-- untranslated -->
     <string name="merc_stats">Ang %1$d Stä %2$d Ver %3$d LP %4$d</string>
-    <string name="merc_cost_per_day">%1$s Münzen pro Tag</string>
+    <string name="merc_cost_per_day">%1$s coins</string> <!-- untranslated -->
     <string name="merc_bran_the_sellsword_name">Bran der Söldner</string>
     <string name="merc_wren_the_stray_name">Wren die Verirrte</string>
     <string name="merc_tam_the_grey_name">Tam der Graue</string>

--- a/app/src/main/res/values-es-rES/strings.xml
+++ b/app/src/main/res/values-es-rES/strings.xml
@@ -1834,7 +1834,7 @@
     <string name="raid_no_mercs">No mercenaries under contract.</string> <!-- untranslated -->
     <string name="merc_camp_open">Hire Mercenaries</string> <!-- untranslated -->
     <string name="merc_camp_title">Mercenary Camp</string> <!-- untranslated -->
-    <string name="merc_camp_desc">Contracts last until the daily reset at %1$s. A new pool of mercenaries arrives each day.</string> <!-- untranslated -->
+    <string name="merc_camp_desc">Contracts last for 24 hours after hiring. A new pool of mercenaries arrives each day.</string> <!-- untranslated -->
     <string name="merc_hire">Hire</string> <!-- untranslated -->
     <string name="merc_dismiss">Dismiss</string> <!-- untranslated -->
     <string name="merc_hired">%1$s joins your party until the daily reset.</string> <!-- untranslated -->
@@ -1843,13 +1843,13 @@
     <string name="merc_not_enough_coins">Not enough coins to hire %1$s.</string> <!-- untranslated -->
     <string name="merc_not_available">%1$s is not available today.</string> <!-- untranslated -->
     <string name="merc_contract_remaining">Contract: %1$s left</string> <!-- untranslated -->
-    <string name="combat_log_ally_hit">Your mercenaries hit %1$s for %2$d</string> <!-- untranslated -->
+    <string name="combat_log_ally_hit">→ Your mercenaries hit %1$s: %2$d dmg</string> <!-- untranslated -->
     <string name="raid_allies_down">Mercenaries down: %1$d</string> <!-- untranslated -->
     <string name="merc_tier_cheap">Sellsword</string> <!-- untranslated -->
     <string name="merc_tier_seasoned">Veteran</string> <!-- untranslated -->
     <string name="merc_tier_elite">Champion</string> <!-- untranslated -->
     <string name="merc_stats">Atk %1$d  Str %2$d  Def %3$d  HP %4$d</string> <!-- untranslated -->
-    <string name="merc_cost_per_day">%1$s coins per day</string> <!-- untranslated -->
+    <string name="merc_cost_per_day">%1$s coins</string> <!-- untranslated -->
     <string name="merc_bran_the_sellsword_name">Bran the Sellsword</string> <!-- untranslated -->
     <string name="merc_wren_the_stray_name">Wren the Stray</string> <!-- untranslated -->
     <string name="merc_tam_the_grey_name">Tam the Grey</string> <!-- untranslated -->

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -1847,7 +1847,7 @@
     <string name="raid_no_mercs">No mercenaries under contract.</string> <!-- untranslated -->
     <string name="merc_camp_open">Hire Mercenaries</string> <!-- untranslated -->
     <string name="merc_camp_title">Mercenary Camp</string> <!-- untranslated -->
-    <string name="merc_camp_desc">Contracts last until the daily reset at %1$s. A new pool of mercenaries arrives each day.</string> <!-- untranslated -->
+    <string name="merc_camp_desc">Contracts last for 24 hours after hiring. A new pool of mercenaries arrives each day.</string> <!-- untranslated -->
     <string name="merc_hire">Hire</string> <!-- untranslated -->
     <string name="merc_dismiss">Dismiss</string> <!-- untranslated -->
     <string name="merc_hired">%1$s joins your party until the daily reset.</string> <!-- untranslated -->
@@ -1856,13 +1856,13 @@
     <string name="merc_not_enough_coins">Not enough coins to hire %1$s.</string> <!-- untranslated -->
     <string name="merc_not_available">%1$s is not available today.</string> <!-- untranslated -->
     <string name="merc_contract_remaining">Contract: %1$s left</string> <!-- untranslated -->
-    <string name="combat_log_ally_hit">Your mercenaries hit %1$s for %2$d</string> <!-- untranslated -->
+    <string name="combat_log_ally_hit">→ Your mercenaries hit %1$s: %2$d dmg</string> <!-- untranslated -->
     <string name="raid_allies_down">Mercenaries down: %1$d</string> <!-- untranslated -->
     <string name="merc_tier_cheap">Sellsword</string> <!-- untranslated -->
     <string name="merc_tier_seasoned">Veteran</string> <!-- untranslated -->
     <string name="merc_tier_elite">Champion</string> <!-- untranslated -->
     <string name="merc_stats">Atk %1$d  Str %2$d  Def %3$d  HP %4$d</string> <!-- untranslated -->
-    <string name="merc_cost_per_day">%1$s coins per day</string> <!-- untranslated -->
+    <string name="merc_cost_per_day">%1$s coins</string> <!-- untranslated -->
     <string name="merc_bran_the_sellsword_name">Bran the Sellsword</string> <!-- untranslated -->
     <string name="merc_wren_the_stray_name">Wren the Stray</string> <!-- untranslated -->
     <string name="merc_tam_the_grey_name">Tam the Grey</string> <!-- untranslated -->

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -1848,7 +1848,7 @@
     <string name="raid_no_mercs">Pas de mercenaires sous contrat.</string>
     <string name="merc_camp_open">Engager des Mercenaires</string>
     <string name="merc_camp_title">Camp de Mercenaires</string>
-    <string name="merc_camp_desc">Les Contrats durent jusqu\'à ce que la réinitialisation quotidienne se produit à %1$s. Une nouvelle troupe de mercenaires arrive chaque jour.</string>
+    <string name="merc_camp_desc">Contracts last for 24 hours after hiring. Une nouvelle troupe de mercenaires arrive chaque jour.</string> <!-- untranslated -->
     <string name="merc_hire">Engager</string>
     <string name="merc_dismiss">Virer</string>
     <string name="merc_hired">%1$s rejoins votre groupe jusqu\'à la réinitialisation quotidienne.</string>
@@ -1857,13 +1857,13 @@
     <string name="merc_not_enough_coins">Pas assez de pièces pour engager %1$s.</string>
     <string name="merc_not_available">%1$s n\'est pas disponible aujourd\'hui.</string>
     <string name="merc_contract_remaining">Contrat : %1$s est parti</string>
-    <string name="combat_log_ally_hit">Vos mercenaires prennent %1$s pour %2$d</string>
+    <string name="combat_log_ally_hit">→ Your mercenaries hit %1$s: %2$d dmg</string> <!-- untranslated -->
     <string name="raid_allies_down">Mercenaires à terre : %1$d</string>
     <string name="merc_tier_cheap">Épée à Louer</string>
     <string name="merc_tier_seasoned">Vétéran</string>
     <string name="merc_tier_elite">Champion</string>
     <string name="merc_stats">Atq %1$d  For %2$d  Déf %3$d  PV %4$d</string>
-    <string name="merc_cost_per_day">%1$s pièces par jour</string>
+    <string name="merc_cost_per_day">%1$s coins</string> <!-- untranslated -->
     <string name="merc_bran_the_sellsword_name">Bran l\'Épée-à-Louer</string>
     <string name="merc_wren_the_stray_name">Wren le Vagabond</string>
     <string name="merc_tam_the_grey_name">Tam le Gris</string>

--- a/app/src/main/res/values-ga/strings.xml
+++ b/app/src/main/res/values-ga/strings.xml
@@ -1881,7 +1881,7 @@
     <string name="raid_no_mercs">No mercenaries under contract.</string> <!-- untranslated -->
     <string name="merc_camp_open">Hire Mercenaries</string> <!-- untranslated -->
     <string name="merc_camp_title">Mercenary Camp</string> <!-- untranslated -->
-    <string name="merc_camp_desc">Contracts last until the daily reset at %1$s. A new pool of mercenaries arrives each day.</string> <!-- untranslated -->
+    <string name="merc_camp_desc">Contracts last for 24 hours after hiring. A new pool of mercenaries arrives each day.</string> <!-- untranslated -->
     <string name="merc_hire">Hire</string> <!-- untranslated -->
     <string name="merc_dismiss">Dismiss</string> <!-- untranslated -->
     <string name="merc_hired">%1$s joins your party until the daily reset.</string> <!-- untranslated -->
@@ -1890,13 +1890,13 @@
     <string name="merc_not_enough_coins">Not enough coins to hire %1$s.</string> <!-- untranslated -->
     <string name="merc_not_available">%1$s is not available today.</string> <!-- untranslated -->
     <string name="merc_contract_remaining">Contract: %1$s left</string> <!-- untranslated -->
-    <string name="combat_log_ally_hit">Your mercenaries hit %1$s for %2$d</string> <!-- untranslated -->
+    <string name="combat_log_ally_hit">→ Your mercenaries hit %1$s: %2$d dmg</string> <!-- untranslated -->
     <string name="raid_allies_down">Mercenaries down: %1$d</string> <!-- untranslated -->
     <string name="merc_tier_cheap">Sellsword</string> <!-- untranslated -->
     <string name="merc_tier_seasoned">Veteran</string> <!-- untranslated -->
     <string name="merc_tier_elite">Champion</string> <!-- untranslated -->
     <string name="merc_stats">Atk %1$d  Str %2$d  Def %3$d  HP %4$d</string> <!-- untranslated -->
-    <string name="merc_cost_per_day">%1$s coins per day</string> <!-- untranslated -->
+    <string name="merc_cost_per_day">%1$s coins</string> <!-- untranslated -->
     <string name="merc_bran_the_sellsword_name">Bran the Sellsword</string> <!-- untranslated -->
     <string name="merc_wren_the_stray_name">Wren the Stray</string> <!-- untranslated -->
     <string name="merc_tam_the_grey_name">Tam the Grey</string> <!-- untranslated -->

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -1839,7 +1839,7 @@
     <string name="raid_no_mercs">No mercenaries under contract.</string> <!-- untranslated -->
     <string name="merc_camp_open">Hire Mercenaries</string> <!-- untranslated -->
     <string name="merc_camp_title">Mercenary Camp</string> <!-- untranslated -->
-    <string name="merc_camp_desc">Contracts last until the daily reset at %1$s. A new pool of mercenaries arrives each day.</string> <!-- untranslated -->
+    <string name="merc_camp_desc">Contracts last for 24 hours after hiring. A new pool of mercenaries arrives each day.</string> <!-- untranslated -->
     <string name="merc_hire">Hire</string> <!-- untranslated -->
     <string name="merc_dismiss">Dismiss</string> <!-- untranslated -->
     <string name="merc_hired">%1$s joins your party until the daily reset.</string> <!-- untranslated -->
@@ -1848,13 +1848,13 @@
     <string name="merc_not_enough_coins">Not enough coins to hire %1$s.</string> <!-- untranslated -->
     <string name="merc_not_available">%1$s is not available today.</string> <!-- untranslated -->
     <string name="merc_contract_remaining">Contract: %1$s left</string> <!-- untranslated -->
-    <string name="combat_log_ally_hit">Your mercenaries hit %1$s for %2$d</string> <!-- untranslated -->
+    <string name="combat_log_ally_hit">→ Your mercenaries hit %1$s: %2$d dmg</string> <!-- untranslated -->
     <string name="raid_allies_down">Mercenaries down: %1$d</string> <!-- untranslated -->
     <string name="merc_tier_cheap">Sellsword</string> <!-- untranslated -->
     <string name="merc_tier_seasoned">Veteran</string> <!-- untranslated -->
     <string name="merc_tier_elite">Champion</string> <!-- untranslated -->
     <string name="merc_stats">Atk %1$d  Str %2$d  Def %3$d  HP %4$d</string> <!-- untranslated -->
-    <string name="merc_cost_per_day">%1$s coins per day</string> <!-- untranslated -->
+    <string name="merc_cost_per_day">%1$s coins</string> <!-- untranslated -->
     <string name="merc_bran_the_sellsword_name">Bran the Sellsword</string> <!-- untranslated -->
     <string name="merc_wren_the_stray_name">Wren the Stray</string> <!-- untranslated -->
     <string name="merc_tam_the_grey_name">Tam the Grey</string> <!-- untranslated -->

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -1847,7 +1847,7 @@
     <string name="raid_no_mercs">Nessun mercenario assunto.</string>
     <string name="merc_camp_open">Assumi Mercenari</string>
     <string name="merc_camp_title">Campo dei mercenari</string>
-    <string name="merc_camp_desc">Il contratto è valido fino all\'orario di ripristino (%1$s). Un nuovo gruppo di mercenari arriverà ogni giorno.</string>
+    <string name="merc_camp_desc">Contracts last for 24 hours after hiring. Un nuovo gruppo di mercenari arriverà ogni giorno.</string> <!-- untranslated -->
     <string name="merc_hire">Assumi</string>
     <string name="merc_dismiss">Congeda</string>
     <string name="merc_hired">%1$s si unisce alla tua squadra fino all\'orario di ripristino.</string>
@@ -1856,13 +1856,13 @@
     <string name="merc_not_enough_coins">Non hai abbastanza monete per assumere %1$s.</string>
     <string name="merc_not_available">%1$s non è disponibile oggi.</string>
     <string name="merc_contract_remaining">Contratti: %1$s rimasti</string>
-    <string name="combat_log_ally_hit">I mercenari colpiscono %1$s per %2$d danni</string>
+    <string name="combat_log_ally_hit">→ Your mercenaries hit %1$s: %2$d dmg</string> <!-- untranslated -->
     <string name="raid_allies_down">Mercenari sconfitti: %1$d</string>
     <string name="merc_tier_cheap">Novizio</string>
     <string name="merc_tier_seasoned">Veterano</string>
     <string name="merc_tier_elite">Campione</string>
     <string name="merc_stats">Att %1$d  Frz %2$d  Dif %3$d  PS %4$d</string>
-    <string name="merc_cost_per_day">%1$s monete al giorno</string>
+    <string name="merc_cost_per_day">%1$s coins</string> <!-- untranslated -->
     <string name="merc_bran_the_sellsword_name">Bran il Cercadenaro</string>
     <string name="merc_wren_the_stray_name">Wren della landa</string>
     <string name="merc_tam_the_grey_name">Tam il Grigio</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -1847,7 +1847,7 @@
     <string name="raid_no_mercs">No mercenaries under contract.</string> <!-- untranslated -->
     <string name="merc_camp_open">Hire Mercenaries</string> <!-- untranslated -->
     <string name="merc_camp_title">Mercenary Camp</string> <!-- untranslated -->
-    <string name="merc_camp_desc">Contracts last until the daily reset at %1$s. A new pool of mercenaries arrives each day.</string> <!-- untranslated -->
+    <string name="merc_camp_desc">Contracts last for 24 hours after hiring. A new pool of mercenaries arrives each day.</string> <!-- untranslated -->
     <string name="merc_hire">Hire</string> <!-- untranslated -->
     <string name="merc_dismiss">Dismiss</string> <!-- untranslated -->
     <string name="merc_hired">%1$s joins your party until the daily reset.</string> <!-- untranslated -->
@@ -1856,13 +1856,13 @@
     <string name="merc_not_enough_coins">Not enough coins to hire %1$s.</string> <!-- untranslated -->
     <string name="merc_not_available">%1$s is not available today.</string> <!-- untranslated -->
     <string name="merc_contract_remaining">Contract: %1$s left</string> <!-- untranslated -->
-    <string name="combat_log_ally_hit">Your mercenaries hit %1$s for %2$d</string> <!-- untranslated -->
+    <string name="combat_log_ally_hit">→ Your mercenaries hit %1$s: %2$d dmg</string> <!-- untranslated -->
     <string name="raid_allies_down">Mercenaries down: %1$d</string> <!-- untranslated -->
     <string name="merc_tier_cheap">Sellsword</string> <!-- untranslated -->
     <string name="merc_tier_seasoned">Veteran</string> <!-- untranslated -->
     <string name="merc_tier_elite">Champion</string> <!-- untranslated -->
     <string name="merc_stats">Atk %1$d  Str %2$d  Def %3$d  HP %4$d</string> <!-- untranslated -->
-    <string name="merc_cost_per_day">%1$s coins per day</string> <!-- untranslated -->
+    <string name="merc_cost_per_day">%1$s coins</string> <!-- untranslated -->
     <string name="merc_bran_the_sellsword_name">Bran the Sellsword</string> <!-- untranslated -->
     <string name="merc_wren_the_stray_name">Wren the Stray</string> <!-- untranslated -->
     <string name="merc_tam_the_grey_name">Tam the Grey</string> <!-- untranslated -->

--- a/app/src/main/res/values-lt/strings.xml
+++ b/app/src/main/res/values-lt/strings.xml
@@ -1847,7 +1847,7 @@
     <string name="raid_no_mercs">No mercenaries under contract.</string> <!-- untranslated -->
     <string name="merc_camp_open">Hire Mercenaries</string> <!-- untranslated -->
     <string name="merc_camp_title">Mercenary Camp</string> <!-- untranslated -->
-    <string name="merc_camp_desc">Contracts last until the daily reset at %1$s. A new pool of mercenaries arrives each day.</string> <!-- untranslated -->
+    <string name="merc_camp_desc">Contracts last for 24 hours after hiring. A new pool of mercenaries arrives each day.</string> <!-- untranslated -->
     <string name="merc_hire">Hire</string> <!-- untranslated -->
     <string name="merc_dismiss">Dismiss</string> <!-- untranslated -->
     <string name="merc_hired">%1$s joins your party until the daily reset.</string> <!-- untranslated -->
@@ -1856,13 +1856,13 @@
     <string name="merc_not_enough_coins">Not enough coins to hire %1$s.</string> <!-- untranslated -->
     <string name="merc_not_available">%1$s is not available today.</string> <!-- untranslated -->
     <string name="merc_contract_remaining">Contract: %1$s left</string> <!-- untranslated -->
-    <string name="combat_log_ally_hit">Your mercenaries hit %1$s for %2$d</string> <!-- untranslated -->
+    <string name="combat_log_ally_hit">→ Your mercenaries hit %1$s: %2$d dmg</string> <!-- untranslated -->
     <string name="raid_allies_down">Mercenaries down: %1$d</string> <!-- untranslated -->
     <string name="merc_tier_cheap">Sellsword</string> <!-- untranslated -->
     <string name="merc_tier_seasoned">Veteran</string> <!-- untranslated -->
     <string name="merc_tier_elite">Champion</string> <!-- untranslated -->
     <string name="merc_stats">Atk %1$d  Str %2$d  Def %3$d  HP %4$d</string> <!-- untranslated -->
-    <string name="merc_cost_per_day">%1$s coins per day</string> <!-- untranslated -->
+    <string name="merc_cost_per_day">%1$s coins</string> <!-- untranslated -->
     <string name="merc_bran_the_sellsword_name">Bran the Sellsword</string> <!-- untranslated -->
     <string name="merc_wren_the_stray_name">Wren the Stray</string> <!-- untranslated -->
     <string name="merc_tam_the_grey_name">Tam the Grey</string> <!-- untranslated -->

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -1847,7 +1847,7 @@
     <string name="raid_no_mercs">No mercenaries under contract.</string> <!-- untranslated -->
     <string name="merc_camp_open">Hire Mercenaries</string> <!-- untranslated -->
     <string name="merc_camp_title">Mercenary Camp</string> <!-- untranslated -->
-    <string name="merc_camp_desc">Contracts last until the daily reset at %1$s. A new pool of mercenaries arrives each day.</string> <!-- untranslated -->
+    <string name="merc_camp_desc">Contracts last for 24 hours after hiring. A new pool of mercenaries arrives each day.</string> <!-- untranslated -->
     <string name="merc_hire">Hire</string> <!-- untranslated -->
     <string name="merc_dismiss">Dismiss</string> <!-- untranslated -->
     <string name="merc_hired">%1$s joins your party until the daily reset.</string> <!-- untranslated -->
@@ -1856,13 +1856,13 @@
     <string name="merc_not_enough_coins">Not enough coins to hire %1$s.</string> <!-- untranslated -->
     <string name="merc_not_available">%1$s is not available today.</string> <!-- untranslated -->
     <string name="merc_contract_remaining">Contract: %1$s left</string> <!-- untranslated -->
-    <string name="combat_log_ally_hit">Your mercenaries hit %1$s for %2$d</string> <!-- untranslated -->
+    <string name="combat_log_ally_hit">→ Your mercenaries hit %1$s: %2$d dmg</string> <!-- untranslated -->
     <string name="raid_allies_down">Mercenaries down: %1$d</string> <!-- untranslated -->
     <string name="merc_tier_cheap">Sellsword</string> <!-- untranslated -->
     <string name="merc_tier_seasoned">Veteran</string> <!-- untranslated -->
     <string name="merc_tier_elite">Champion</string> <!-- untranslated -->
     <string name="merc_stats">Atk %1$d  Str %2$d  Def %3$d  HP %4$d</string> <!-- untranslated -->
-    <string name="merc_cost_per_day">%1$s coins per day</string> <!-- untranslated -->
+    <string name="merc_cost_per_day">%1$s coins</string> <!-- untranslated -->
     <string name="merc_bran_the_sellsword_name">Bran the Sellsword</string> <!-- untranslated -->
     <string name="merc_wren_the_stray_name">Wren the Stray</string> <!-- untranslated -->
     <string name="merc_tam_the_grey_name">Tam the Grey</string> <!-- untranslated -->

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -1867,7 +1867,7 @@
     <string name="raid_no_mercs">No mercenaries under contract.</string> <!-- untranslated -->
     <string name="merc_camp_open">Hire Mercenaries</string> <!-- untranslated -->
     <string name="merc_camp_title">Mercenary Camp</string> <!-- untranslated -->
-    <string name="merc_camp_desc">Contracts last until the daily reset at %1$s. A new pool of mercenaries arrives each day.</string> <!-- untranslated -->
+    <string name="merc_camp_desc">Contracts last for 24 hours after hiring. A new pool of mercenaries arrives each day.</string> <!-- untranslated -->
     <string name="merc_hire">Hire</string> <!-- untranslated -->
     <string name="merc_dismiss">Dismiss</string> <!-- untranslated -->
     <string name="merc_hired">%1$s joins your party until the daily reset.</string> <!-- untranslated -->
@@ -1876,13 +1876,13 @@
     <string name="merc_not_enough_coins">Not enough coins to hire %1$s.</string> <!-- untranslated -->
     <string name="merc_not_available">%1$s is not available today.</string> <!-- untranslated -->
     <string name="merc_contract_remaining">Contract: %1$s left</string> <!-- untranslated -->
-    <string name="combat_log_ally_hit">Your mercenaries hit %1$s for %2$d</string> <!-- untranslated -->
+    <string name="combat_log_ally_hit">→ Your mercenaries hit %1$s: %2$d dmg</string> <!-- untranslated -->
     <string name="raid_allies_down">Mercenaries down: %1$d</string> <!-- untranslated -->
     <string name="merc_tier_cheap">Sellsword</string> <!-- untranslated -->
     <string name="merc_tier_seasoned">Veteran</string> <!-- untranslated -->
     <string name="merc_tier_elite">Champion</string> <!-- untranslated -->
     <string name="merc_stats">Atk %1$d  Str %2$d  Def %3$d  HP %4$d</string> <!-- untranslated -->
-    <string name="merc_cost_per_day">%1$s coins per day</string> <!-- untranslated -->
+    <string name="merc_cost_per_day">%1$s coins</string> <!-- untranslated -->
     <string name="merc_bran_the_sellsword_name">Bran the Sellsword</string> <!-- untranslated -->
     <string name="merc_wren_the_stray_name">Wren the Stray</string> <!-- untranslated -->
     <string name="merc_tam_the_grey_name">Tam the Grey</string> <!-- untranslated -->

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -1847,7 +1847,7 @@
     <string name="raid_no_mercs">No mercenaries under contract.</string> <!-- untranslated -->
     <string name="merc_camp_open">Hire Mercenaries</string> <!-- untranslated -->
     <string name="merc_camp_title">Mercenary Camp</string> <!-- untranslated -->
-    <string name="merc_camp_desc">Contracts last until the daily reset at %1$s. A new pool of mercenaries arrives each day.</string> <!-- untranslated -->
+    <string name="merc_camp_desc">Contracts last for 24 hours after hiring. A new pool of mercenaries arrives each day.</string> <!-- untranslated -->
     <string name="merc_hire">Hire</string> <!-- untranslated -->
     <string name="merc_dismiss">Dismiss</string> <!-- untranslated -->
     <string name="merc_hired">%1$s joins your party until the daily reset.</string> <!-- untranslated -->
@@ -1856,13 +1856,13 @@
     <string name="merc_not_enough_coins">Not enough coins to hire %1$s.</string> <!-- untranslated -->
     <string name="merc_not_available">%1$s is not available today.</string> <!-- untranslated -->
     <string name="merc_contract_remaining">Contract: %1$s left</string> <!-- untranslated -->
-    <string name="combat_log_ally_hit">Your mercenaries hit %1$s for %2$d</string> <!-- untranslated -->
+    <string name="combat_log_ally_hit">→ Your mercenaries hit %1$s: %2$d dmg</string> <!-- untranslated -->
     <string name="raid_allies_down">Mercenaries down: %1$d</string> <!-- untranslated -->
     <string name="merc_tier_cheap">Sellsword</string> <!-- untranslated -->
     <string name="merc_tier_seasoned">Veteran</string> <!-- untranslated -->
     <string name="merc_tier_elite">Champion</string> <!-- untranslated -->
     <string name="merc_stats">Atk %1$d  Str %2$d  Def %3$d  HP %4$d</string> <!-- untranslated -->
-    <string name="merc_cost_per_day">%1$s coins per day</string> <!-- untranslated -->
+    <string name="merc_cost_per_day">%1$s coins</string> <!-- untranslated -->
     <string name="merc_bran_the_sellsword_name">Bran the Sellsword</string> <!-- untranslated -->
     <string name="merc_wren_the_stray_name">Wren the Stray</string> <!-- untranslated -->
     <string name="merc_tam_the_grey_name">Tam the Grey</string> <!-- untranslated -->

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -1867,7 +1867,7 @@
     <string name="raid_no_mercs">Нет нанятых наемников.</string>
     <string name="merc_camp_open">Нанять наемников</string>
     <string name="merc_camp_title">Лагерь наемников</string>
-    <string name="merc_camp_desc">Контракты действуют до ежедневного сброса в %1$s. Каждый день прибывает новый набор наемников.</string>
+    <string name="merc_camp_desc">Contracts last for 24 hours after hiring. Каждый день прибывает новый набор наемников.</string> <!-- untranslated -->
     <string name="merc_hire">Нанять</string>
     <string name="merc_dismiss">Уволить</string>
     <string name="merc_hired">%1$s присоединяется к вашей группе до тех пор, пока не начнется ежедневная сброс.</string>
@@ -1876,13 +1876,13 @@
     <string name="merc_not_enough_coins">Не хватает монет, чтобы нанять %1$s.</string>
     <string name="merc_not_available">%1$s сегодня он недоступен.</string>
     <string name="merc_contract_remaining">Контракты: %1$s осталось</string>
-    <string name="combat_log_ally_hit">Ваши наемники нанесли удар %1$s по %2$d</string>
+    <string name="combat_log_ally_hit">→ Your mercenaries hit %1$s: %2$d dmg</string> <!-- untranslated -->
     <string name="raid_allies_down">Наемники повержены: %1$d</string>
     <string name="merc_tier_cheap">Наемник</string>
     <string name="merc_tier_seasoned">Ветеран</string>
     <string name="merc_tier_elite">Чемпион</string>
     <string name="merc_stats">Атк %1$d  Сил %2$d  Защ %3$d  HP %4$d</string>
-    <string name="merc_cost_per_day">%1$s монет в день</string>
+    <string name="merc_cost_per_day">%1$s coins</string> <!-- untranslated -->
     <string name="merc_bran_the_sellsword_name">Бран Наёмник</string>
     <string name="merc_wren_the_stray_name">Рен Бродяга</string>
     <string name="merc_tam_the_grey_name">Тэм Серый</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -1847,7 +1847,7 @@
     <string name="raid_no_mercs">No mercenaries under contract.</string> <!-- untranslated -->
     <string name="merc_camp_open">Hire Mercenaries</string> <!-- untranslated -->
     <string name="merc_camp_title">Mercenary Camp</string> <!-- untranslated -->
-    <string name="merc_camp_desc">Contracts last until the daily reset at %1$s. A new pool of mercenaries arrives each day.</string> <!-- untranslated -->
+    <string name="merc_camp_desc">Contracts last for 24 hours after hiring. A new pool of mercenaries arrives each day.</string> <!-- untranslated -->
     <string name="merc_hire">Hire</string> <!-- untranslated -->
     <string name="merc_dismiss">Dismiss</string> <!-- untranslated -->
     <string name="merc_hired">%1$s joins your party until the daily reset.</string> <!-- untranslated -->
@@ -1856,13 +1856,13 @@
     <string name="merc_not_enough_coins">Not enough coins to hire %1$s.</string> <!-- untranslated -->
     <string name="merc_not_available">%1$s is not available today.</string> <!-- untranslated -->
     <string name="merc_contract_remaining">Contract: %1$s left</string> <!-- untranslated -->
-    <string name="combat_log_ally_hit">Your mercenaries hit %1$s for %2$d</string> <!-- untranslated -->
+    <string name="combat_log_ally_hit">→ Your mercenaries hit %1$s: %2$d dmg</string> <!-- untranslated -->
     <string name="raid_allies_down">Mercenaries down: %1$d</string> <!-- untranslated -->
     <string name="merc_tier_cheap">Sellsword</string> <!-- untranslated -->
     <string name="merc_tier_seasoned">Veteran</string> <!-- untranslated -->
     <string name="merc_tier_elite">Champion</string> <!-- untranslated -->
     <string name="merc_stats">Atk %1$d  Str %2$d  Def %3$d  HP %4$d</string> <!-- untranslated -->
-    <string name="merc_cost_per_day">%1$s coins per day</string> <!-- untranslated -->
+    <string name="merc_cost_per_day">%1$s coins</string> <!-- untranslated -->
     <string name="merc_bran_the_sellsword_name">Bran the Sellsword</string> <!-- untranslated -->
     <string name="merc_wren_the_stray_name">Wren the Stray</string> <!-- untranslated -->
     <string name="merc_tam_the_grey_name">Tam the Grey</string> <!-- untranslated -->

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -1847,7 +1847,7 @@
     <string name="raid_no_mercs">No mercenaries under contract.</string> <!-- untranslated -->
     <string name="merc_camp_open">Hire Mercenaries</string> <!-- untranslated -->
     <string name="merc_camp_title">Mercenary Camp</string> <!-- untranslated -->
-    <string name="merc_camp_desc">Contracts last until the daily reset at %1$s. A new pool of mercenaries arrives each day.</string> <!-- untranslated -->
+    <string name="merc_camp_desc">Contracts last for 24 hours after hiring. A new pool of mercenaries arrives each day.</string> <!-- untranslated -->
     <string name="merc_hire">Hire</string> <!-- untranslated -->
     <string name="merc_dismiss">Dismiss</string> <!-- untranslated -->
     <string name="merc_hired">%1$s joins your party until the daily reset.</string> <!-- untranslated -->
@@ -1856,13 +1856,13 @@
     <string name="merc_not_enough_coins">Not enough coins to hire %1$s.</string> <!-- untranslated -->
     <string name="merc_not_available">%1$s is not available today.</string> <!-- untranslated -->
     <string name="merc_contract_remaining">Contract: %1$s left</string> <!-- untranslated -->
-    <string name="combat_log_ally_hit">Your mercenaries hit %1$s for %2$d</string> <!-- untranslated -->
+    <string name="combat_log_ally_hit">→ Your mercenaries hit %1$s: %2$d dmg</string> <!-- untranslated -->
     <string name="raid_allies_down">Mercenaries down: %1$d</string> <!-- untranslated -->
     <string name="merc_tier_cheap">Sellsword</string> <!-- untranslated -->
     <string name="merc_tier_seasoned">Veteran</string> <!-- untranslated -->
     <string name="merc_tier_elite">Champion</string> <!-- untranslated -->
     <string name="merc_stats">Atk %1$d  Str %2$d  Def %3$d  HP %4$d</string> <!-- untranslated -->
-    <string name="merc_cost_per_day">%1$s coins per day</string> <!-- untranslated -->
+    <string name="merc_cost_per_day">%1$s coins</string> <!-- untranslated -->
     <string name="merc_bran_the_sellsword_name">Bran the Sellsword</string> <!-- untranslated -->
     <string name="merc_wren_the_stray_name">Wren the Stray</string> <!-- untranslated -->
     <string name="merc_tam_the_grey_name">Tam the Grey</string> <!-- untranslated -->

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -557,6 +557,7 @@
     <string name="combat_log_player_miss">→ You missed %1$s</string>
     <string name="combat_log_enemy_hit">← %1$s hit you: %2$d dmg</string>
     <string name="combat_log_enemy_miss">← %1$s missed</string>
+    <string name="combat_log_ally_hit">→ Your mercenaries hit %1$s: %2$d dmg</string>
     <string name="combat_log_heal">✚ You eat: +%1$d HP</string>
     <string name="combat_eat_threshold_warning">Risky: at a low threshold a hard hit can drop you to 0 HP before your character eats.</string>
     <string name="combat_rec_level">Recommended combat level</string>
@@ -1847,7 +1848,7 @@
     <string name="raid_no_mercs">No mercenaries under contract.</string>
     <string name="merc_camp_open">Hire Mercenaries</string>
     <string name="merc_camp_title">Mercenary Camp</string>
-    <string name="merc_camp_desc">Contracts last until the daily reset at %1$s. A new pool of mercenaries arrives each day.</string>
+    <string name="merc_camp_desc">Contracts last for 24 hours after hiring. A new pool of mercenaries arrives each day.</string>
     <string name="merc_hire">Hire</string>
     <string name="merc_dismiss">Dismiss</string>
     <string name="merc_hired">%1$s joins your party until the daily reset.</string>
@@ -1856,13 +1857,12 @@
     <string name="merc_not_enough_coins">Not enough coins to hire %1$s.</string>
     <string name="merc_not_available">%1$s is not available today.</string>
     <string name="merc_contract_remaining">Contract: %1$s left</string>
-    <string name="combat_log_ally_hit">Your mercenaries hit %1$s for %2$d</string>
     <string name="raid_allies_down">Mercenaries down: %1$d</string>
     <string name="merc_tier_cheap">Sellsword</string>
     <string name="merc_tier_seasoned">Veteran</string>
     <string name="merc_tier_elite">Champion</string>
     <string name="merc_stats">Atk %1$d  Str %2$d  Def %3$d  HP %4$d</string>
-    <string name="merc_cost_per_day">%1$s coins per day</string>
+    <string name="merc_cost_per_day">%1$s coins</string>
     <string name="merc_bran_the_sellsword_name">Bran the Sellsword</string>
     <string name="merc_wren_the_stray_name">Wren the Stray</string>
     <string name="merc_tam_the_grey_name">Tam the Grey</string>


### PR DESCRIPTION
## Before submitting

- [x] I've tested any changes with the appropriate tests (eg. Unit tests, validation scripts)
- [x] I've pulled and merged the latest changes from the repository

## Summary

<!-- Short summary of the pull request and what it changes -->

This applies a number of minor visual changes to the mercenaries, changing some strings relating to combat, clarifying the process of changing per 24 hours instead of at 6am, and sorting mercenaries by their hire cost. Where strings from other languages were changed, these were converted to their English variants with <!-- untranslated --> being appended afterwards.

## Related issue(s) or discussion(s)

<!-- Prepend issues with "Fixes" if this should close the issue, e.g. Fixes #283, Relates to #284 -->

N/A

## Changelog

<!-- Concise list of changes, e.g.
- Fix time-slot bug causing XP gains to not show in notification banner
- Added ellipsis for quests XP gains exceeding screen width
-->

- Adjust daily reset string to say contracts are hired for 24 hours. Changed other language strings by converting to English and adding untranslated marker
- Mercenaries are now sorted by hire cost in hire screen
- Adjusted mercenary hit string in combat log to match other hits
- Where English strings have received changes, these have been remarked as untranslated and converted back the english

