### PR TITLE
 Make boost formatting more consistent, their types more distinguishable and extend tap area

### DIFF
--- a/app/src/main/kotlin/com/fantasyidler/ui/components/PlayerStatsBar.kt
+++ b/app/src/main/kotlin/com/fantasyidler/ui/components/PlayerStatsBar.kt
@@ -84,7 +84,7 @@ fun PlayerStatsBar(
                 val boostDesc = blessingData?.let { b ->
                     val eff = ChurchRepository.effectiveMagnitude(b, prayerCapeMult)
                     when (b.type) {
-                        BlessingType.XP      -> "${(eff * 100).roundToInt() / 100f}× XP"
+                        BlessingType.XP      -> "${(eff * 100).roundToInt() / 100f}× All skills XP"
                         BlessingType.DEFENSE -> "+${eff.toInt()} DEF"
                         BlessingType.COINS   -> "+${(eff * 100).roundToInt()}% coins"
                     }
@@ -133,7 +133,7 @@ fun PlayerStatsBar(
             val collapsible = boostLines.size > MAX_VISIBLE_BOOST_LINES
             val visibleLines = if (collapsible && !expanded) boostLines.take(MAX_VISIBLE_BOOST_LINES) else boostLines
             Column(
-                modifier = if (collapsible) Modifier.clickable { expanded = !expanded } else Modifier,
+                modifier = if (collapsible) Modifier.fillMaxWidth().clickable { expanded = !expanded } else Modifier.fillMaxWidth(),
                 verticalArrangement = Arrangement.spacedBy(4.dp),
             ) {
                 visibleLines.forEach { line ->

--- a/app/src/main/kotlin/com/fantasyidler/ui/components/PlayerStatsBar.kt
+++ b/app/src/main/kotlin/com/fantasyidler/ui/components/PlayerStatsBar.kt
@@ -14,7 +14,10 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Bolt
+import androidx.compose.material.icons.filled.MilitaryTech
 import androidx.compose.material.icons.filled.Star
+import androidx.compose.material.icons.filled.WorkspacePremium
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
@@ -26,6 +29,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import com.fantasyidler.R
@@ -39,7 +43,7 @@ import com.fantasyidler.util.formatDurationMs
 
 private const val MAX_VISIBLE_BOOST_LINES = 3
 
-private data class BoostLine(val tint: Color, val text: String)
+private data class BoostLine(val icon: ImageVector, val tint: Color, val text: String)
 
 @OptIn(ExperimentalLayoutApi::class)
 @Composable
@@ -79,6 +83,7 @@ fun PlayerStatsBar(
             )
         }
         val primaryTint = MaterialTheme.colorScheme.primary
+        val secondaryTint = MaterialTheme.colorScheme.secondary
         val tertiaryTint = MaterialTheme.colorScheme.tertiary
         val boostLines = buildList {
             if (blessingActive) {
@@ -90,20 +95,27 @@ fun PlayerStatsBar(
                 val boostDesc = blessingData?.let { b ->
                     val eff = ChurchRepository.effectiveMagnitude(b, prayerCapeMult)
                     when (b.type) {
-                        BlessingType.XP      -> "${(eff * 100).roundToInt() / 100f}x XP"
+                        BlessingType.XP      -> "${(eff * 100).roundToInt() / 100f}× XP"
                         BlessingType.DEFENSE -> "+${eff.toInt()} DEF"
                         BlessingType.COINS   -> "+${(eff * 100).roundToInt()}% coins"
                     }
                 }
                 val timeLeft = activeBlessingRemainingMs.formatDurationMs(context)
-                val blessingText = if (boostDesc != null) "$blessingName ($boostDesc) - $timeLeft"
+                val blessingText = if (boostDesc != null) "$boostDesc - $blessingName - $timeLeft"
                                   else "$blessingName - $timeLeft"
-                add(BoostLine(tint = primaryTint, text = blessingText))
+                add(
+                    BoostLine(
+                        icon = Icons.Filled.Star,
+                        tint = primaryTint,
+                        text = blessingText
+                    )
+                )
             }
             if (boostActive) {
                 add(
                     BoostLine(
-                        tint = tertiaryTint,
+                        icon = Icons.Filled.Bolt,
+                        tint = secondaryTint,
                         text = stringResource(R.string.home_xp_boost_active, xpBoostRemainingMs.formatDurationMs(context)),
                     )
                 )
@@ -111,6 +123,7 @@ fun PlayerStatsBar(
             prestigeBoostsRemainingMs.entries.sortedBy { it.key }.forEach { (skill, remainingMs) ->
                 add(
                     BoostLine(
+                        icon = Icons.Filled.WorkspacePremium,
                         tint = tertiaryTint,
                         text = stringResource(
                             R.string.home_prestige_xp_boost_active,
@@ -137,7 +150,7 @@ fun PlayerStatsBar(
                 visibleLines.forEach { line ->
                     Row(verticalAlignment = Alignment.CenterVertically) {
                         Icon(
-                            imageVector        = Icons.Filled.Star,
+                            imageVector        = line.icon,
                             contentDescription = null,
                             tint               = line.tint,
                             modifier           = Modifier.size(12.dp),

--- a/app/src/main/kotlin/com/fantasyidler/ui/components/PlayerStatsBar.kt
+++ b/app/src/main/kotlin/com/fantasyidler/ui/components/PlayerStatsBar.kt
@@ -2,20 +2,9 @@ package com.fantasyidler.ui.components
 
 import android.content.Context
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.ExperimentalLayoutApi
-import androidx.compose.foundation.layout.FlowRow
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.*
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Bolt
-import androidx.compose.material.icons.filled.MilitaryTech
 import androidx.compose.material.icons.filled.Star
 import androidx.compose.material.icons.filled.WorkspacePremium
 import androidx.compose.material3.Icon
@@ -35,11 +24,11 @@ import androidx.compose.ui.unit.dp
 import com.fantasyidler.R
 import com.fantasyidler.data.json.BlessingType
 import com.fantasyidler.repository.ChurchRepository
-import kotlin.math.roundToInt
 import com.fantasyidler.ui.screen.StatInline
 import com.fantasyidler.util.GameStrings
 import com.fantasyidler.util.formatCoins
 import com.fantasyidler.util.formatDurationMs
+import kotlin.math.roundToInt
 
 private const val MAX_VISIBLE_BOOST_LINES = 3
 

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -507,9 +507,9 @@
     <string name="guild_progress_dailies_and_quest">Complete %1$d/%2$d daily requests &amp; quests to advance</string> <!-- untranslated -->
     <string name="guild_progress_dailies_only">Complete %1$d/%2$d daily requests to advance</string> <!-- untranslated -->
     <string name="home_died_message">You died and lost most of your gains.</string> <!-- untranslated -->
-    <string name="home_xp_boost_was_active">2× XP Boost was active</string> <!-- untranslated -->
-    <string name="home_xp_boost_active">2× XP Boost active — %1$s remaining</string> <!-- untranslated -->
-    <string name="home_prestige_xp_boost_active">2× %1$s XP Boost - %2$s remaining</string> <!-- untranslated -->
+    <string name="home_xp_boost_was_active">2× All skills XP was active</string> <!-- untranslated -->
+    <string name="home_xp_boost_active">2× All skills XP - %1$s</string> <!-- untranslated -->
+    <string name="home_prestige_xp_boost_active">2× %1$s XP - %2$s</string> <!-- untranslated -->
     <string name="boosts_show_more">+%1$d more boosts (tap to show)</string> <!-- untranslated -->
     <string name="boosts_show_less">Show less</string> <!-- untranslated -->
     <string name="home_loot">Loot</string> <!-- untranslated -->

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -507,9 +507,9 @@
     <string name="guild_progress_dailies_and_quest">Complete %1$d/%2$d daily requests &amp; quests to advance</string> <!-- untranslated -->
     <string name="guild_progress_dailies_only">Complete %1$d/%2$d daily requests to advance</string> <!-- untranslated -->
     <string name="home_died_message">You died and lost most of your gains.</string> <!-- untranslated -->
-    <string name="home_xp_boost_was_active">2× XP Boost was active</string> <!-- untranslated -->
-    <string name="home_xp_boost_active">2× XP Boost active — %1$s remaining</string> <!-- untranslated -->
-    <string name="home_prestige_xp_boost_active">2× %1$s XP Boost - %2$s remaining</string> <!-- untranslated -->
+    <string name="home_xp_boost_was_active">2× All skills XP was active</string> <!-- untranslated -->
+    <string name="home_xp_boost_active">2× All skills XP - %1$s</string> <!-- untranslated -->
+    <string name="home_prestige_xp_boost_active">2× %1$s XP - %2$s</string> <!-- untranslated -->
     <string name="boosts_show_more">+%1$d more boosts (tap to show)</string> <!-- untranslated -->
     <string name="boosts_show_less">Show less</string> <!-- untranslated -->
     <string name="home_loot">Loot</string> <!-- untranslated -->

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -511,9 +511,9 @@
     <string name="guild_progress_dailies_and_quest">Complete %1$d/%2$d daily requests &amp; quests to advance</string> <!-- untranslated -->
     <string name="guild_progress_dailies_only">Complete %1$d/%2$d daily requests to advance</string> <!-- untranslated -->
     <string name="home_died_message">You died and lost most of your gains.</string> <!-- untranslated -->
-    <string name="home_xp_boost_was_active">2× XP Boost was active</string> <!-- untranslated -->
-    <string name="home_xp_boost_active">2× XP Boost active — %1$s remaining</string> <!-- untranslated -->
-    <string name="home_prestige_xp_boost_active">2× %1$s XP Boost - %2$s remaining</string> <!-- untranslated -->
+    <string name="home_xp_boost_was_active">2× All skills XP was active</string> <!-- untranslated -->
+    <string name="home_xp_boost_active">2× All skills XP - %1$s</string> <!-- untranslated -->
+    <string name="home_prestige_xp_boost_active">2× %1$s XP - %2$s</string> <!-- untranslated -->
     <string name="boosts_show_more">+%1$d more boosts (tap to show)</string> <!-- untranslated -->
     <string name="boosts_show_less">Show less</string> <!-- untranslated -->
     <string name="home_loot">Loot</string> <!-- untranslated -->

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -507,9 +507,9 @@
     <string name="guild_progress_dailies_and_quest">Erledige %1$d/%2$d tägliche Aufträge und Aufgaben, um weiterzukommen</string>
     <string name="guild_progress_dailies_only">Erledige %1$d/%2$d tägliche Aufträge um weiterzukommen</string>
     <string name="home_died_message">Ihr seid verstorben und habt daher den Großteil Eurer Gewinne verloren.</string>
-    <string name="home_xp_boost_was_active">2×EP-Hilfe war aktiv</string>
-    <string name="home_xp_boost_active">2×EP-Hilfe aktiv — noch %1$s</string>
-    <string name="home_prestige_xp_boost_active">2× %1$s XP Boost - %2$s remaining</string> <!-- untranslated -->
+    <string name="home_xp_boost_was_active">2× EP für alle Fähigkeiten war aktiv</string>
+    <string name="home_xp_boost_active">2× EP alle Fähigkeiten — %1$s</string>
+    <string name="home_prestige_xp_boost_active">2× EP %1$s — %2$s</string> <!-- untranslated -->
     <string name="boosts_show_more">+%1$d more boosts (tap to show)</string> <!-- untranslated -->
     <string name="boosts_show_less">Show less</string> <!-- untranslated -->
     <string name="home_loot">Beute</string>

--- a/app/src/main/res/values-es-rES/strings.xml
+++ b/app/src/main/res/values-es-rES/strings.xml
@@ -507,8 +507,8 @@
     <string name="guild_progress_dailies_and_quest">Complete %1$d/%2$d daily requests &amp; quests to advance</string> <!-- untranslated -->
     <string name="guild_progress_dailies_only">Complete %1$d/%2$d daily requests to advance</string> <!-- untranslated -->
     <string name="home_died_message">Moriste y perdiste la mayor parte de tus ganancias.</string>
-    <string name="home_xp_boost_was_active">2× XP Boost was active</string> <!-- untranslated -->
-    <string name="home_xp_boost_active">2× XP Boost active — %1$s remaining</string> <!-- untranslated -->
+    <string name="home_xp_boost_was_active">2× All skills XP was active</string> <!-- untranslated -->
+    <string name="home_xp_boost_active">2× All skills XP - %1$s</string> <!-- untranslated -->
     <string name="home_prestige_xp_boost_active">2× %1$s XP Boost - %2$s remaining</string> <!-- untranslated -->
     <string name="boosts_show_more">+%1$d more boosts (tap to show)</string> <!-- untranslated -->
     <string name="boosts_show_less">Show less</string> <!-- untranslated -->

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -507,9 +507,9 @@
     <string name="guild_progress_dailies_and_quest">Complete %1$d/%2$d daily requests &amp; quests to advance</string> <!-- untranslated -->
     <string name="guild_progress_dailies_only">Complete %1$d/%2$d daily requests to advance</string> <!-- untranslated -->
     <string name="home_died_message">Moriste y perdiste la mayor parte de tus ganancias.</string>
-    <string name="home_xp_boost_was_active">2× XP Boost was active</string> <!-- untranslated -->
-    <string name="home_xp_boost_active">2× XP Boost active — %1$s remaining</string> <!-- untranslated -->
-    <string name="home_prestige_xp_boost_active">2× %1$s XP Boost - %2$s remaining</string> <!-- untranslated -->
+    <string name="home_xp_boost_was_active">2× All skills XP was active</string> <!-- untranslated -->
+    <string name="home_xp_boost_active">2× All skills XP - %1$s</string> <!-- untranslated -->
+    <string name="home_prestige_xp_boost_active">2× %1$s XP - %2$s</string> <!-- untranslated -->
     <string name="boosts_show_more">+%1$d more boosts (tap to show)</string> <!-- untranslated -->
     <string name="boosts_show_less">Show less</string> <!-- untranslated -->
     <string name="home_loot">Botín</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -507,9 +507,9 @@
     <string name="guild_progress_dailies_and_quest">Compléter %1$d/%2$d requêtes quotidiennes &amp; quêtes pour avancer</string>
     <string name="guild_progress_dailies_only">Compléter %1$d/%2$d requêtes quotidiennes pour avancer</string>
     <string name="home_died_message">Vous êtes mort et avez perdu la majorité de vos gains.</string>
-    <string name="home_xp_boost_was_active">Le bonus d\'XP ×2 était actif</string>
-    <string name="home_xp_boost_active">Bonus XP ×2 actif — %1$s restant</string>
-    <string name="home_prestige_xp_boost_active">Bonus d\'XP 2× %1$s - %2$s restant</string>
+    <string name="home_xp_boost_was_active">Le bonus d’XP ×2 de toutes les compétences était actif</string>
+    <string name="home_xp_boost_active">×2 XP toutes les compétences — %1$s</string>
+    <string name="home_prestige_xp_boost_active">×2 XP %1$s — %2$s</string>
     <string name="boosts_show_more">+%1$d more boosts (tap to show)</string> <!-- untranslated -->
     <string name="boosts_show_less">Show less</string> <!-- untranslated -->
     <string name="home_loot">Butin</string>

--- a/app/src/main/res/values-ga/strings.xml
+++ b/app/src/main/res/values-ga/strings.xml
@@ -535,9 +535,9 @@
     <string name="guild_progress_dailies_and_quest">Complete %1$d/%2$d daily requests &amp; quests to advance</string> <!-- untranslated -->
     <string name="guild_progress_dailies_only">Complete %1$d/%2$d daily requests to advance</string> <!-- untranslated -->
     <string name="home_died_message">You died and lost most of your gains.</string> <!-- untranslated -->
-    <string name="home_xp_boost_was_active">2× XP Boost was active</string> <!-- untranslated -->
-    <string name="home_xp_boost_active">2× XP Boost active — %1$s remaining</string> <!-- untranslated -->
-    <string name="home_prestige_xp_boost_active">2× %1$s XP Boost - %2$s remaining</string> <!-- untranslated -->
+    <string name="home_xp_boost_was_active">2× All skills XP was active</string> <!-- untranslated -->
+    <string name="home_xp_boost_active">2× All skills XP - %1$s</string> <!-- untranslated -->
+    <string name="home_prestige_xp_boost_active">2× %1$s XP - %2$s</string> <!-- untranslated -->
     <string name="boosts_show_more">+%1$d more boosts (tap to show)</string> <!-- untranslated -->
     <string name="boosts_show_less">Show less</string> <!-- untranslated -->
     <string name="home_loot">Creach</string>

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -500,9 +500,9 @@
     <string name="guild_progress_dailies_and_quest">Complete %1$d/%2$d daily requests &amp; quests to advance</string> <!-- untranslated -->
     <string name="guild_progress_dailies_only">Complete %1$d/%2$d daily requests to advance</string> <!-- untranslated -->
     <string name="home_died_message">Anda meninggal dan kehilangan sebagian besar keuntungan Anda.</string>
-    <string name="home_xp_boost_was_active">Bonus XP 2x aktif.</string>
-    <string name="home_xp_boost_active">2x XP Boost aktif — %1$s tersisa</string>
-    <string name="home_prestige_xp_boost_active">2× %1$s XP Boost - %2$s remaining</string> <!-- untranslated -->
+    <string name="home_xp_boost_was_active">Peningkat XP 2× semua skill sedang aktif</string>
+    <string name="home_xp_boost_active">2× XP semua skill — %1$s</string>
+    <string name="home_prestige_xp_boost_active">2× XP %1$s — %2$s</string> <!-- untranslated -->
     <string name="boosts_show_more">+%1$d more boosts (tap to show)</string> <!-- untranslated -->
     <string name="boosts_show_less">Show less</string> <!-- untranslated -->
     <string name="home_loot">Jarahan</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -507,9 +507,9 @@
     <string name="guild_progress_dailies_and_quest">Completa %1$d/%2$d incarichi per avanzare</string>
     <string name="guild_progress_dailies_only">Completa %1$d/%2$d giornaliere per avanzare</string>
     <string name="home_died_message">Sei morto e hai perso la maggior parte dei tuoi guadagni.</string>
-    <string name="home_xp_boost_was_active">Il bonus 2× XP era attivo</string>
-    <string name="home_xp_boost_active">Bonus 2× XP attivo — %1$s rimasti</string>
-    <string name="home_prestige_xp_boost_active">Bonus 2× %1$s XP - %2$s rimasti</string>
+    <string name="home_xp_boost_was_active">Il potenziamento XP 2× di tutte le abilità era attivo</string>
+    <string name="home_xp_boost_active">2× XP tutte le abilità — %1$s</string>
+    <string name="home_prestige_xp_boost_active">2× XP %1$s — %2$s</string>
     <string name="boosts_show_more">+%1$d more boosts (tap to show)</string> <!-- untranslated -->
     <string name="boosts_show_less">Show less</string> <!-- untranslated -->
     <string name="home_loot">Bottino</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -507,9 +507,9 @@
     <string name="guild_progress_dailies_and_quest">Complete %1$d/%2$d daily requests &amp; quests to advance</string> <!-- untranslated -->
     <string name="guild_progress_dailies_only">Complete %1$d/%2$d daily requests to advance</string> <!-- untranslated -->
     <string name="home_died_message">あなたは死亡し、獲得したものの大部分を失いました。</string>
-    <string name="home_xp_boost_was_active">2倍経験値ブーストが有効でした</string>
-    <string name="home_xp_boost_active">2倍経験値ブースト有効中 — 残り %1$s</string>
-    <string name="home_prestige_xp_boost_active">2× %1$s XP Boost - %2$s remaining</string> <!-- untranslated -->
+    <string name="home_xp_boost_was_active">全スキルXP 2倍が有効でした</string>
+    <string name="home_xp_boost_active">全スキルXP 2倍 — %1$s</string>
+    <string name="home_prestige_xp_boost_active">%1$s XP 2倍 — %2$s</string> <!-- untranslated -->
     <string name="boosts_show_more">+%1$d more boosts (tap to show)</string> <!-- untranslated -->
     <string name="boosts_show_less">Show less</string> <!-- untranslated -->
     <string name="home_loot">戦利品</string>

--- a/app/src/main/res/values-lt/strings.xml
+++ b/app/src/main/res/values-lt/strings.xml
@@ -507,9 +507,9 @@
     <string name="guild_progress_dailies_and_quest">Complete %1$d/%2$d daily requests &amp; quests to advance</string> <!-- untranslated -->
     <string name="guild_progress_dailies_only">Complete %1$d/%2$d daily requests to advance</string> <!-- untranslated -->
     <string name="home_died_message">You died and lost most of your gains.</string> <!-- untranslated -->
-    <string name="home_xp_boost_was_active">2× XP Boost was active</string> <!-- untranslated -->
-    <string name="home_xp_boost_active">2× XP Boost active — %1$s remaining</string> <!-- untranslated -->
-    <string name="home_prestige_xp_boost_active">2× %1$s XP Boost - %2$s remaining</string> <!-- untranslated -->
+    <string name="home_xp_boost_was_active">2× All skills XP was active</string> <!-- untranslated -->
+    <string name="home_xp_boost_active">2× All skills XP - %1$s</string> <!-- untranslated -->
+    <string name="home_prestige_xp_boost_active">2× %1$s XP - %2$s</string> <!-- untranslated -->
     <string name="boosts_show_more">+%1$d more boosts (tap to show)</string> <!-- untranslated -->
     <string name="boosts_show_less">Show less</string> <!-- untranslated -->
     <string name="home_loot">Loot</string> <!-- untranslated -->

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -507,11 +507,11 @@
     <string name="guild_progress_dailies_and_quest">Complete %1$d/%2$d daily requests &amp; quests to advance</string> <!-- untranslated -->
     <string name="guild_progress_dailies_only">Complete %1$d/%2$d daily requests to advance</string> <!-- untranslated -->
     <string name="home_died_message">Je bent dood en hebt het grootste deel van je voortgang verloren.</string>
-    <string name="home_xp_boost_was_active">2× XP Boost was actief</string>
-    <string name="home_xp_boost_active">2× XP-boost actief — nog %1$s</string>
-    <string name="home_prestige_xp_boost_active">2× %1$s XP Boost - %2$s remaining</string> <!-- untranslated -->
-    <string name="boosts_show_more">+%1$d more boosts (tap to show)</string> <!-- untranslated -->
-    <string name="boosts_show_less">Show less</string> <!-- untranslated -->
+    <string name="home_xp_boost_was_active">2× Alle vaardigheden XP was actief</string>
+    <string name="home_xp_boost_active">2× Alle vaardigheden XP - %1$s</string>
+    <string name="home_prestige_xp_boost_active">2× %1$s XP - %2$s</string> <!-- untranslated -->
+    <string name="boosts_show_more">+%1$d extra boosts (tik om weer te geven)</string> <!-- untranslated -->
+    <string name="boosts_show_less">Minder tonen</string> <!-- untranslated -->
     <string name="home_loot">Buit</string>
     <string name="home_food_consumed">Gegeten voedsel</string>
     <string name="home_bones_buried">Begraven botten</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -521,9 +521,9 @@
     <string name="guild_progress_dailies_and_quest">Complete %1$d/%2$d daily requests &amp; quests to advance</string> <!-- untranslated -->
     <string name="guild_progress_dailies_only">Complete %1$d/%2$d daily requests to advance</string> <!-- untranslated -->
     <string name="home_died_message">Zginąłeś i straciłeś większość zdobyczy.</string>
-    <string name="home_xp_boost_was_active">Wzmocnienie 2× XP było aktywne</string>
-    <string name="home_xp_boost_active">Wzmocnienie 2× XP aktywne — pozostało %1$s</string>
-    <string name="home_prestige_xp_boost_active">2× %1$s XP Boost - %2$s remaining</string> <!-- untranslated -->
+    <string name="home_xp_boost_was_active">Wzmocnienie 2× PD wszystkich umiejętności było aktywne</string>
+    <string name="home_xp_boost_active">2× PD wszystkie umiejętności — %1$s</string>
+    <string name="home_prestige_xp_boost_active">2× PD %1$s — %2$s</string> <!-- untranslated -->
     <string name="boosts_show_more">+%1$d more boosts (tap to show)</string> <!-- untranslated -->
     <string name="boosts_show_less">Show less</string> <!-- untranslated -->
     <string name="home_loot">Łupy</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -507,9 +507,9 @@
     <string name="guild_progress_dailies_and_quest">Complete %1$d/%2$d daily requests &amp; quests to advance</string> <!-- untranslated -->
     <string name="guild_progress_dailies_only">Complete %1$d/%2$d daily requests to advance</string> <!-- untranslated -->
     <string name="home_died_message">Você morreu e perdeu a maior parte dos seus ganhos.</string>
-    <string name="home_xp_boost_was_active">Impulso de 2× XP estava ativo</string>
-    <string name="home_xp_boost_active">Impulso de 2× XP ativo — %1$s restantes</string>
-    <string name="home_prestige_xp_boost_active">2× %1$s XP Boost - %2$s remaining</string> <!-- untranslated -->
+    <string name="home_xp_boost_was_active">O bônus de XP 2× de todas as habilidades estava ativo</string>
+    <string name="home_xp_boost_active">2× XP todas as habilidades — %1$s</string>
+    <string name="home_prestige_xp_boost_active">2× XP de %1$s — %2$s</string> <!-- untranslated -->
     <string name="boosts_show_more">+%1$d more boosts (tap to show)</string> <!-- untranslated -->
     <string name="boosts_show_less">Show less</string> <!-- untranslated -->
     <string name="home_loot">Saque</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -523,9 +523,9 @@
     <string name="guild_progress_dailies_and_quest">Завершено %1$d/%2$d ежедневных поручения и заданий для продвижения</string>
     <string name="guild_progress_dailies_only">Завершено %1$d/%2$d ежедневных поручений для продвижения</string>
     <string name="home_died_message">Вы погибли и потеряли большую часть добычи.</string>
-    <string name="home_xp_boost_was_active">Бонус ×2 опыта был активен</string>
-    <string name="home_xp_boost_active">Бонус ×2 опыта активен — %1$s осталось</string>
-    <string name="home_prestige_xp_boost_active">2× %1$s бонус опыта - %2$s осталось</string>
+    <string name="home_xp_boost_was_active">Усиление опыта всех навыков ×2 было активно</string>
+    <string name="home_xp_boost_active">×2 опыта всех навыков — %1$s</string>
+    <string name="home_prestige_xp_boost_active">×2 опыта навыка «%1$s» — %2$s</string>
     <string name="boosts_show_more">+%1$d more boosts (tap to show)</string> <!-- untranslated -->
     <string name="boosts_show_less">Show less</string> <!-- untranslated -->
     <string name="home_loot">Добыча</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -507,9 +507,9 @@
     <string name="guild_progress_dailies_and_quest">Complete %1$d/%2$d daily requests &amp; quests to advance</string> <!-- untranslated -->
     <string name="guild_progress_dailies_only">Complete %1$d/%2$d daily requests to advance</string> <!-- untranslated -->
     <string name="home_died_message">Öldün ve kazanımlarının çoğunu kaybettin.</string>
-    <string name="home_xp_boost_was_active">2× XP Takviyesi aktifti</string>
-    <string name="home_xp_boost_active">2x XP Takviyesi aktif — %1$s kaldı</string>
-    <string name="home_prestige_xp_boost_active">2× %1$s XP Boost - %2$s remaining</string> <!-- untranslated -->
+    <string name="home_xp_boost_was_active">Tüm beceriler XP 2× artışı etkindi</string>
+    <string name="home_xp_boost_active">2× XP tüm beceriler — %1$s</string>
+    <string name="home_prestige_xp_boost_active">2× XP %1$s — %2$s</string> <!-- untranslated -->
     <string name="boosts_show_more">+%1$d more boosts (tap to show)</string> <!-- untranslated -->
     <string name="boosts_show_less">Show less</string> <!-- untranslated -->
     <string name="home_loot">Ganimet</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -507,9 +507,9 @@
     <string name="guild_progress_dailies_and_quest">Complete %1$d/%2$d daily requests &amp; quests to advance</string>
     <string name="guild_progress_dailies_only">Complete %1$d/%2$d daily requests to advance</string>
     <string name="home_died_message">You died and lost most of your gains.</string>
-    <string name="home_xp_boost_was_active">2× XP Boost was active</string>
-    <string name="home_xp_boost_active">2× XP Boost active — %1$s remaining</string>
-    <string name="home_prestige_xp_boost_active">2× %1$s XP Boost - %2$s remaining</string>
+    <string name="home_xp_boost_was_active">2× All skills XP was active</string>
+    <string name="home_xp_boost_active">2× All skills XP - %1$s</string>
+    <string name="home_prestige_xp_boost_active">2× %1$s XP - %2$s</string>
     <string name="boosts_show_more">+%1$d more boosts (tap to show)</string>
     <string name="boosts_show_less">Show less</string>
     <string name="home_loot">Loot</string>


### PR DESCRIPTION
## Before submitting

- [x] I've tested any changes with the appropriate tests (eg. Unit tests, validation scripts)
- [x] I've pulled and merged the latest changes from the repository

## Summary

 Make boost formatting more consistent, their types more distinguishable and extend tap area


## Related issue(s) or discussion(s)


## Changelog

- Gave each boost type its own recognizable icon
- Made boost formatting consistent "<amount> - <skill/blessing name> - duration"
- Change x to × on blessing boost name
- Change — to - on all translations
- Made tap trigger area to extend and collapse boosts full width

## Anything else?

Not sure if i updated the translations correctly, some indicated "not translated"?
