### PR TITLE
Synchronize player mutations and offline queue catch-up to prevent concurrent state corruption

### DIFF
--- a/app/src/main/kotlin/com/fantasyidler/repository/PlayerRepository.kt
+++ b/app/src/main/kotlin/com/fantasyidler/repository/PlayerRepository.kt
@@ -207,7 +207,7 @@ class PlayerRepository @Inject constructor(
     }
 
     /** Subtract XP from a skill, flooring at 0. Recalculates level. */
-    suspend fun deductSkillXp(skillName: String, amount: Long) {
+    suspend fun deductSkillXp(skillName: String, amount: Long) = playerMutex.withLock {
         val player = getOrCreatePlayer()
         val levels: MutableMap<String, Int> = json.decodeFromString(player.skillLevels)
         val xpMap:  MutableMap<String, Long> = json.decodeFromString(player.skillXp)
@@ -221,7 +221,7 @@ class PlayerRepository @Inject constructor(
     }
 
     /** Add XP to a skill with no boosts or multipliers. Recalculates level. */
-    suspend fun debugAddSkillXp(skillName: String, amount: Long) {
+    suspend fun debugAddSkillXp(skillName: String, amount: Long) = playerMutex.withLock {
         if (amount <= 0L) return
         val player = getOrCreatePlayer()
         val levels: MutableMap<String, Int> = json.decodeFromString(player.skillLevels)
@@ -242,7 +242,7 @@ class PlayerRepository @Inject constructor(
      * prayer XP (scaled down proportionally if fewer bones were available). One DB write
      * regardless of [count] — the Bone Altar accumulates rapid taps into batches.
      */
-    suspend fun buryBonesAtomic(boneKey: String, count: Int, xpToAward: Long): BuryBonesResult {
+    suspend fun buryBonesAtomic(boneKey: String, count: Int, xpToAward: Long): BuryBonesResult = playerMutex.withLock {
         val player    = getOrCreatePlayer()
         val inventory: MutableMap<String, Int> = json.decodeFromString(player.inventory)
         val available = inventory[boneKey] ?: 0
@@ -575,14 +575,14 @@ class PlayerRepository @Inject constructor(
     }
 
     /** Removes and returns the queued item at [index], or null if out of range. */
-    suspend fun removeFromQueue(index: Int): QueuedAction? {
-        val flags = getFlags()
+    suspend fun removeFromQueue(index: Int): QueuedAction? = playerMutex.withLock {
+        val flags = getFlagsUnlocked()
         val queue = flags.sessionQueue
-        if (index < 0 || index >= queue.size) return null
+        if (index < 0 || index >= queue.size) return@withLock null
         val removed = queue[index]
         val newQueue = queue.toMutableList().apply { removeAt(index) }
-        updateFlags(flags.copy(sessionQueue = renumberTowerQueue(newQueue, flags.towerCurrentFloor)))
-        return removed
+        updateFlagsUnlocked(flags.copy(sessionQueue = renumberTowerQueue(newQueue, flags.towerCurrentFloor)))
+        removed
     }
 
     /**
@@ -602,31 +602,31 @@ class PlayerRepository @Inject constructor(
         }
     }
 
-    suspend fun evictQueueForSkill(skillName: String): List<QueuedAction> {
-        val flags = getFlags()
+    suspend fun evictQueueForSkill(skillName: String): List<QueuedAction> = playerMutex.withLock {
+        val flags = getFlagsUnlocked()
         val (evicted, remaining) = flags.sessionQueue.partition { it.skillName == skillName }
-        if (evicted.isNotEmpty()) updateFlags(flags.copy(sessionQueue = remaining))
-        return evicted
+        if (evicted.isNotEmpty()) updateFlagsUnlocked(flags.copy(sessionQueue = remaining))
+        evicted
     }
 
-    suspend fun moveQueueItem(fromIndex: Int, toIndex: Int) {
-        val flags = getFlags()
+    suspend fun moveQueueItem(fromIndex: Int, toIndex: Int) = playerMutex.withLock {
+        val flags = getFlagsUnlocked()
         val queue = flags.sessionQueue.toMutableList()
-        if (fromIndex < 0 || toIndex < 0 || fromIndex >= queue.size || toIndex >= queue.size) return
+        if (fromIndex < 0 || toIndex < 0 || fromIndex >= queue.size || toIndex >= queue.size) return@withLock
         val item = queue.removeAt(fromIndex)
         queue.add(toIndex, item)
-        updateFlags(flags.copy(sessionQueue = queue))
+        updateFlagsUnlocked(flags.copy(sessionQueue = queue))
     }
 
-    suspend fun incrementDungeonRun(activityKey: String) {
-        val flags = getFlags()
+    suspend fun incrementDungeonRun(activityKey: String) = playerMutex.withLock {
+        val flags = getFlagsUnlocked()
         val updated = flags.dungeonRuns.toMutableMap()
         updated[activityKey] = (updated[activityKey] ?: 0) + 1
-        updateFlags(flags.copy(dungeonRuns = updated))
+        updateFlagsUnlocked(flags.copy(dungeonRuns = updated))
     }
 
-    suspend fun markWhatsNewSeen(versionCode: Int) {
-        updateFlags(getFlags().copy(lastSeenVersionCode = versionCode))
+    suspend fun markWhatsNewSeen(versionCode: Int) = playerMutex.withLock {
+        updateFlagsUnlocked(getFlagsUnlocked().copy(lastSeenVersionCode = versionCode))
     }
 
     /**
@@ -713,16 +713,19 @@ class PlayerRepository @Inject constructor(
         playerDao.upsert(player.copy(flags = json.encode<PlayerFlags>(flags.copy(characterRace = race))))
     }
 
-    suspend fun dismissCharacterSetup() {
+    suspend fun dismissCharacterSetup() = playerMutex.withLock {
         val player = getOrCreatePlayer()
         val flags: PlayerFlags = json.decodeFromString(player.flags)
         playerDao.upsert(player.copy(flags = json.encode<PlayerFlags>(flags.copy(characterSetupDone = true))))
     }
 
-    suspend fun updateEquipped(equipped: Map<String, String?>) {
+    internal suspend fun updateEquippedUnlocked(equipped: Map<String, String?>) {
         val player = getOrCreatePlayer()
         playerDao.upsert(player.copy(equipped = json.encode<Map<String, String?>>(equipped)))
     }
+
+    suspend fun updateEquipped(equipped: Map<String, String?>) =
+        playerMutex.withLock { updateEquippedUnlocked(equipped) }
 
     /**
      * Re-applies [style]'s remembered loadout: armor (EquipSlot.ARMOR_SLOTS; weapons are
@@ -732,7 +735,7 @@ class PlayerRepository @Inject constructor(
      * style's complete loadout so the next switch is deterministic. Entries referencing an item
      * the player no longer owns, or doesn't meet the level requirement for, are skipped silently.
      */
-    suspend fun applyLoadout(style: String, equipment: Map<String, EquipmentData>) {
+    suspend fun applyLoadout(style: String, equipment: Map<String, EquipmentData>) = playerMutex.withLock {
         val player = getOrCreatePlayer()
         val flags: PlayerFlags = json.decodeFromString(player.flags)
         val inventory: Map<String, Int> = json.decodeFromString(player.inventory)
@@ -763,7 +766,7 @@ class PlayerRepository @Inject constructor(
                 }
             }
         }
-        if (newEquipped != currentEquipped) updateEquipped(newEquipped)
+        if (newEquipped != currentEquipped) updateEquippedUnlocked(newEquipped)
 
         var newFlags = flags
         // Snapshot the applied result as this style's complete loadout. Legacy sparse
@@ -780,16 +783,16 @@ class PlayerRepository @Inject constructor(
             val spellName = flags.magicLoadoutSpellName
             if (spellName != null) newFlags = newFlags.copy(activeSpell = spellName)
         }
-        if (newFlags != flags) updateFlags(newFlags)
+        if (newFlags != flags) updateFlagsUnlocked(newFlags)
     }
 
-    suspend fun updatePets(pets: List<OwnedPet>) {
+    suspend fun updatePets(pets: List<OwnedPet>) = playerMutex.withLock {
         val player = getOrCreatePlayer()
         playerDao.upsert(player.copy(pets = json.encode<List<OwnedPet>>(pets)))
     }
 
     /** Buy [qty] of [itemKey] at [priceEach] coins. Returns false if insufficient coins. */
-    suspend fun buyItem(itemKey: String, qty: Int, priceEach: Int): Boolean {
+    suspend fun buyItem(itemKey: String, qty: Int, priceEach: Int): Boolean = playerMutex.withLock {
         val player = getOrCreatePlayer()
         val total  = priceEach.toLong() * qty
         if (player.coins < total) return false
@@ -807,7 +810,7 @@ class PlayerRepository @Inject constructor(
     }
 
     /** Sell [qty] of [itemKey] for [priceEach] coins each. Returns false if not enough in inventory. Unequips the item if no copies remain. */
-    suspend fun sellItem(itemKey: String, qty: Int, priceEach: Int): Boolean {
+    suspend fun sellItem(itemKey: String, qty: Int, priceEach: Int): Boolean = playerMutex.withLock {
         val player = getOrCreatePlayer()
         val inventory: MutableMap<String, Int> = json.decodeFromString(player.inventory)
         if ((inventory[itemKey] ?: 0) < qty) return false
@@ -929,7 +932,7 @@ class PlayerRepository @Inject constructor(
      * (no stacking) and limited to one purchase per weekly reset (Monday 6am, same clock as
      * weekly quests). Deducts [cost] coins on success.
      */
-    suspend fun activateXpBoost(durationMs: Long, cost: Long = XP_BOOST_COST): XpBoostPurchaseResult {
+    suspend fun activateXpBoost(durationMs: Long, cost: Long = XP_BOOST_COST): XpBoostPurchaseResult = playerMutex.withLock {
         val player = getOrCreatePlayer()
         val flags: PlayerFlags = json.decodeFromString(player.flags)
         val now = System.currentTimeMillis()
@@ -959,7 +962,7 @@ class PlayerRepository @Inject constructor(
      * Grants [durationMs] of 2× XP boost as a reward (seasonal event tiers). No cost, exempt
      * from the purchase limits, and extends any boost already running so the reward is never lost.
      */
-    suspend fun grantXpBoost(durationMs: Long) {
+    internal suspend fun grantXpBoostUnlocked(durationMs: Long) {
         val player = getOrCreatePlayer()
         val flags: PlayerFlags = json.decodeFromString(player.flags)
         val now        = System.currentTimeMillis()
@@ -972,6 +975,8 @@ class PlayerRepository @Inject constructor(
         buffNotifScheduler.cancelXpBoostExpiry()
         buffNotifScheduler.scheduleXpBoostExpiry(newExpiry)
     }
+
+    suspend fun grantXpBoost(durationMs: Long) = playerMutex.withLock { grantXpBoostUnlocked(durationMs) }
 
     /** Bronze/starter fallback item granted to a slot if prestige invalidates its gear and nothing else in inventory qualifies. */
     private val prestigeStarterGearForSlot = mapOf(

--- a/app/src/main/kotlin/com/fantasyidler/repository/PlayerRepository.kt
+++ b/app/src/main/kotlin/com/fantasyidler/repository/PlayerRepository.kt
@@ -707,7 +707,7 @@ class PlayerRepository @Inject constructor(
         PrestigeActionResult.SUCCESS
     }
 
-    suspend fun debugChangeRaceFree(race: String) {
+    suspend fun debugChangeRaceFree(race: String) = playerMutex.withLock {
         val player = getOrCreatePlayer()
         val flags: PlayerFlags = json.decodeFromString(player.flags)
         playerDao.upsert(player.copy(flags = json.encode<PlayerFlags>(flags.copy(characterRace = race))))

--- a/app/src/main/kotlin/com/fantasyidler/repository/QueuedSessionStarter.kt
+++ b/app/src/main/kotlin/com/fantasyidler/repository/QueuedSessionStarter.kt
@@ -190,90 +190,92 @@ class QueuedSessionStarter @Inject constructor(
      * Called from [SessionRepository.recoverActiveSession] to reconstruct offline progress.
      */
     suspend fun insertNextQueuedAsOffline(remainingMs: Long): Long {
-        mutex.withLock {
-            val player = playerRepo.getOrCreatePlayer()
-            val levels: Map<String, Int> = json.decodeFromString(player.skillLevels)
-            val flags: PlayerFlags       = json.decodeFromString(player.flags)
-            val agilityLevel    = levels[Skills.AGILITY] ?: 1
-            val floorReductionMin = boostRepo.sessionFloorReductionMin(flags)
-            val chronosMult     = townRepo.playerSessionDurationMultiplier(flags)
-            // A boss repeat run (queued as one entry, tracked via PlayerFlags rather than N
-            // separate queue entries) is advanced here one fight at a time, same as the live
-            // (non-offline) chain in startNextQueued() -- returning before ever reaching the
-            // sessionQueue scan below preserves the "don't let another queue item jump an
-            // in-progress chain" guarantee from issue #1167.
-            if (flags.activeBossRepeatSnapshot != null && flags.activeBossRepeatIndex < flags.activeBossRepeatTotal) {
-                val current = sessionRepo.getActiveSession()
-                if (current == null || !current.completed || current.skillName != "boss") return 0L
-                val won = (json.decodeFromString<List<SessionFrame>>(current.frames).lastOrNull()?.kills ?: 0) > 0
-                if (!won) {
-                    playerRepo.clearActiveBossRepeatUnlocked()
-                    return 0L
+        return playerRepo.playerMutex.withLock {
+            mutex.withLock {
+                val player = playerRepo.getOrCreatePlayer()
+                val levels: Map<String, Int> = json.decodeFromString(player.skillLevels)
+                val flags: PlayerFlags       = json.decodeFromString(player.flags)
+                val agilityLevel    = levels[Skills.AGILITY] ?: 1
+                val floorReductionMin = boostRepo.sessionFloorReductionMin(flags)
+                val chronosMult     = townRepo.playerSessionDurationMultiplier(flags)
+                // A boss repeat run (queued as one entry, tracked via PlayerFlags rather than N
+                // separate queue entries) is advanced here one fight at a time, same as the live
+                // (non-offline) chain in startNextQueued() -- returning before ever reaching the
+                // sessionQueue scan below preserves the "don't let another queue item jump an
+                // in-progress chain" guarantee from issue #1167.
+                if (flags.activeBossRepeatSnapshot != null && flags.activeBossRepeatIndex < flags.activeBossRepeatTotal) {
+                    val current = sessionRepo.getActiveSession()
+                    if (current == null || !current.completed || current.skillName != "boss") return@withLock 0L
+                    val won = (json.decodeFromString<List<SessionFrame>>(current.frames).lastOrNull()?.kills ?: 0) > 0
+                    if (!won) {
+                        playerRepo.clearActiveBossRepeatUnlocked()
+                        return@withLock 0L
+                    }
+                    val snapshot = flags.activeBossRepeatSnapshot!!
+                    val duration = estimateDuration(snapshot, agilityLevel, floorReductionMin, chronosMult)
+                    if (duration > remainingMs) return@withLock 0L
+                    return@withLock try {
+                        startQueuedAction(snapshot, offline = true, backdateMs = remainingMs)
+                        playerRepo.updateFlagsUnlocked(playerRepo.getFlagsUnlocked().copy(activeBossRepeatIndex = flags.activeBossRepeatIndex + 1))
+                        duration
+                    } catch (_: Exception) {
+                        playerRepo.clearActiveBossRepeatUnlocked()
+                        0L
+                    }
                 }
-                val snapshot = flags.activeBossRepeatSnapshot!!
-                val duration = estimateDuration(snapshot, agilityLevel, floorReductionMin, chronosMult)
-                if (duration > remainingMs) return 0L
-                return try {
-                    startQueuedAction(snapshot, offline = true, backdateMs = remainingMs)
-                    playerRepo.updateFlagsUnlocked(playerRepo.getFlagsUnlocked().copy(activeBossRepeatIndex = flags.activeBossRepeatIndex + 1))
-                    duration
-                } catch (_: Exception) {
-                    playerRepo.clearActiveBossRepeatUnlocked()
-                    0L
+                // Same idea as the boss repeat chain above, but for dungeon runs (issue #1167 / #1189).
+                if (flags.activeDungeonRepeatSnapshot != null && flags.activeDungeonRepeatIndex < flags.activeDungeonRepeatTotal) {
+                    val current = sessionRepo.getActiveSession()
+                    if (current == null || !current.completed || current.skillName != "combat") return@withLock 0L
+                    val survived = json.decodeFromString<List<SessionFrame>>(current.frames).lastOrNull()?.died != true
+                    if (!survived) {
+                        playerRepo.clearActiveDungeonRepeatUnlocked()
+                        return@withLock 0L
+                    }
+                    val snapshot = flags.activeDungeonRepeatSnapshot!!
+                    val duration = estimateDuration(snapshot, agilityLevel, floorReductionMin, chronosMult)
+                    if (duration > remainingMs) return@withLock 0L
+                    return@withLock try {
+                        startQueuedAction(snapshot, offline = true, backdateMs = remainingMs)
+                        playerRepo.updateFlagsUnlocked(playerRepo.getFlagsUnlocked().copy(activeDungeonRepeatIndex = flags.activeDungeonRepeatIndex + 1))
+                        duration
+                    } catch (_: Exception) {
+                        playerRepo.clearActiveDungeonRepeatUnlocked()
+                        0L
+                    }
                 }
-            }
-            // Same idea as the boss repeat chain above, but for dungeon runs (issue #1167 / #1189).
-            if (flags.activeDungeonRepeatSnapshot != null && flags.activeDungeonRepeatIndex < flags.activeDungeonRepeatTotal) {
-                val current = sessionRepo.getActiveSession()
-                if (current == null || !current.completed || current.skillName != "combat") return 0L
-                val survived = json.decodeFromString<List<SessionFrame>>(current.frames).lastOrNull()?.died != true
-                if (!survived) {
-                    playerRepo.clearActiveDungeonRepeatUnlocked()
-                    return 0L
+                // Same reasoning as startNextQueued(): scan a local copy of the queue and persist
+                // at most once, only when something actually starts (issue #1183).
+                val originalQueue = flags.sessionQueue
+                var remaining = originalQueue
+                val skippedTowerActions = mutableListOf<QueuedAction>()
+                var maxAttempts = originalQueue.size
+                while (maxAttempts-- >= 0) {
+                    val next = remaining.firstOrNull() ?: break
+                    remaining = remaining.drop(1)
+                    val duration = estimateDuration(next, agilityLevel, floorReductionMin, chronosMult)
+                    if (duration > remainingMs) return@withLock 0L
+                    try {
+                        // backdateMs = remainingMs so each fast-forwarded session in the same
+                        // catch-up burst gets a distinct startedAt (now - remainingMs), staying
+                        // strictly ordered by queue position instead of all colliding on "now".
+                        startQueuedAction(next, offline = true, backdateMs = remainingMs)
+                        if (next.skillName == "boss") playerRepo.stampBossRepeatStartUnlocked(next)
+                        if (next.skillName == "combat") playerRepo.stampDungeonRepeatStartUnlocked(next)
+                        val finalQueue = skippedTowerActions + remaining
+                        playerRepo.updateFlagsUnlocked(playerRepo.getFlagsUnlocked().copy(sessionQueue = finalQueue))
+                        return@withLock duration
+                    } catch (_: TowerPendingCollectionException) {
+                        skippedTowerActions += next
+                    } catch (_: Exception) {
+                        // Nothing was ever written to the DB, so the queue is still exactly
+                        // originalQueue -- no requeue needed.
+                        return@withLock 0L
+                    }
                 }
-                val snapshot = flags.activeDungeonRepeatSnapshot!!
-                val duration = estimateDuration(snapshot, agilityLevel, floorReductionMin, chronosMult)
-                if (duration > remainingMs) return 0L
-                return try {
-                    startQueuedAction(snapshot, offline = true, backdateMs = remainingMs)
-                    playerRepo.updateFlagsUnlocked(playerRepo.getFlagsUnlocked().copy(activeDungeonRepeatIndex = flags.activeDungeonRepeatIndex + 1))
-                    duration
-                } catch (_: Exception) {
-                    playerRepo.clearActiveDungeonRepeatUnlocked()
-                    0L
-                }
-            }
-            // Same reasoning as startNextQueued(): scan a local copy of the queue and persist
-            // at most once, only when something actually starts (issue #1183).
-            val originalQueue = flags.sessionQueue
-            var remaining = originalQueue
-            val skippedTowerActions = mutableListOf<QueuedAction>()
-            var maxAttempts = originalQueue.size
-            while (maxAttempts-- >= 0) {
-                val next = remaining.firstOrNull() ?: break
-                remaining = remaining.drop(1)
-                val duration = estimateDuration(next, agilityLevel, floorReductionMin, chronosMult)
-                if (duration > remainingMs) return 0L
-                try {
-                    // backdateMs = remainingMs so each fast-forwarded session in the same
-                    // catch-up burst gets a distinct startedAt (now - remainingMs), staying
-                    // strictly ordered by queue position instead of all colliding on "now".
-                    startQueuedAction(next, offline = true, backdateMs = remainingMs)
-                    if (next.skillName == "boss") playerRepo.stampBossRepeatStartUnlocked(next)
-                    if (next.skillName == "combat") playerRepo.stampDungeonRepeatStartUnlocked(next)
-                    val finalQueue = skippedTowerActions + remaining
-                    playerRepo.updateFlagsUnlocked(playerRepo.getFlagsUnlocked().copy(sessionQueue = finalQueue))
-                    return duration
-                } catch (_: TowerPendingCollectionException) {
-                    skippedTowerActions += next
-                } catch (_: Exception) {
-                    // Nothing was ever written to the DB, so the queue is still exactly
-                    // originalQueue -- no requeue needed.
-                    return 0L
-                }
+                0L
             }
         }
-        return 0L
     }
 
     private suspend fun startQueuedAction(action: QueuedAction, offline: Boolean = false, backdateMs: Long = 0L) {

--- a/app/src/main/kotlin/com/fantasyidler/repository/SeasonalEventRepository.kt
+++ b/app/src/main/kotlin/com/fantasyidler/repository/SeasonalEventRepository.kt
@@ -276,7 +276,7 @@ class SeasonalEventRepository @Inject constructor(
         }
         // Ironman characters never receive the XP boost component (boosts are inert for them);
         // the tier's other rewards are still granted.
-        if (tier.xpBoost && !flags.ironman) playerRepo.grantXpBoost(PlayerRepository.XP_BOOST_DURATION_MS)
+        if (tier.xpBoost && !flags.ironman) playerRepo.grantXpBoostUnlocked(PlayerRepository.XP_BOOST_DURATION_MS)
 
         // The grants above rewrite the flags column (seen items, boost expiry) — re-read before recording the claim.
         val latest = playerRepo.getFlagsUnlocked()

--- a/app/src/test/kotlin/com/fantasyidler/repository/OfflineCatchUpMutexTest.kt
+++ b/app/src/test/kotlin/com/fantasyidler/repository/OfflineCatchUpMutexTest.kt
@@ -1,0 +1,92 @@
+package com.fantasyidler.repository
+
+import android.content.Context
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.fantasyidler.data.db.AppDatabase
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeoutOrNull
+import kotlinx.serialization.json.Json
+import org.junit.After
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.annotation.Config
+
+/**
+ * H2 regression guard (issues.md): offline queue fast-forward must hold playerMutex
+ * around its internal mutex, matching startNextQueued()'s lock hierarchy
+ * (playerMutex -> QueuedSessionStarter.mutex), and must not re-enter playerMutex.
+ */
+@RunWith(AndroidJUnit4::class)
+@Config(manifest = Config.NONE, sdk = [34])
+class OfflineCatchUpMutexTest {
+
+    private lateinit var context: Context
+    private lateinit var db: AppDatabase
+    private lateinit var playerRepo: PlayerRepository
+    private lateinit var starter: QueuedSessionStarter
+
+    @Before
+    fun setup() {
+        context = ApplicationProvider.getApplicationContext()
+        db = Room.inMemoryDatabaseBuilder(context, AppDatabase::class.java)
+            .allowMainThreadQueries()
+            .build()
+        val json = Json { ignoreUnknownKeys = true }
+        val gameData = GameDataRepository(context, json)
+        val dailyQuestRepo = DailyQuestRepository(gameData)
+        val weeklyQuestRepo = WeeklyQuestRepository(gameData)
+        val boostRepo = BoostRepository(gameData)
+        playerRepo = PlayerRepository(
+            db.playerDao(),
+            db.questProgressDao(),
+            db.farmingPatchDao(),
+            json,
+            dailyQuestRepo,
+            weeklyQuestRepo,
+            BuffNotificationScheduler(context),
+            gameData,
+            boostRepo,
+            db,
+        )
+        val sessionRepo = SessionRepository(db.skillSessionDao(), context, json, gameData, db.playerDao())
+        val questRepo = QuestRepository(db.questProgressDao(), gameData)
+        val townRepo = TownRepository(gameData, playerRepo, questRepo, boostRepo)
+        val mercRepo = MercenaryRepository(playerRepo, gameData, dailyQuestRepo)
+        starter = QueuedSessionStarter(
+            boostRepo, context, playerRepo, sessionRepo, townRepo, gameData, mercRepo, json,
+        )
+        runBlocking { playerRepo.getOrCreatePlayer() }
+    }
+
+    @After
+    fun tearDown() {
+        db.close()
+    }
+
+    @Test
+    fun `insertNextQueuedAsOffline serializes on playerMutex without re-entering it`() = runBlocking {
+        val gate = CompletableDeferred<Unit>()
+        val holder = launch { playerRepo.withLock { gate.await() } }
+        var waited = 0
+        while (!playerRepo.playerMutex.isLocked && waited < 2_000) { delay(5); waited += 5 }
+        assertTrue("holder never acquired playerMutex", playerRepo.playerMutex.isLocked)
+
+        val ranWhileLocked = withTimeoutOrNull(300) { starter.insertNextQueuedAsOffline(1_000L); true }
+        assertNull("offline catch-up ran while playerMutex was held elsewhere", ranWhileLocked)
+
+        gate.complete(Unit)
+        val finishedAfterRelease = withTimeoutOrNull(3_000) { starter.insertNextQueuedAsOffline(1_000L); true }
+        assertNotNull("offline catch-up did not finish after lock release (re-entry deadlock)", finishedAfterRelease)
+
+        holder.cancel()
+    }
+}

--- a/app/src/test/kotlin/com/fantasyidler/repository/OfflineCatchUpMutexTest.kt
+++ b/app/src/test/kotlin/com/fantasyidler/repository/OfflineCatchUpMutexTest.kt
@@ -21,7 +21,7 @@ import org.junit.runner.RunWith
 import org.robolectric.annotation.Config
 
 /**
- * H2 regression guard (issues.md): offline queue fast-forward must hold playerMutex
+ * Offline queue fast-forward must hold playerMutex
  * around its internal mutex, matching startNextQueued()'s lock hierarchy
  * (playerMutex -> QueuedSessionStarter.mutex), and must not re-enter playerMutex.
  */

--- a/app/src/test/kotlin/com/fantasyidler/repository/PlayerMutexCoverageTest.kt
+++ b/app/src/test/kotlin/com/fantasyidler/repository/PlayerMutexCoverageTest.kt
@@ -101,5 +101,6 @@ class PlayerMutexCoverageTest {
         probe("sellItem") { playerRepo.sellItem("probe_item", 1, 1) }
         probe("activateXpBoost") { playerRepo.activateXpBoost(1_000L, 0L) }
         probe("grantXpBoost") { playerRepo.grantXpBoost(1_000L) }
+        probe("debugChangeRaceFree") { playerRepo.debugChangeRaceFree("human") }
     }
 }

--- a/app/src/test/kotlin/com/fantasyidler/repository/PlayerMutexCoverageTest.kt
+++ b/app/src/test/kotlin/com/fantasyidler/repository/PlayerMutexCoverageTest.kt
@@ -1,0 +1,105 @@
+package com.fantasyidler.repository
+
+import android.content.Context
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.fantasyidler.data.db.AppDatabase
+import com.fantasyidler.data.model.OwnedPet
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeoutOrNull
+import kotlinx.serialization.json.Json
+import org.junit.After
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.annotation.Config
+
+/**
+ * H1 regression guard (issues.md): every whole-row PlayerEntity mutator must serialize on
+ * [PlayerRepository.playerMutex], and none may re-enter that mutex internally --
+ * kotlinx Mutex is non-reentrant, so nested acquisition hangs forever.
+ */
+@RunWith(AndroidJUnit4::class)
+@Config(manifest = Config.NONE, sdk = [34])
+class PlayerMutexCoverageTest {
+
+    private lateinit var context: Context
+    private lateinit var db: AppDatabase
+    private lateinit var playerRepo: PlayerRepository
+
+    @Before
+    fun setup() {
+        context = ApplicationProvider.getApplicationContext()
+        db = Room.inMemoryDatabaseBuilder(context, AppDatabase::class.java)
+            .allowMainThreadQueries()
+            .build()
+        val json = Json { ignoreUnknownKeys = true }
+        val gameData = GameDataRepository(context, json)
+        playerRepo = PlayerRepository(
+            db.playerDao(),
+            db.questProgressDao(),
+            db.farmingPatchDao(),
+            json,
+            DailyQuestRepository(gameData),
+            WeeklyQuestRepository(gameData),
+            BuffNotificationScheduler(context),
+            gameData,
+            BoostRepository(gameData),
+            db,
+        )
+        runBlocking { playerRepo.getOrCreatePlayer() }
+    }
+
+    @After
+    fun tearDown() {
+        db.close()
+    }
+
+    /**
+     * While an external holder owns playerMutex, [op] must not run at all;
+     * after the holder releases, [op] must finish promptly (no nested-lock hang).
+     */
+    private fun probe(opName: String, op: suspend () -> Unit) = runBlocking {
+        val gate = CompletableDeferred<Unit>()
+        val holder = launch { playerRepo.withLock { gate.await() } }
+        var waited = 0
+        while (!playerRepo.playerMutex.isLocked && waited < 2_000) { delay(5); waited += 5 }
+        assertTrue("$opName: holder never acquired playerMutex", playerRepo.playerMutex.isLocked)
+
+        val ranWhileLocked = withTimeoutOrNull(300) { op(); true }
+        assertNull("$opName ran while playerMutex was held elsewhere (unlocked mutator)", ranWhileLocked)
+
+        gate.complete(Unit)
+        val finishedAfterRelease = withTimeoutOrNull(3_000) { op(); true }
+        assertNotNull("$opName did not finish after lock release (internal re-entry deadlock)", finishedAfterRelease)
+
+        holder.cancel()
+    }
+
+    @Test
+    fun `all player entity mutators serialize on playerMutex without re-entering it`() {
+        probe("deductSkillXp") { playerRepo.deductSkillXp("mining", 10L) }
+        probe("debugAddSkillXp") { playerRepo.debugAddSkillXp("mining", 10L) }
+        probe("buryBonesAtomic") { playerRepo.buryBonesAtomic("bones", 1, 100L) }
+        probe("removeFromQueue") { playerRepo.removeFromQueue(0) }
+        probe("evictQueueForSkill") { playerRepo.evictQueueForSkill("mining") }
+        probe("moveQueueItem") { playerRepo.moveQueueItem(0, 0) }
+        probe("incrementDungeonRun") { playerRepo.incrementDungeonRun("crypt") }
+        probe("markWhatsNewSeen") { playerRepo.markWhatsNewSeen(1) }
+        probe("dismissCharacterSetup") { playerRepo.dismissCharacterSetup() }
+        probe("updateEquipped") { playerRepo.updateEquipped(mapOf("head" to null)) }
+        probe("applyLoadout") { playerRepo.applyLoadout("melee", emptyMap()) }
+        probe("updatePets") { playerRepo.updatePets(emptyList<OwnedPet>()) }
+        probe("buyItem") { playerRepo.buyItem("probe_item", 1, 1) }
+        probe("sellItem") { playerRepo.sellItem("probe_item", 1, 1) }
+        probe("activateXpBoost") { playerRepo.activateXpBoost(1_000L, 0L) }
+        probe("grantXpBoost") { playerRepo.grantXpBoost(1_000L) }
+    }
+}

--- a/app/src/test/kotlin/com/fantasyidler/repository/PlayerMutexCoverageTest.kt
+++ b/app/src/test/kotlin/com/fantasyidler/repository/PlayerMutexCoverageTest.kt
@@ -22,7 +22,7 @@ import org.junit.runner.RunWith
 import org.robolectric.annotation.Config
 
 /**
- * H1 regression guard (issues.md): every whole-row PlayerEntity mutator must serialize on
+ * Every whole-row PlayerEntity mutator must serialize on
  * [PlayerRepository.playerMutex], and none may re-enter that mutex internally --
  * kotlinx Mutex is non-reentrant, so nested acquisition hangs forever.
  */


### PR DESCRIPTION
## Summary

This change fixes concurrency race conditions where simultaneous player entity mutations and background offline queue catch-up could overwrite state changes or corrupt player data.

### 1. Synchronize `PlayerRepository` Mutations
- `PlayerEntity` is stored as a single database row and updated via full-row `@Upsert`. Previously, several mutation methods did not acquire `playerMutex`, allowing concurrent writes (such as session completions, shop transactions, and queue modifications) to overwrite intermediate database changes.
- Wrapped all mutation methods in `playerMutex.withLock`:
  - `deductSkillXp`
  - `debugAddSkillXp`
  - `buryBonesAtomic`
  - `removeFromQueue`
  - `evictQueueForSkill`
  - `moveQueueItem`
  - `incrementDungeonRun`
  - `markWhatsNewSeen`
  - `dismissCharacterSetup`
  - `updateEquipped`
  - `applyLoadout`
  - `updatePets`
  - `buyItem`
  - `sellItem`
  - `activateXpBoost`
  - `grantXpBoost`
  - `debugChangeRaceFree`
- Resolved non-reentrant deadlock hazards across nested calls by extracting internal unlocked counterparts (`updateEquippedUnlocked`, `grantXpBoostUnlocked`) and delegating internal calls to `getFlagsUnlocked()` and `updateFlagsUnlocked()`.
- Updated `SeasonalEventRepository` claim flow to invoke `grantXpBoostUnlocked()` within its existing lock boundary.

### 2. Lock Hierarchy Synchronization in Offline Queue Catch-Up
- `QueuedSessionStarter.insertNextQueuedAsOffline()` previously acquired only its local mutex while calling unlocked player state mutators. This created a race condition with foreground UI operations (such as session claims or inventory updates).
- Wrapped `insertNextQueuedAsOffline()` in `playerRepo.playerMutex.withLock { mutex.withLock { ... } }`, aligning its lock acquisition hierarchy with `startNextQueued()`.

### 3. Automated Test Coverage
- Added `PlayerMutexCoverageTest`: Validates that all 17 player entity mutators properly serialize on `playerMutex` and do not deadlock from re-entrant lock acquisitions.
- Added `OfflineCatchUpMutexTest`: Validates that `insertNextQueuedAsOffline()` serializes against external `playerMutex` holders and completes cleanly without deadlock.

## Verification

- Ran unit and Robolectric test suites.
- Verified thread serialization and non-reentrant execution across all modified repository endpoints.