### PR TITLE
Add year to duration strings. 250mo -> 20y 7mo

### DIFF
--- a/app/src/main/kotlin/com/fantasyidler/util/Extensions.kt
+++ b/app/src/main/kotlin/com/fantasyidler/util/Extensions.kt
@@ -122,12 +122,14 @@ internal fun Long.formatDurationMs(unitString: (Int, Long) -> String): String {
     var rem = totalSeconds / 60
     if (rem == 0L) return unitString(R.string.duration_seconds, totalSeconds)
     val minutesPerDay = 24L * 60
-    val months = rem / (30 * minutesPerDay); rem %= 30 * minutesPerDay
-    val weeks  = rem / (7 * minutesPerDay);  rem %= 7 * minutesPerDay
-    val days   = rem / minutesPerDay;        rem %= minutesPerDay
+    val years  = rem / (365 * minutesPerDay); rem %= 365 * minutesPerDay  // this does allow 1y 12mo 4 days, which is acceptable
+    val months = rem / (30 * minutesPerDay);  rem %= 30 * minutesPerDay
+    val weeks  = rem / (7 * minutesPerDay);   rem %= 7 * minutesPerDay
+    val days   = rem / minutesPerDay;         rem %= minutesPerDay
     val hours  = rem / 60
     val minutes = rem % 60
     return buildList {
+        if (years   > 0) add(unitString(R.string.duration_years, years))
         if (months  > 0) add(unitString(R.string.duration_months, months))
         if (weeks   > 0) add(unitString(R.string.duration_weeks, weeks))
         if (days    > 0) add(unitString(R.string.duration_days, days))

--- a/app/src/main/kotlin/com/fantasyidler/util/Extensions.kt
+++ b/app/src/main/kotlin/com/fantasyidler/util/Extensions.kt
@@ -110,8 +110,8 @@ fun Long.toRelativeTime(): String {
 
 /**
  * Format a raw millisecond duration (not an epoch) as a human-readable string, e.g. "2h 30m",
- * "45m", or "1mo 1w 1d 8h 54m". Zero-valued units are omitted; months are 30 days. Unit
- * suffixes come from string resources so each locale can abbreviate its own way (issue #1399).
+ * "45m", or "4y 1mo 1w 1d 8h 54m". Zero-valued units are omitted; months are 30 days, years 365.
+ * Unit suffixes come from string resources so each locale can abbreviate its own way (issue #1399).
  */
 fun Long.formatDurationMs(context: android.content.Context): String =
     context.withAppLocale().let { ctx -> formatDurationMs { resId, value -> ctx.getString(resId, value) } }

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -102,6 +102,7 @@
     <string name="label_coming_soon">آت قريباً</string>
     <string name="label_time_remaining">الوقت المتبقي</string>
     <!-- Translator note: compact duration units; English puts the letter(s) right after the number -->
+    <string name="duration_years">%1$dy</string> <!-- untranslated -->
     <string name="duration_months">%1$d شهر</string>
     <string name="duration_weeks">%1$d اسبوع</string>
     <string name="duration_days">%1$d يوم</string>

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -102,6 +102,7 @@
     <string name="label_coming_soon">Coming soon</string> <!-- untranslated -->
     <string name="label_time_remaining">Time remaining</string> <!-- untranslated -->
     <!-- Translator note: compact duration units; English puts the letter(s) right after the number -->
+    <string name="duration_years">%1$dy</string> <!-- untranslated -->
     <string name="duration_months">%1$dmo</string> <!-- untranslated -->
     <string name="duration_weeks">%1$dw</string> <!-- untranslated -->
     <string name="duration_days">%1$dd</string> <!-- untranslated -->

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -102,6 +102,7 @@
     <string name="label_coming_soon">Již brzy</string>
     <string name="label_time_remaining">Zbývající čas</string>
     <!-- Translator note: compact duration units; English puts the letter(s) right after the number -->
+    <string name="duration_years">%1$dy</string> <!-- untranslated -->
     <string name="duration_months">%1$dměs</string>
     <string name="duration_weeks">%1$dt</string>
     <string name="duration_days">%1$dd</string> <!-- untranslated -->

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -102,6 +102,7 @@
     <string name="label_coming_soon">Bald verfügbar</string>
     <string name="label_time_remaining">Verbleibende Zeit</string>
     <!-- Translator note: compact duration units; English puts the letter(s) right after the number -->
+    <string name="duration_years">%1$dy</string> <!-- untranslated -->
     <string name="duration_months">%1$dmo</string>
     <string name="duration_weeks">%1$dw</string>
     <string name="duration_days">%1$dd</string>

--- a/app/src/main/res/values-es-rES/strings.xml
+++ b/app/src/main/res/values-es-rES/strings.xml
@@ -102,6 +102,7 @@
     <string name="label_coming_soon">Coming soon</string> <!-- untranslated -->
     <string name="label_time_remaining">Tiempo restante</string>
     <!-- Translator note: compact duration units; English puts the letter(s) right after the number -->
+    <string name="duration_years">%1$dy</string> <!-- untranslated -->
     <string name="duration_months">%1$dmo</string> <!-- untranslated -->
     <string name="duration_weeks">%1$dw</string> <!-- untranslated -->
     <string name="duration_days">%1$dd</string> <!-- untranslated -->

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -102,6 +102,7 @@
     <string name="label_coming_soon">Próximamente</string>
     <string name="label_time_remaining">Tiempo restante</string>
     <!-- Translator note: compact duration units; English puts the letter(s) right after the number -->
+    <string name="duration_years">%1$dy</string> <!-- untranslated -->
     <string name="duration_months">%1$dmo</string> <!-- untranslated -->
     <string name="duration_weeks">%1$dw</string> <!-- untranslated -->
     <string name="duration_days">%1$dd</string> <!-- untranslated -->

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -102,6 +102,7 @@
     <string name="label_coming_soon">À venir</string>
     <string name="label_time_remaining">Temps restant</string>
     <!-- Translator note: compact duration units; English puts the letter(s) right after the number -->
+    <string name="duration_years">%1$dy</string> <!-- untranslated -->
     <string name="duration_months">%1$dmo</string>
     <string name="duration_weeks">%1$dS</string>
     <string name="duration_days">%1$dj</string>

--- a/app/src/main/res/values-ga/strings.xml
+++ b/app/src/main/res/values-ga/strings.xml
@@ -102,6 +102,7 @@
     <string name="label_coming_soon">Ah teacht go luath</string>
     <string name="label_time_remaining">Am atá fágtha</string>
     <!-- Translator note: compact duration units; English puts the letter(s) right after the number -->
+    <string name="duration_years">%1$dy</string> <!-- untranslated -->
     <string name="duration_months">%1$dmo</string> <!-- untranslated -->
     <string name="duration_weeks">%1$dw</string> <!-- untranslated -->
     <string name="duration_days">%1$dd</string> <!-- untranslated -->

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -102,6 +102,7 @@
     <string name="label_coming_soon">Segera hadir</string>
     <string name="label_time_remaining">Waktu tersisa</string>
     <!-- Translator note: compact duration units; English puts the letter(s) right after the number -->
+    <string name="duration_years">%1$dy</string> <!-- untranslated -->
     <string name="duration_months">%1$dmo</string> <!-- untranslated -->
     <string name="duration_weeks">%1$dw</string> <!-- untranslated -->
     <string name="duration_days">%1$dd</string> <!-- untranslated -->

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -102,6 +102,7 @@
     <string name="label_coming_soon">In arrivo</string>
     <string name="label_time_remaining">Tempo rimanente</string>
     <!-- Translator note: compact duration units; English puts the letter(s) right after the number -->
+    <string name="duration_years">%1$dy</string> <!-- untranslated -->
     <string name="duration_months">%1$dme</string>
     <string name="duration_weeks">%1$dsett</string>
     <string name="duration_days">%1$dg</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -102,6 +102,7 @@
     <string name="label_coming_soon">近日公開</string>
     <string name="label_time_remaining">残り時間</string>
     <!-- Translator note: compact duration units; English puts the letter(s) right after the number -->
+    <string name="duration_years">%1$dy</string> <!-- untranslated -->
     <string name="duration_months">%1$dmo</string> <!-- untranslated -->
     <string name="duration_weeks">%1$dw</string> <!-- untranslated -->
     <string name="duration_days">%1$dd</string> <!-- untranslated -->

--- a/app/src/main/res/values-lt/strings.xml
+++ b/app/src/main/res/values-lt/strings.xml
@@ -102,6 +102,7 @@
     <string name="label_coming_soon">Greitai Pasirodys</string>
     <string name="label_time_remaining">Liko Laiko</string>
     <!-- Translator note: compact duration units; English puts the letter(s) right after the number -->
+    <string name="duration_years">%1$dy</string> <!-- untranslated -->
     <string name="duration_months">%1$dmo</string> <!-- untranslated -->
     <string name="duration_weeks">%1$dw</string> <!-- untranslated -->
     <string name="duration_days">%1$dd</string> <!-- untranslated -->

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -102,6 +102,7 @@
     <string name="label_coming_soon">Binnenkort Beschikbaar</string>
     <string name="label_time_remaining">Resterende Tijd</string>
     <!-- Translator note: compact duration units; English puts the letter(s) right after the number -->
+    <string name="duration_years">%1$dy</string> <!-- untranslated -->
     <string name="duration_months">%1$dmo</string> <!-- untranslated -->
     <string name="duration_weeks">%1$dw</string> <!-- untranslated -->
     <string name="duration_days">%1$dd</string> <!-- untranslated -->

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -102,6 +102,7 @@
     <string name="label_coming_soon">Wkrótce</string>
     <string name="label_time_remaining">Pozostały czas</string>
     <!-- Translator note: compact duration units; English puts the letter(s) right after the number -->
+    <string name="duration_years">%1$dy</string> <!-- untranslated -->
     <string name="duration_months">%1$dmo</string> <!-- untranslated -->
     <string name="duration_weeks">%1$dw</string> <!-- untranslated -->
     <string name="duration_days">%1$dd</string> <!-- untranslated -->

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -102,6 +102,7 @@
     <string name="label_coming_soon">Em breve</string>
     <string name="label_time_remaining">Tempo restante</string>
     <!-- Translator note: compact duration units; English puts the letter(s) right after the number -->
+    <string name="duration_years">%1$dy</string> <!-- untranslated -->
     <string name="duration_months">%1$dmo</string> <!-- untranslated -->
     <string name="duration_weeks">%1$dw</string> <!-- untranslated -->
     <string name="duration_days">%1$dd</string> <!-- untranslated -->

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -102,6 +102,7 @@
     <string name="label_coming_soon">Скоро</string>
     <string name="label_time_remaining">Осталось времени</string>
     <!-- Translator note: compact duration units; English puts the letter(s) right after the number -->
+    <string name="duration_years">%1$dy</string> <!-- untranslated -->
     <string name="duration_months">%1$dмес</string>
     <string name="duration_weeks">%1$dн</string>
     <string name="duration_days">%1$dд</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -102,6 +102,7 @@
     <string name="label_coming_soon">Çok yakında</string>
     <string name="label_time_remaining">Kalan süre</string>
     <!-- Translator note: compact duration units; English puts the letter(s) right after the number -->
+    <string name="duration_years">%1$dy</string> <!-- untranslated -->
     <string name="duration_months">%1$dmo</string> <!-- untranslated -->
     <string name="duration_weeks">%1$dw</string> <!-- untranslated -->
     <string name="duration_days">%1$dd</string> <!-- untranslated -->

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -102,6 +102,7 @@
     <string name="label_coming_soon">即将推出</string>
     <string name="label_time_remaining">剩余时间</string>
     <!-- Translator note: compact duration units; English puts the letter(s) right after the number -->
+    <string name="duration_years">%1$dy</string> <!-- untranslated -->
     <string name="duration_months">%1$d月</string>
     <string name="duration_weeks">%1$d周</string>
     <string name="duration_days">%1$d天</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -102,6 +102,7 @@
     <string name="label_coming_soon">Coming soon</string>
     <string name="label_time_remaining">Time remaining</string>
     <!-- Translator note: compact duration units; English puts the letter(s) right after the number -->
+    <string name="duration_years">%1$dy</string>
     <string name="duration_months">%1$dmo</string>
     <string name="duration_weeks">%1$dw</string>
     <string name="duration_days">%1$dd</string>

--- a/app/src/test/kotlin/com/fantasyidler/util/ExtensionsTest.kt
+++ b/app/src/test/kotlin/com/fantasyidler/util/ExtensionsTest.kt
@@ -80,6 +80,7 @@ class ExtensionsTest {
     // The context overload just resolves string resources; the ladder logic under test lives in
     // the lambda-based core, exercised here with the English unit templates.
     private val englishUnits = mapOf(
+        com.fantasyidler.R.string.duration_years   to "y",
         com.fantasyidler.R.string.duration_months  to "mo",
         com.fantasyidler.R.string.duration_weeks   to "w",
         com.fantasyidler.R.string.duration_days    to "d",
@@ -113,6 +114,7 @@ class ExtensionsTest {
         assertEquals("2mo", 60 * 24 * hour)
         assertEquals("1mo 1w 1d 8h 54m", 920 * hour + 54 * 60_000L)
         assertEquals("1mo 1m", 30 * 24 * hour + 60_000L)     // interior zero units skipped
+        assertEquals("1y 1mo 1w 1d 8h 54m", 9680 * hour + 54 * 60_000L)  // years are 365 days
     }
 
     private fun assertEquals(expected: String, ms: Long) =


### PR DESCRIPTION
Currently formatDurationMs tops out at months. However if a player has a large XP or prayer timer, or is (hopefully not) starting a very long session, then a time in years is a lot easier to understand than one in months.

<img width="1644" height="1239" alt="Screenshot_20260830-190711_Idle Fantasy" src="https://github.com/user-attachments/assets/eb48753b-1efd-4d2b-a5fb-f8275a28029c" />

Before:  
<img width="1038" height="126" alt="Screenshot_20260830-185455_Idle Fantasy" src="https://github.com/user-attachments/assets/71411728-89c7-46bf-81d8-8a350471068b" />

After:  
<img width="1107" height="133" alt="Screenshot_20260830-185425_Idle Fantasy" src="https://github.com/user-attachments/assets/6e26ade5-dd9f-43f0-92a9-037e4e7ad80b" />

I have successfully built the apps and tests. The screenshots are from my phone, where it installed and worked correctly.

## Before submitting

- [x] I've tested any changes with the appropriate tests (eg. Unit tests, validation scripts)
- [x] I've pulled and merged the latest changes from the repository

## Changelog

- Very long durations now display with years instead of huge month counts (e.g. 250mo 3w 1d 8h 7m becomes 20y 7mo 1w 5d 8h 7m)
