### PR TITLE
Add Skill Tree button to combat skill dialog

### DIFF
--- a/app/src/main/kotlin/com/fantasyidler/ui/screen/CombatScreen.kt
+++ b/app/src/main/kotlin/com/fantasyidler/ui/screen/CombatScreen.kt
@@ -803,7 +803,23 @@ private fun CombatSkillsTab(
         AlertDialog(
             onDismissRequest = { tappedSkill = null },
             title = { Text(GameStrings.skillName(context, key)) },
-            text  = { Text(GameStrings.skillDesc(context, key)) },
+            text  = {
+                Column {
+                    Text(GameStrings.skillDesc(context, key))
+                    onOpenPrestige?.let { cb ->
+                        Spacer(Modifier.height(8.dp))
+                        TextButton(
+                            onClick = {
+                                tappedSkill = null
+                                cb(key)
+                            },
+                            contentPadding = PaddingValues(0.dp),
+                        ) {
+                            Text(stringResource(R.string.prestige_skill_tree))
+                        }
+                    }
+                }
+            },
             confirmButton = {
                 TextButton(onClick = { tappedSkill = null }) {
                     Text(stringResource(R.string.btn_close))

--- a/app/src/main/kotlin/com/fantasyidler/ui/screen/CombatScreen.kt
+++ b/app/src/main/kotlin/com/fantasyidler/ui/screen/CombatScreen.kt
@@ -807,13 +807,11 @@ private fun CombatSkillsTab(
                 Column {
                     Text(GameStrings.skillDesc(context, key))
                     onOpenPrestige?.let { cb ->
-                        Spacer(Modifier.height(8.dp))
                         TextButton(
                             onClick = {
                                 tappedSkill = null
                                 cb(key)
-                            },
-                            contentPadding = PaddingValues(0.dp),
+                            }
                         ) {
                             Text(stringResource(R.string.prestige_skill_tree))
                         }


### PR DESCRIPTION
## Before submitting

- [x] I've tested the final changes (with unit tests) to ensure the feature works
- [x] I have pulled and merged the latest changes from the repository


## Summary

<img width="372" height="334" alt="image" src="https://github.com/user-attachments/assets/20628ef4-0a67-42f1-bfd9-cfefa1fbe84e" />


## Changelog

- Added a "Skill Tree" button in Combat Skill dialog to show skill tree if no prestige is possible yet. 

## Anything else?

Nothing else.
