### PR TITLE
Extend roman numerals up to 10 to fix 'Precision 6'

### DIFF
--- a/app/src/main/kotlin/com/fantasyidler/ui/screen/PrestigeDetailScreen.kt
+++ b/app/src/main/kotlin/com/fantasyidler/ui/screen/PrestigeDetailScreen.kt
@@ -69,7 +69,7 @@ import androidx.compose.ui.graphics.Color
 import com.fantasyidler.util.GameStrings
 import com.fantasyidler.util.formatDurationMs
 
-private val TIER_NUMERALS = listOf("I", "II", "III", "IV", "V")
+private val TIER_NUMERALS = listOf("I", "II", "III", "IV", "V", "VI", "VII", "VIII", "IX", "X")
 
 // Same success green as the quest/guild checkmarks; "your race" on race locks.
 private val RaceLockGreen = Color(0xFF4CAF50)


### PR DESCRIPTION
## Before submitting

- [x] I've tested any changes with the appropriate tests (eg. Unit tests, validation scripts)
- [x] I've pulled and merged the latest changes from the repository

## Summary

Extend roman numerals up to 10 to fix 'Precision 6'

## Related issue(s) or discussion(s)

## Changelog

- Extended roman numerals up to 10

## Anything else?

