### PR TITLE
refactor: combat Arrow/Spell dropdown UI + show spell Magic level

### DIFF
--- a/app/src/main/kotlin/com/fantasyidler/ui/screen/CombatScreen.kt
+++ b/app/src/main/kotlin/com/fantasyidler/ui/screen/CombatScreen.kt
@@ -252,7 +252,8 @@ fun CombatScreen(
                             context        = context,
                             activeWeaponSlot    = state.selectedWeaponSlot,
                             foodEatThresholdPct = invState.foodEatThresholdPct,
-                            availableSpells  = viewModel.availableSpells(state.skillLevels),
+                            availableSpells  = viewModel.availableSpells(),
+                            magicLevel       = state.skillLevels[Skills.MAGIC] ?: 1,
                             selectedArrowKey = state.selectedArrowKey,
                             selectedSpell    = state.selectedSpell,
                             onSlotTap      = inventoryVm::openSlotPicker,
@@ -336,7 +337,8 @@ fun CombatScreen(
                             context        = context,
                             activeWeaponSlot    = state.selectedWeaponSlot,
                             foodEatThresholdPct = invState.foodEatThresholdPct,
-                            availableSpells  = viewModel.availableSpells(state.skillLevels),
+                            availableSpells  = viewModel.availableSpells(),
+                            magicLevel       = state.skillLevels[Skills.MAGIC] ?: 1,
                             selectedArrowKey = state.selectedArrowKey,
                             selectedSpell    = state.selectedSpell,
                             onSlotTap      = inventoryVm::openSlotPicker,
@@ -608,6 +610,7 @@ private fun CombatGearTab(
     activeWeaponSlot: String?,
     foodEatThresholdPct: Int,
     availableSpells: List<SpellData>,
+    magicLevel: Int,
     selectedArrowKey: String?,
     selectedSpell: SpellData?,
     onSlotTap: (String) -> Unit,
@@ -670,27 +673,30 @@ private fun CombatGearTab(
                 onUnequip = { onUnequip(weaponSlot) },
             )
         }
-        if (EquipSlot.combatStyleForSlot(activeWeaponSlot ?: "") == "ranged") {
+        val loadoutStyle = EquipSlot.combatStyleForSlot(activeWeaponSlot ?: "")
+        if (loadoutStyle == "ranged" || loadoutStyle == "magic") {
             item {
-                ArrowLoadoutPicker(
-                    selectedArrowKey = selectedArrowKey,
-                    inventory        = inventory,
-                    context          = context,
-                    onArrowSelected  = onArrowSelected,
-                )
-            }
-        }
-        if (EquipSlot.combatStyleForSlot(activeWeaponSlot ?: "") == "magic") {
-            item {
-                val weaponSlot = activeWeaponSlot ?: EquipSlot.WEAPON_ATK
-                SpellLoadoutPicker(
-                    selectedSpell   = selectedSpell,
-                    availableSpells = availableSpells,
-                    inventory       = inventory,
-                    equippedWeapon  = allEquipment[equipped[weaponSlot]],
-                    context         = context,
-                    onSpellSelected = onSpellSelected,
-                )
+                Column(Modifier.padding(vertical = 12.dp)) {
+                    if (loadoutStyle == "ranged") {
+                        ArrowLoadoutPicker(
+                            selectedArrowKey = selectedArrowKey,
+                            inventory        = inventory,
+                            context          = context,
+                            onArrowSelected  = onArrowSelected,
+                        )
+                    } else {
+                        val weaponSlot = activeWeaponSlot ?: EquipSlot.WEAPON_ATK
+                        SpellLoadoutPicker(
+                            selectedSpell   = selectedSpell,
+                            availableSpells = availableSpells,
+                            magicLevel      = magicLevel,
+                            inventory       = inventory,
+                            equippedWeapon  = allEquipment[equipped[weaponSlot]],
+                            context         = context,
+                            onSpellSelected = onSpellSelected,
+                        )
+                    }
+                }
             }
         }
         item { SlotSectionHeader(stringResource(R.string.profile_combat_gear)) }
@@ -1208,4 +1214,14 @@ internal const val UNLOCK_TOLERANCE = 5
 internal val ARROW_TIERS = listOf(
     "runite_arrow", "adamantite_arrow", "mithril_arrow",
     "steel_arrow", "iron_arrow", "bronze_arrow",
+)
+
+/** Ranged strength each arrow tier contributes — mirrors CombatViewModel.ARROW_STRENGTH_BONUS. */
+internal val ARROW_STRENGTH_BONUS = mapOf(
+    "bronze_arrow"     to 7,
+    "iron_arrow"       to 10,
+    "steel_arrow"      to 16,
+    "mithril_arrow"    to 22,
+    "adamantite_arrow" to 31,
+    "runite_arrow"     to 49,
 )

--- a/app/src/main/kotlin/com/fantasyidler/ui/screen/LoadoutEditorSheet.kt
+++ b/app/src/main/kotlin/com/fantasyidler/ui/screen/LoadoutEditorSheet.kt
@@ -1,5 +1,8 @@
 package com.fantasyidler.ui.screen
 
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.DropdownMenuItem
@@ -14,8 +17,10 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.foundation.layout.Column
 import com.fantasyidler.R
@@ -66,14 +71,34 @@ internal fun ArrowLoadoutPicker(
             onDismissRequest = { expanded = false },
         ) {
             arrowOptions.forEach { key ->
-                val label = if (key == null) {
-                    stringResource(R.string.combat_arrow_auto)
-                } else {
-                    val qty = inventory[key] ?: 0
-                    "${GameStrings.itemName(context, key)} ($qty)"
-                }
                 DropdownMenuItem(
-                    text    = { Text(label) },
+                    contentPadding = PaddingValues(horizontal = 16.dp, vertical = 12.dp),
+                    text = {
+                        if (key == null) {
+                            Text(stringResource(R.string.combat_arrow_auto))
+                        } else {
+                            Row(
+                                modifier              = Modifier.fillMaxWidth(),
+                                horizontalArrangement = Arrangement.SpaceBetween,
+                                verticalAlignment     = Alignment.CenterVertically,
+                            ) {
+                                val qty = inventory[key] ?: 0
+                                Text(
+                                    text  = "${GameStrings.itemName(context, key)} ($qty)",
+                                    style = MaterialTheme.typography.bodyMedium,
+                                )
+                                Text(
+                                    text  = stringResource(
+                                        R.string.combat_arrow_ranged_str,
+                                        ARROW_STRENGTH_BONUS[key] ?: 0,
+                                    ),
+                                    style     = MaterialTheme.typography.bodySmall,
+                                    color     = MaterialTheme.colorScheme.onSurfaceVariant,
+                                    textAlign = TextAlign.End,
+                                )
+                            }
+                        }
+                    },
                     onClick = { onArrowSelected(key); expanded = false },
                 )
             }
@@ -86,6 +111,7 @@ internal fun ArrowLoadoutPicker(
 internal fun SpellLoadoutPicker(
     selectedSpell: SpellData?,
     availableSpells: List<SpellData>,
+    magicLevel: Int,
     inventory: Map<String, Int>,
     equippedWeapon: EquipmentData?,
     context: android.content.Context,
@@ -126,32 +152,57 @@ internal fun SpellLoadoutPicker(
             onDismissRequest = { expanded = false },
         ) {
             availableSpells.forEach { spell ->
+                val locked   = spell.magicLevelRequired > magicLevel
+                val infinite = equippedWeapon?.infiniteRunes == "all" || equippedWeapon?.infiniteRunes == spell.runeType
+                val held     = inventory[spell.runeType] ?: 0
+                val runeName = GameStrings.itemName(context, spell.runeType)
                 DropdownMenuItem(
+                    enabled        = !locked,
+                    contentPadding = PaddingValues(horizontal = 16.dp, vertical = 12.dp),
                     text = {
-                        Column {
-                            Text(
-                                text  = GameStrings.spellName(context, spell.name),
-                                style = MaterialTheme.typography.bodyMedium,
-                            )
-                            Text(
-                                text  = "${spell.runeCost}× ${GameStrings.itemName(context, spell.runeType)}  •  ${stringResource(R.string.combat_max_hit)} ${spell.maxHit}",
-                                style = MaterialTheme.typography.bodySmall,
-                                color = MaterialTheme.colorScheme.onSurfaceVariant,
-                            )
-                            val infinite = equippedWeapon?.infiniteRunes == "all" || equippedWeapon?.infiniteRunes == spell.runeType
-                            if (infinite) {
+                        Row(
+                            modifier              = Modifier.fillMaxWidth(),
+                            horizontalArrangement = Arrangement.SpaceBetween,
+                            verticalAlignment     = Alignment.Top,
+                        ) {
+                            Column(modifier = Modifier.weight(1f)) {
+                                Row(verticalAlignment = Alignment.Bottom) {
+                                    Text(
+                                        text  = GameStrings.spellName(context, spell.name),
+                                        style = MaterialTheme.typography.bodyMedium,
+                                    )
+                                    Text(
+                                        text  = "  " + if (infinite) {
+                                            stringResource(R.string.combat_infinite_runes, runeName)
+                                        } else {
+                                            stringResource(R.string.combat_you_have_runes, held, runeName)
+                                        },
+                                        style = MaterialTheme.typography.labelSmall,
+                                        color = if (infinite || held >= spell.runeCost) MaterialTheme.colorScheme.onSurfaceVariant
+                                                else MaterialTheme.colorScheme.error,
+                                    )
+                                }
                                 Text(
-                                    text  = stringResource(R.string.combat_infinite_runes, GameStrings.itemName(context, spell.runeType)),
-                                    style = MaterialTheme.typography.labelSmall,
+                                    text  = "${spell.runeCost}× $runeName",
+                                    style = MaterialTheme.typography.bodySmall,
                                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                                 )
-                            } else {
-                                val held = inventory[spell.runeType] ?: 0
+                            }
+                            Column(horizontalAlignment = Alignment.End) {
                                 Text(
-                                    text  = stringResource(R.string.combat_you_have_runes, held, GameStrings.itemName(context, spell.runeType)),
-                                    style = MaterialTheme.typography.labelSmall,
-                                    color = if (held >= spell.runeCost) MaterialTheme.colorScheme.onSurfaceVariant
-                                            else MaterialTheme.colorScheme.error,
+                                    text  = "${stringResource(R.string.combat_max_hit)} ${spell.maxHit}",
+                                    style = MaterialTheme.typography.bodySmall,
+                                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                )
+                                Text(
+                                    text      = if (locked) {
+                                        stringResource(R.string.combat_spell_locked, spell.magicLevelRequired)
+                                    } else {
+                                        stringResource(R.string.combat_spell_level_met, spell.magicLevelRequired)
+                                    },
+                                    style     = MaterialTheme.typography.labelSmall,
+                                    color     = if (locked) MaterialTheme.colorScheme.error else MaterialTheme.colorScheme.primary,
+                                    textAlign = TextAlign.End,
                                 )
                             }
                         }

--- a/app/src/main/kotlin/com/fantasyidler/ui/viewmodel/CombatViewModel.kt
+++ b/app/src/main/kotlin/com/fantasyidler/ui/viewmodel/CombatViewModel.kt
@@ -437,11 +437,11 @@ class CombatViewModel @Inject constructor(
         }
     }
 
-    /** Returns spells available at the player's current magic level. */
-    fun availableSpells(skillLevels: Map<String, Int>): List<SpellData> {
-        val magicLevel = skillLevels[Skills.MAGIC] ?: 1
+    /**
+     * All spells, sorted by Magic level requirement.
+     */
+    fun availableSpells(): List<SpellData> {
         return gameData.spells.values
-            .filter { it.magicLevelRequired <= magicLevel }
             .sortedBy { it.magicLevelRequired }
     }
 

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -569,6 +569,7 @@
     <string name="combat_best_arrow">Best arrow</string> <!-- untranslated -->
     <string name="combat_arrow_auto">Auto (best available)</string> <!-- untranslated -->
     <string name="combat_label_arrow">Arrow</string> <!-- untranslated -->
+    <string name="combat_arrow_ranged_str">+%1$d Ranged Strength</string> <!-- untranslated -->
     <string name="combat_select_loadout">Select Loadout</string> <!-- untranslated -->
     <string name="combat_enemies">Enemies</string> <!-- untranslated -->
     <string name="combat_no_spells">No spells available at your magic level.</string> <!-- untranslated -->
@@ -576,6 +577,8 @@
     <string name="combat_max_hit">max hit</string> <!-- untranslated -->
     <string name="combat_you_have_runes">(you have %1$d %2$s)</string> <!-- untranslated -->
     <string name="combat_infinite_runes">(infinite %1$s)</string> <!-- untranslated -->
+    <string name="combat_spell_locked">Requires Magic level %1$d</string> <!-- untranslated -->
+    <string name="combat_spell_level_met">Magic level %1$d</string> <!-- untranslated -->
     <string name="combat_no_potion">No Potion</string> <!-- untranslated -->
     <string name="combat_req_level">Required combat level</string> <!-- untranslated -->
     <string name="combat_duration">Duration</string> <!-- untranslated -->

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -569,6 +569,7 @@
     <string name="combat_best_arrow">Best arrow</string> <!-- untranslated -->
     <string name="combat_arrow_auto">Auto (best available)</string> <!-- untranslated -->
     <string name="combat_label_arrow">Arrow</string> <!-- untranslated -->
+    <string name="combat_arrow_ranged_str">+%1$d Ranged Strength</string> <!-- untranslated -->
     <string name="combat_select_loadout">Select Loadout</string> <!-- untranslated -->
     <string name="combat_enemies">Enemies</string> <!-- untranslated -->
     <string name="combat_no_spells">No spells available at your magic level.</string> <!-- untranslated -->
@@ -576,6 +577,8 @@
     <string name="combat_max_hit">max hit</string> <!-- untranslated -->
     <string name="combat_you_have_runes">(you have %1$d %2$s)</string> <!-- untranslated -->
     <string name="combat_infinite_runes">(infinite %1$s)</string> <!-- untranslated -->
+    <string name="combat_spell_locked">Requires Magic level %1$d</string> <!-- untranslated -->
+    <string name="combat_spell_level_met">Magic level %1$d</string> <!-- untranslated -->
     <string name="combat_no_potion">No Potion</string> <!-- untranslated -->
     <string name="combat_req_level">Required combat level</string> <!-- untranslated -->
     <string name="combat_duration">Duration</string> <!-- untranslated -->

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -573,6 +573,7 @@
     <string name="combat_best_arrow">Best arrow</string> <!-- untranslated -->
     <string name="combat_arrow_auto">Auto (best available)</string> <!-- untranslated -->
     <string name="combat_label_arrow">Arrow</string> <!-- untranslated -->
+    <string name="combat_arrow_ranged_str">+%1$d Ranged Strength</string> <!-- untranslated -->
     <string name="combat_select_loadout">Select Loadout</string> <!-- untranslated -->
     <string name="combat_enemies">Enemies</string> <!-- untranslated -->
     <string name="combat_no_spells">No spells available at your magic level.</string> <!-- untranslated -->
@@ -580,6 +581,8 @@
     <string name="combat_max_hit">max hit</string> <!-- untranslated -->
     <string name="combat_you_have_runes">(you have %1$d %2$s)</string> <!-- untranslated -->
     <string name="combat_infinite_runes">(infinite %1$s)</string> <!-- untranslated -->
+    <string name="combat_spell_locked">Requires Magic level %1$d</string> <!-- untranslated -->
+    <string name="combat_spell_level_met">Magic level %1$d</string> <!-- untranslated -->
     <string name="combat_no_potion">No Potion</string> <!-- untranslated -->
     <string name="combat_req_level">Required combat level</string> <!-- untranslated -->
     <string name="combat_duration">Duration</string> <!-- untranslated -->

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -569,6 +569,7 @@
     <string name="combat_best_arrow">Bester Pfeil</string>
     <string name="combat_arrow_auto">Auto (bester verfügbar)</string>
     <string name="combat_label_arrow">Pfeil</string>
+    <string name="combat_arrow_ranged_str">+%1$d Ranged Strength</string> <!-- untranslated -->
     <string name="combat_select_loadout">Loadout auswählen</string>
     <string name="combat_enemies">Feinde</string>
     <string name="combat_no_spells">Für Eure Magiestufe sind keine Zauber verfügbar.</string>
@@ -576,6 +577,8 @@
     <string name="combat_max_hit">maximaler Treffer</string>
     <string name="combat_you_have_runes">(Ihr habt %1$d %2$s)</string>
     <string name="combat_infinite_runes">(unendlich %1$s)</string>
+    <string name="combat_spell_locked">Requires Magic level %1$d</string> <!-- untranslated -->
+    <string name="combat_spell_level_met">Magic level %1$d</string> <!-- untranslated -->
     <string name="combat_no_potion">Kein Zaubertrank</string>
     <string name="combat_req_level">Erforderliches Kampflevel</string>
     <string name="combat_duration">Dauer</string>

--- a/app/src/main/res/values-es-rES/strings.xml
+++ b/app/src/main/res/values-es-rES/strings.xml
@@ -569,6 +569,7 @@
     <string name="combat_best_arrow">Mejor flecha</string>
     <string name="combat_arrow_auto">Auto (best available)</string> <!-- untranslated -->
     <string name="combat_label_arrow">Arrow</string> <!-- untranslated -->
+    <string name="combat_arrow_ranged_str">+%1$d Ranged Strength</string> <!-- untranslated -->
     <string name="combat_select_loadout">Select Loadout</string> <!-- untranslated -->
     <string name="combat_enemies">Enemigos</string>
     <string name="combat_no_spells">No tienes hechizos disponibles con tu nivel de magia.</string>
@@ -576,6 +577,8 @@
     <string name="combat_max_hit">max hit</string> <!-- untranslated -->
     <string name="combat_you_have_runes">(tienes %1$d %2$s)</string>
     <string name="combat_infinite_runes">(infinite %1$s)</string> <!-- untranslated -->
+    <string name="combat_spell_locked">Requires Magic level %1$d</string> <!-- untranslated -->
+    <string name="combat_spell_level_met">Magic level %1$d</string> <!-- untranslated -->
     <string name="combat_no_potion">Sin poción</string>
     <string name="combat_req_level">Nivel de combate requerido</string>
     <string name="combat_duration">Duracion</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -569,6 +569,7 @@
     <string name="combat_best_arrow">Mejor flecha</string>
     <string name="combat_arrow_auto">Auto (best available)</string> <!-- untranslated -->
     <string name="combat_label_arrow">Arrow</string> <!-- untranslated -->
+    <string name="combat_arrow_ranged_str">+%1$d Ranged Strength</string> <!-- untranslated -->
     <string name="combat_select_loadout">Seleccionar equipamiento</string>
     <string name="combat_enemies">Enemigos</string>
     <string name="combat_no_spells">No tienes hechizos disponibles con tu nivel de magia.</string>
@@ -576,6 +577,8 @@
     <string name="combat_max_hit">max hit</string> <!-- untranslated -->
     <string name="combat_you_have_runes">(tienes %1$d %2$s)</string>
     <string name="combat_infinite_runes">(infinito %1$s)</string>
+    <string name="combat_spell_locked">Requires Magic level %1$d</string> <!-- untranslated -->
+    <string name="combat_spell_level_met">Magic level %1$d</string> <!-- untranslated -->
     <string name="combat_no_potion">Sin poción</string>
     <string name="combat_req_level">Nivel de combate requerido</string>
     <string name="combat_duration">Duracion</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -570,6 +570,7 @@
     <string name="combat_best_arrow">Meilleure flèche</string>
     <string name="combat_arrow_auto">Auto (meilleure disponible)</string>
     <string name="combat_label_arrow">Flèche</string>
+    <string name="combat_arrow_ranged_str">+%1$d Ranged Strength</string> <!-- untranslated -->
     <string name="combat_select_loadout">Choisir l\'équipement</string>
     <string name="combat_enemies">Ennemis</string>
     <string name="combat_no_spells">Aucun sort disponible à votre niveau de magie.</string>
@@ -577,6 +578,8 @@
     <string name="combat_max_hit">dégâts max</string>
     <string name="combat_you_have_runes">(vous avez %1$d %2$s)</string>
     <string name="combat_infinite_runes">(%1$s infinies)</string>
+    <string name="combat_spell_locked">Requires Magic level %1$d</string> <!-- untranslated -->
+    <string name="combat_spell_level_met">Magic level %1$d</string> <!-- untranslated -->
     <string name="combat_no_potion">Pas de potion</string>
     <string name="combat_req_level">Niveau de combat requis</string>
     <string name="combat_duration">Durée</string>

--- a/app/src/main/res/values-ga/strings.xml
+++ b/app/src/main/res/values-ga/strings.xml
@@ -597,6 +597,7 @@
     <string name="combat_best_arrow">Best arrow</string> <!-- untranslated -->
     <string name="combat_arrow_auto">Auto (best available)</string> <!-- untranslated -->
     <string name="combat_label_arrow">Saighead</string>
+    <string name="combat_arrow_ranged_str">+%1$d Ranged Strength</string> <!-- untranslated -->
     <string name="combat_select_loadout">Select Loadout</string> <!-- untranslated -->
     <string name="combat_enemies">Naimhde</string>
     <string name="combat_no_spells">No spells available at your magic level.</string> <!-- untranslated -->
@@ -604,6 +605,8 @@
     <string name="combat_max_hit">max hit</string> <!-- untranslated -->
     <string name="combat_you_have_runes">(you have %1$d %2$s)</string> <!-- untranslated -->
     <string name="combat_infinite_runes">(%1$s gan teorainn)</string>
+    <string name="combat_spell_locked">Requires Magic level %1$d</string> <!-- untranslated -->
+    <string name="combat_spell_level_met">Magic level %1$d</string> <!-- untranslated -->
     <string name="combat_no_potion">Gan Posóid</string>
     <string name="combat_req_level">Required combat level</string> <!-- untranslated -->
     <string name="combat_duration">Fad</string>

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -561,6 +561,7 @@
     <string name="combat_best_arrow">Anak panah terbaik</string>
     <string name="combat_arrow_auto">Otomatis (pilihan terbaik)</string>
     <string name="combat_label_arrow">Anak panah</string>
+    <string name="combat_arrow_ranged_str">+%1$d Ranged Strength</string> <!-- untranslated -->
     <string name="combat_select_loadout">Pilih Perlengkapan</string>
     <string name="combat_enemies">Musuh</string>
     <string name="combat_no_spells">Mantra tidak tersedia di level sihir mu</string>
@@ -568,6 +569,8 @@
     <string name="combat_max_hit">pukulan maksimal</string>
     <string name="combat_you_have_runes">(Anda memiliki %1$d %2$s)</string>
     <string name="combat_infinite_runes">(infinite %1$s)</string> <!-- untranslated -->
+    <string name="combat_spell_locked">Requires Magic level %1$d</string> <!-- untranslated -->
+    <string name="combat_spell_level_met">Magic level %1$d</string> <!-- untranslated -->
     <string name="combat_no_potion">Tidak ada ramuan</string>
     <string name="combat_req_level">Level tempur yang dibutuhkan</string>
     <string name="combat_duration">Durasi</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -569,6 +569,7 @@
     <string name="combat_best_arrow">Miglior freccia</string>
     <string name="combat_arrow_auto">Usa migliore</string>
     <string name="combat_label_arrow">Freccia</string>
+    <string name="combat_arrow_ranged_str">+%1$d Ranged Strength</string> <!-- untranslated -->
     <string name="combat_select_loadout">Seleziona Equipaggiamento</string>
     <string name="combat_enemies">Nemici</string>
     <string name="combat_no_spells">Nessun incantesimo disponibile al tuo livello di magia.</string>
@@ -576,6 +577,8 @@
     <string name="combat_max_hit">danni massimi</string>
     <string name="combat_you_have_runes">(hai %1$d %2$s)</string>
     <string name="combat_infinite_runes">(%1$s infinite)</string>
+    <string name="combat_spell_locked">Requires Magic level %1$d</string> <!-- untranslated -->
+    <string name="combat_spell_level_met">Magic level %1$d</string> <!-- untranslated -->
     <string name="combat_no_potion">Nessuna pozione</string>
     <string name="combat_req_level">Livello di combattimento richiesto</string>
     <string name="combat_duration">Durata</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -569,6 +569,7 @@
     <string name="combat_best_arrow">最良の矢</string>
     <string name="combat_arrow_auto">自動 (使用可能な最良の矢)</string>
     <string name="combat_label_arrow">矢</string>
+    <string name="combat_arrow_ranged_str">+%1$d Ranged Strength</string> <!-- untranslated -->
     <string name="combat_select_loadout">装備セットを選択</string>
     <string name="combat_enemies">敵</string>
     <string name="combat_no_spells">あなたの魔法レベルでは使用できるスペルがありません。</string>
@@ -576,6 +577,8 @@
     <string name="combat_max_hit">最大ダメージ</string>
     <string name="combat_you_have_runes">(所持数: %2$s ×%1$d)</string>
     <string name="combat_infinite_runes">(無限 %1$s)</string>
+    <string name="combat_spell_locked">Requires Magic level %1$d</string> <!-- untranslated -->
+    <string name="combat_spell_level_met">Magic level %1$d</string> <!-- untranslated -->
     <string name="combat_no_potion">ポーションなし</string>
     <string name="combat_req_level">必要戦闘レベル</string>
     <string name="combat_duration">所要時間</string>

--- a/app/src/main/res/values-lt/strings.xml
+++ b/app/src/main/res/values-lt/strings.xml
@@ -569,6 +569,7 @@
     <string name="combat_best_arrow">Best arrow</string> <!-- untranslated -->
     <string name="combat_arrow_auto">Auto (best available)</string> <!-- untranslated -->
     <string name="combat_label_arrow">Arrow</string> <!-- untranslated -->
+    <string name="combat_arrow_ranged_str">+%1$d Ranged Strength</string> <!-- untranslated -->
     <string name="combat_select_loadout">Select Loadout</string> <!-- untranslated -->
     <string name="combat_enemies">Enemies</string> <!-- untranslated -->
     <string name="combat_no_spells">No spells available at your magic level.</string> <!-- untranslated -->
@@ -576,6 +577,8 @@
     <string name="combat_max_hit">max hit</string> <!-- untranslated -->
     <string name="combat_you_have_runes">(you have %1$d %2$s)</string> <!-- untranslated -->
     <string name="combat_infinite_runes">(infinite %1$s)</string> <!-- untranslated -->
+    <string name="combat_spell_locked">Requires Magic level %1$d</string> <!-- untranslated -->
+    <string name="combat_spell_level_met">Magic level %1$d</string> <!-- untranslated -->
     <string name="combat_no_potion">No Potion</string> <!-- untranslated -->
     <string name="combat_req_level">Required combat level</string> <!-- untranslated -->
     <string name="combat_duration">Duration</string> <!-- untranslated -->

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -569,6 +569,7 @@
     <string name="combat_best_arrow">Beste pijlen</string>
     <string name="combat_arrow_auto">Automatisch (beste beschikbare)</string>
     <string name="combat_label_arrow">Pijl</string>
+    <string name="combat_arrow_ranged_str">+%1$d Ranged Strength</string> <!-- untranslated -->
     <string name="combat_select_loadout">Uitrusting kiezen</string>
     <string name="combat_enemies">Vijanden</string>
     <string name="combat_no_spells">Geen spreuken beschikbaar op jouw magielevel.</string>
@@ -576,6 +577,8 @@
     <string name="combat_max_hit">maximale hit</string>
     <string name="combat_you_have_runes">(je hebt %1$d %2$s)</string>
     <string name="combat_infinite_runes">(oneindig %1$s)</string>
+    <string name="combat_spell_locked">Requires Magic level %1$d</string> <!-- untranslated -->
+    <string name="combat_spell_level_met">Magic level %1$d</string> <!-- untranslated -->
     <string name="combat_no_potion">Geen drank</string>
     <string name="combat_req_level">Vereist gevechtslevel</string>
     <string name="combat_duration">Duur</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -585,6 +585,7 @@
     <string name="combat_best_arrow">Najlepsza strzała</string>
     <string name="combat_arrow_auto">Auto (najlepsza dostępna)</string>
     <string name="combat_label_arrow">Strzała</string>
+    <string name="combat_arrow_ranged_str">+%1$d Ranged Strength</string> <!-- untranslated -->
     <string name="combat_select_loadout">Wybierz zestaw ekwipunku</string>
     <string name="combat_enemies">Wrogowie</string>
     <string name="combat_no_spells">Brak dostępnych zaklęć na Twoim poziomie magii.</string>
@@ -592,6 +593,8 @@
     <string name="combat_max_hit">maks. obrażenia</string>
     <string name="combat_you_have_runes">(masz %1$d %2$s)</string>
     <string name="combat_infinite_runes">(nieskończone %1$s)</string>
+    <string name="combat_spell_locked">Requires Magic level %1$d</string> <!-- untranslated -->
+    <string name="combat_spell_level_met">Magic level %1$d</string> <!-- untranslated -->
     <string name="combat_no_potion">Brak mikstury</string>
     <string name="combat_req_level">Wymagany poziom walki</string>
     <string name="combat_duration">Czas trwania</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -569,6 +569,7 @@
     <string name="combat_best_arrow">Melhor flecha</string>
     <string name="combat_arrow_auto">Automático (melhor disponível)</string>
     <string name="combat_label_arrow">Flecha</string>
+    <string name="combat_arrow_ranged_str">+%1$d Ranged Strength</string> <!-- untranslated -->
     <string name="combat_select_loadout">Selecionar Conjunto</string>
     <string name="combat_enemies">Inimigos</string>
     <string name="combat_no_spells">Nenhuma magia disponível no seu nível de magia.</string>
@@ -576,6 +577,8 @@
     <string name="combat_max_hit">acerto máximo</string>
     <string name="combat_you_have_runes">(você tem %1$d %2$s)</string>
     <string name="combat_infinite_runes">(%1$s infinito)</string>
+    <string name="combat_spell_locked">Requires Magic level %1$d</string> <!-- untranslated -->
+    <string name="combat_spell_level_met">Magic level %1$d</string> <!-- untranslated -->
     <string name="combat_no_potion">Sem Poção</string>
     <string name="combat_req_level">Nível de combate necessário</string>
     <string name="combat_duration">Duração</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -587,6 +587,7 @@
     <string name="combat_best_arrow">Лучшая стрела</string>
     <string name="combat_arrow_auto">Авто (лучшая доступная)</string>
     <string name="combat_label_arrow">Стрела</string>
+    <string name="combat_arrow_ranged_str">+%1$d Ranged Strength</string> <!-- untranslated -->
     <string name="combat_select_loadout">Выбрать комплект</string>
     <string name="combat_enemies">Враги</string>
     <string name="combat_no_spells">Нет доступных заклинаний на вашем уровне магии.</string>
@@ -594,6 +595,8 @@
     <string name="combat_max_hit">макс. удар</string>
     <string name="combat_you_have_runes">(у вас %1$d %2$s)</string>
     <string name="combat_infinite_runes">(бесконечно %1$s)</string>
+    <string name="combat_spell_locked">Requires Magic level %1$d</string> <!-- untranslated -->
+    <string name="combat_spell_level_met">Magic level %1$d</string> <!-- untranslated -->
     <string name="combat_no_potion">Без зелья</string>
     <string name="combat_req_level">Требуемый боевой уровень</string>
     <string name="combat_duration">Длительность</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -569,6 +569,7 @@
     <string name="combat_best_arrow">En iyi ok</string>
     <string name="combat_arrow_auto">Otomatik (mevcut olan en iyisi)</string>
     <string name="combat_label_arrow">Ok</string>
+    <string name="combat_arrow_ranged_str">+%1$d Ranged Strength</string> <!-- untranslated -->
     <string name="combat_select_loadout">Ekipman Setini Seç</string>
     <string name="combat_enemies">Düşmanlar</string>
     <string name="combat_no_spells">Büyü seviyene uygun büyü yok.</string>
@@ -576,6 +577,8 @@
     <string name="combat_max_hit">Maksimum vuruş</string>
     <string name="combat_you_have_runes">(%1$d %2$s var)</string>
     <string name="combat_infinite_runes">(sonsuz %1$s)</string>
+    <string name="combat_spell_locked">Requires Magic level %1$d</string> <!-- untranslated -->
+    <string name="combat_spell_level_met">Magic level %1$d</string> <!-- untranslated -->
     <string name="combat_no_potion">İksir Yok</string>
     <string name="combat_req_level">Gereken savaş seviyesi</string>
     <string name="combat_duration">Süre</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -569,6 +569,7 @@
     <string name="combat_best_arrow">最佳箭矢</string>
     <string name="combat_arrow_auto">自动（使用最佳可用）</string>
     <string name="combat_label_arrow">箭矢</string>
+    <string name="combat_arrow_ranged_str">+%1$d Ranged Strength</string> <!-- untranslated -->
     <string name="combat_select_loadout">选择装备方案</string>
     <string name="combat_enemies">敌人</string>
     <string name="combat_no_spells">你的魔法等级不足，暂无法术可用。</string>
@@ -576,6 +577,8 @@
     <string name="combat_max_hit">最大伤害</string>
     <string name="combat_you_have_runes">（你有 %1$d %2$s）</string>
     <string name="combat_infinite_runes">（无限 %1$s）</string>
+    <string name="combat_spell_locked">Requires Magic level %1$d</string> <!-- untranslated -->
+    <string name="combat_spell_level_met">Magic level %1$d</string> <!-- untranslated -->
     <string name="combat_no_potion">无药水</string>
     <string name="combat_req_level">所需战斗等级</string>
     <string name="combat_duration">持续时间</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -569,6 +569,7 @@
     <string name="combat_best_arrow">Best arrow</string>
     <string name="combat_arrow_auto">Auto (best available)</string>
     <string name="combat_label_arrow">Arrow</string>
+    <string name="combat_arrow_ranged_str">+%1$d Ranged Strength</string>
     <string name="combat_select_loadout">Select Loadout</string>
     <string name="combat_enemies">Enemies</string>
     <string name="combat_no_spells">No spells available at your magic level.</string>
@@ -576,6 +577,8 @@
     <string name="combat_max_hit">max hit</string>
     <string name="combat_you_have_runes">(you have %1$d %2$s)</string>
     <string name="combat_infinite_runes">(infinite %1$s)</string>
+    <string name="combat_spell_locked">Requires Magic level %1$d</string>
+    <string name="combat_spell_level_met">Magic level %1$d</string>
     <string name="combat_no_potion">No Potion</string>
     <string name="combat_req_level">Required combat level</string>
     <string name="combat_duration">Duration</string>


### PR DESCRIPTION
## Before submitting

- [x] I've tested any changes with the appropriate tests (eg. Unit tests, validation scripts)
- [x] I've pulled and merged the latest changes from the repository

## Summary

- Refactored the Arrow dropdown to also show range strength
- Refactored the Magic dropdown UI
- Spell dropdown now lists spells above your Magic level, previously no way to know level required to cast something.

<img width="2441" height="1636" alt="image" src="https://github.com/user-attachments/assets/c7fd8500-c3b0-4c9f-9f4f-d8532ad681ca" />

## Related issue(s) or discussion(s)

<!-- none -->

## Changelog

- refactor combat UI

## Anything else?

First part of a big refactoring effort to improve the combat UI.
