### PR TITLE
Add seasonal event bounty quest indicators and skill sheet integration

### DIFF
--- a/app/src/main/assets/data/seasonal_events.json
+++ b/app/src/main/assets/data/seasonal_events.json
@@ -6,6 +6,7 @@
     "end_ms": 1788220800000,
     "token_goal": 100,
     "pillars": ["bounty", "expedition", "boss", "minigame"],
+    "icon_emoji": "☀️",
     "bounty_tasks": [
       {
         "id": "sunspire_firewood",
@@ -116,6 +117,7 @@
     "end_ms": 1796083200000,
     "token_goal": 300,
     "pillars": ["bounty", "expedition", "boss", "minigame"],
+    "icon_emoji": "🎃",
     "bounty_tasks": [
       {
         "id": "gloom_pumpkins",

--- a/app/src/main/kotlin/com/fantasyidler/data/json/SeasonalEventData.kt
+++ b/app/src/main/kotlin/com/fantasyidler/data/json/SeasonalEventData.kt
@@ -12,6 +12,8 @@ data class SeasonalEventData(
     @SerialName("token_goal") val tokenGoal: Int,
     /** Subset of "bounty" | "expedition" | "boss" | "minigame". */
     val pillars: List<String>,
+    /** Emoji icon displayed for this event's quest indicators (e.g. "☀️" or "🎃"); defaults to "🎯". */
+    @SerialName("icon_emoji") val iconEmoji: String = "🎯",
     @SerialName("bounty_tasks") val bountyTasks: List<SeasonalBountyTaskData> = emptyList(),
     /** How long a Bounty Board slot waits after a claim before a new task rotates in. */
     @SerialName("bounty_rotation_ms") val bountyRotationMs: Long = 3_600_000L,

--- a/app/src/main/kotlin/com/fantasyidler/repository/SeasonalEventRepository.kt
+++ b/app/src/main/kotlin/com/fantasyidler/repository/SeasonalEventRepository.kt
@@ -56,6 +56,20 @@ class SeasonalEventRepository @Inject constructor(
         }
     }
 
+    /** Returns currently active bounty tasks (excluding slots on cooldown), or empty if no event or bounty pillar is active. */
+    fun getActiveBounties(
+        flags: PlayerFlags,
+        inventory: Map<String, Int> = emptyMap(),
+        now: Long = System.currentTimeMillis(),
+    ): List<SeasonalBountyTaskWithProgress> {
+        val event = activeEvent() ?: return emptyList()
+        if ("bounty" !in event.pillars) return emptyList()
+        return bountyTasksWithProgress(event, flags, inventory).filter { bp ->
+            val cooldown = bp.cooldownUntilMs
+            cooldown == null || now >= cooldown
+        }
+    }
+
     // -------------------------------------------------------------------------
     // Bounty Board — 3 slots (one per task type), each independently rotating to
     // a new same-type task [SeasonalEventData.bountyRotationMs] after it's claimed.

--- a/app/src/main/kotlin/com/fantasyidler/ui/screen/QuestIndicatorIcons.kt
+++ b/app/src/main/kotlin/com/fantasyidler/ui/screen/QuestIndicatorIcons.kt
@@ -20,10 +20,10 @@ private fun superscriptCount(count: Int): String =
 @Composable
 internal fun QuestIndicatorIcons(indicators: List<QuestIndicator>) {
     if (indicators.isEmpty()) return
-    indicators.groupBy { it.category }.entries.sortedBy { it.key }.forEach { (category, list) ->
+    indicators.groupBy { it.category }.entries.sortedBy { it.key }.forEach { (_, list) ->
         val alpha = if (list.any { it.isCompletable }) 1.0f else 0.38f
         Text(
-            text     = " ${category.emoji}${superscriptCount(list.size)}",
+            text     = " ${list.first().emoji}${superscriptCount(list.size)}",
             style    = MaterialTheme.typography.bodyMedium,
             modifier = Modifier.alpha(alpha),
         )

--- a/app/src/main/kotlin/com/fantasyidler/ui/screen/SkillsScreen.kt
+++ b/app/src/main/kotlin/com/fantasyidler/ui/screen/SkillsScreen.kt
@@ -123,15 +123,17 @@ fun SkillsScreen(
             onDismissRequest = { showLegend = false },
             title = { Text(stringResource(R.string.quest_legend_title)) },
             text  = {
+                val seasonalEmoji = state.seasonalEventEmoji ?: QuestCategory.SEASONAL.emoji
                 Column(verticalArrangement = Arrangement.spacedBy(6.dp)) {
                     listOf(
-                        QuestCategory.DAILY       to R.string.quest_legend_daily,
-                        QuestCategory.WEEKLY      to R.string.quest_legend_weekly,
-                        QuestCategory.GUILD_DAILY to R.string.quest_legend_guild_daily,
-                        QuestCategory.GUILD       to R.string.quest_legend_guild,
-                        QuestCategory.MAIN        to R.string.quest_legend_quest,
-                    ).forEach { (category, labelRes) ->
-                        Text("${category.emoji}  ${stringResource(labelRes)}")
+                        QuestCategory.DAILY.emoji       to R.string.quest_legend_daily,
+                        QuestCategory.WEEKLY.emoji      to R.string.quest_legend_weekly,
+                        seasonalEmoji                   to R.string.quest_legend_seasonal,
+                        QuestCategory.GUILD_DAILY.emoji to R.string.quest_legend_guild_daily,
+                        QuestCategory.GUILD.emoji       to R.string.quest_legend_guild,
+                        QuestCategory.MAIN.emoji        to R.string.quest_legend_quest,
+                    ).forEach { (emoji, labelRes) ->
+                        Text("$emoji  ${stringResource(labelRes)}")
                     }
                     Row(verticalAlignment = Alignment.CenterVertically) {
                         Text("●  ", color = MaterialTheme.colorScheme.primary)
@@ -511,9 +513,10 @@ private fun GuildDailySheetBanner(
 
     if (showDialog) {
         val sections = listOf(
-            SheetQuestSource.GUILD  to R.string.guild_daily_button,
-            SheetQuestSource.DAILY  to R.string.label_daily,
-            SheetQuestSource.WEEKLY to R.string.label_weekly,
+            SheetQuestSource.GUILD    to R.string.guild_daily_button,
+            SheetQuestSource.DAILY    to R.string.label_daily,
+            SheetQuestSource.WEEKLY   to R.string.label_weekly,
+            SheetQuestSource.SEASONAL to R.string.seasonal_bounty_board_title,
         ).mapNotNull { (source, labelRes) ->
             quests.filter { it.source == source }.takeIf { it.isNotEmpty() }?.let { labelRes to it }
         }
@@ -542,17 +545,21 @@ private fun GuildDailySheetBanner(
                             Row(verticalAlignment = Alignment.CenterVertically) {
                                 Column(Modifier.weight(1f)) {
                                     Text(
-                                        text       = GameStrings.questName(context, quest.questId, quest.questName),
+                                        text       = when (quest.source) {
+                                            SheetQuestSource.SEASONAL -> GameStrings.seasonalBountyName(context, quest.questId, quest.questName)
+                                            else                      -> GameStrings.questName(context, quest.questId, quest.questName)
+                                        },
                                         style      = MaterialTheme.typography.bodyMedium,
                                         fontWeight = FontWeight.SemiBold,
                                     )
                                     Spacer(Modifier.height(2.dp))
                                     Text(
                                         text  = when (quest.source) {
-                                            SheetQuestSource.GUILD  -> localizedQuestDesc(quest.type, quest.target, quest.amount, quest.guild)
-                                            SheetQuestSource.DAILY  -> buildDailyObjective(context, quest.guild, quest.target, quest.amount, quest.description)
-                                            SheetQuestSource.WEEKLY -> GameStrings.questDesc(context, quest.questId)
+                                            SheetQuestSource.GUILD    -> localizedQuestDesc(quest.type, quest.target, quest.amount, quest.guild)
+                                            SheetQuestSource.DAILY    -> buildDailyObjective(context, quest.guild, quest.target, quest.amount, quest.description)
+                                            SheetQuestSource.WEEKLY   -> GameStrings.questDesc(context, quest.questId)
                                                 .takeIf { it.isNotBlank() } ?: quest.description
+                                            SheetQuestSource.SEASONAL -> GameStrings.seasonalBountyHint(context, quest.questId, quest.description)
                                         },
                                         style = MaterialTheme.typography.bodySmall,
                                         color = MaterialTheme.colorScheme.onSurfaceVariant,

--- a/app/src/main/kotlin/com/fantasyidler/ui/screen/SlayerScreen.kt
+++ b/app/src/main/kotlin/com/fantasyidler/ui/screen/SlayerScreen.kt
@@ -127,9 +127,10 @@ fun SlayerScreen(
 
     if (showQuestsDialog) {
         val sections = listOf(
-            SheetQuestSource.GUILD  to R.string.guild_daily_button,
-            SheetQuestSource.DAILY  to R.string.label_daily,
-            SheetQuestSource.WEEKLY to R.string.label_weekly,
+            SheetQuestSource.GUILD    to R.string.guild_daily_button,
+            SheetQuestSource.DAILY    to R.string.label_daily,
+            SheetQuestSource.WEEKLY   to R.string.label_weekly,
+            SheetQuestSource.SEASONAL to R.string.seasonal_bounty_board_title,
         ).mapNotNull { (source, labelRes) ->
             quests.filter { it.source == source }.takeIf { it.isNotEmpty() }?.let { labelRes to it }
         }
@@ -157,17 +158,21 @@ fun SlayerScreen(
                             }
                             Column {
                                 Text(
-                                    text       = GameStrings.questName(context, quest.questId, quest.questName),
+                                    text       = when (quest.source) {
+                                        SheetQuestSource.SEASONAL -> GameStrings.seasonalBountyName(context, quest.questId, quest.questName)
+                                        else                      -> GameStrings.questName(context, quest.questId, quest.questName)
+                                    },
                                     style      = MaterialTheme.typography.bodyMedium,
                                     fontWeight = FontWeight.SemiBold,
                                 )
                                 Spacer(Modifier.height(2.dp))
                                 Text(
                                     text  = when (quest.source) {
-                                        SheetQuestSource.GUILD  -> localizedQuestDesc(quest.type, quest.target, quest.amount, quest.guild)
-                                        SheetQuestSource.DAILY  -> buildDailyObjective(context, quest.guild, quest.target, quest.amount, quest.description)
-                                        SheetQuestSource.WEEKLY -> GameStrings.questDesc(context, quest.questId)
+                                        SheetQuestSource.GUILD    -> localizedQuestDesc(quest.type, quest.target, quest.amount, quest.guild)
+                                        SheetQuestSource.DAILY    -> buildDailyObjective(context, quest.guild, quest.target, quest.amount, quest.description)
+                                        SheetQuestSource.WEEKLY   -> GameStrings.questDesc(context, quest.questId)
                                             .takeIf { it.isNotBlank() } ?: quest.description
+                                        SheetQuestSource.SEASONAL -> GameStrings.seasonalBountyHint(context, quest.questId, quest.description)
                                     },
                                     style = MaterialTheme.typography.bodySmall,
                                     color = MaterialTheme.colorScheme.onSurfaceVariant,

--- a/app/src/main/kotlin/com/fantasyidler/ui/viewmodel/CraftingViewModel.kt
+++ b/app/src/main/kotlin/com/fantasyidler/ui/viewmodel/CraftingViewModel.kt
@@ -19,6 +19,7 @@ import com.fantasyidler.repository.GameDataRepository
 import com.fantasyidler.repository.GuildRepository
 import com.fantasyidler.repository.PlayerRepository
 import com.fantasyidler.repository.QuestRepository
+import com.fantasyidler.data.json.SeasonalBountyTaskData
 import com.fantasyidler.repository.SeasonalEventRepository
 import com.fantasyidler.repository.SessionRepository
 import com.fantasyidler.repository.TownRepository
@@ -52,6 +53,7 @@ data class QuestFillSuggestion(val label: String, val qty: Int)
 enum class QuestCategory(val emoji: String) {
     DAILY("⏰"),
     WEEKLY("📅"),
+    SEASONAL("🎯"),
     GUILD_DAILY("⚒️"),
     GUILD("🏰"),
     MAIN("📜"),
@@ -62,7 +64,11 @@ data class QuestIndicator(
     val isCompletable: Boolean,
     /** Source quest id, used to dedupe skill-row counts when one quest spans many activities. */
     val questId: String = "",
-)
+    /** Custom emoji override (e.g. seasonal event's iconEmoji), falling back to category.emoji. */
+    val customEmoji: String? = null,
+) {
+    val emoji: String get() = customEmoji ?: category.emoji
+}
 
 // ---------------------------------------------------------------------------
 // Unified recipe model (normalises all 4 recipe types for display + crafting)
@@ -640,11 +646,10 @@ class CraftingViewModel @Inject constructor(
 
         // Seasonal Event Bounty Board
         seasonalEventRepo.activeEvent()?.let { event ->
-            for (taskProgress in seasonalEventRepo.bountyTasksWithProgress(event, flags)) {
-                if (taskProgress.cooldownUntilMs != null) continue
-                val task = taskProgress.task
+            for (bounty in seasonalEventRepo.getActiveBounties(flags)) {
+                val task = bounty.task
                 if (task.type != "craft" || task.target != recipe.outputKey) continue
-                val remaining = task.amount - taskProgress.progress
+                val remaining = task.amount - bounty.progress
                 if (remaining > 0)
                     fills += QuestFillSuggestion(GameStrings.seasonalEventName(context, event.id, event.displayName), ceilDiv(remaining, recipe.outputQty))
             }
@@ -671,6 +676,12 @@ class CraftingViewModel @Inject constructor(
         val guildPool = gameData.guildDailyPool.associateBy { it.id }
         val activeGuildDailyIds = flags.guildDailyIds.filter { it !in flags.guildDailyClaimed }
         val completedIds = progressById.entries.filter { it.value.completed }.map { it.key }.toSet()
+
+        // 6. Seasonal Event Bounties (pre-computed before loop for performance)
+        val seasonalEmoji = seasonalEventRepo.activeEvent()?.iconEmoji ?: QuestCategory.SEASONAL.emoji
+        val activeSeasonalBounties = seasonalEventRepo.getActiveBounties(flags)
+            .filter { it.task.type == "craft" && it.progress < it.task.amount }
+            .map { it.task to (it.task.amount - it.progress) }
 
         for (recipe in allRecipes) {
             val key = recipe.outputKey
@@ -773,6 +784,14 @@ class CraftingViewModel @Inject constructor(
                 if (matches) {
                     val neededCrafts = ceilDiv(remaining, recipe.outputQty)
                     indicators.add(QuestIndicator(QuestCategory.GUILD_DAILY, max >= neededCrafts))
+                }
+            }
+
+            // 6. Seasonal Event Bounties
+            for ((task, remaining) in activeSeasonalBounties) {
+                if (task.target == key) {
+                    val neededCrafts = ceilDiv(remaining, recipe.outputQty)
+                    indicators.add(QuestIndicator(QuestCategory.SEASONAL, max >= neededCrafts, task.id, seasonalEmoji))
                 }
             }
 

--- a/app/src/main/kotlin/com/fantasyidler/ui/viewmodel/FarmingViewModel.kt
+++ b/app/src/main/kotlin/com/fantasyidler/ui/viewmodel/FarmingViewModel.kt
@@ -12,6 +12,7 @@ import com.fantasyidler.repository.GameDataRepository
 import com.fantasyidler.repository.GuildRepository
 import com.fantasyidler.repository.PlayerRepository
 import com.fantasyidler.repository.QuestRepository
+import com.fantasyidler.repository.SeasonalEventRepository
 import com.fantasyidler.repository.TownRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
 import dagger.hilt.android.qualifiers.ApplicationContext
@@ -82,6 +83,7 @@ class FarmingViewModel @Inject constructor(
     private val gameData: GameDataRepository,
     private val townRepo: TownRepository,
     private val questRepo: QuestRepository,
+    private val seasonalEventRepo: SeasonalEventRepository,
     private val json: Json,
 ) : ViewModel() {
 
@@ -266,8 +268,8 @@ class FarmingViewModel @Inject constructor(
         val guildPool = gameData.guildDailyPool.associateBy { it.id }
         val activeGuildDailyIds = flags.guildDailyIds.filter { it !in flags.guildDailyClaimed }
 
-        fun addIndicator(cropId: String, category: QuestCategory, questId: String) {
-            result.getOrPut(cropId) { mutableListOf() }.add(QuestIndicator(category, isCompletable = true, questId = questId))
+        fun addIndicator(cropId: String, category: QuestCategory, questId: String, customEmoji: String? = null) {
+            result.getOrPut(cropId) { mutableListOf() }.add(QuestIndicator(category, isCompletable = true, questId = questId, customEmoji = customEmoji))
         }
 
         for ((id, quest) in gameData.guildQuests) {
@@ -287,6 +289,14 @@ class FarmingViewModel @Inject constructor(
             val progress = flags.guildDailyProgress[id] ?: 0
             if (template.amount - progress <= 0) continue
             addIndicator(template.target, QuestCategory.GUILD_DAILY, id)
+        }
+
+        // Seasonal Event Bounties
+        val eventEmoji = seasonalEventRepo.activeEvent()?.iconEmoji ?: QuestCategory.SEASONAL.emoji
+        for (bounty in seasonalEventRepo.getActiveBounties(flags)) {
+            val task = bounty.task
+            if (task.skill != Skills.FARMING || bounty.progress >= task.amount) continue
+            addIndicator(task.target, QuestCategory.SEASONAL, task.id, eventEmoji)
         }
 
         return result

--- a/app/src/main/kotlin/com/fantasyidler/ui/viewmodel/SkillsViewModel.kt
+++ b/app/src/main/kotlin/com/fantasyidler/ui/viewmodel/SkillsViewModel.kt
@@ -107,9 +107,10 @@ data class SkillsUiState(
     val showQuestDots: Boolean = true,
     /** Guild dailies plus daily/weekly quests for each sheet skill, keyed by skill (guild keys match skill keys). */
     val sheetQuests: Map<String, List<SheetQuestSummary>> = emptyMap(),
+    val seasonalEventEmoji: String? = null,
 )
 
-enum class SheetQuestSource { GUILD, DAILY, WEEKLY }
+enum class SheetQuestSource { GUILD, DAILY, WEEKLY, SEASONAL }
 
 data class SheetQuestSummary(
     val questId: String,
@@ -200,6 +201,8 @@ class SkillsViewModel @Inject constructor(
             val inv:      Map<String, Int>     = json.decodeFromString(player.inventory)
             val flags = try { json.decodeFromString<PlayerFlags>(player.flags) } catch (_: Exception) { PlayerFlags() }
             val activeQuests = computeActiveQuests(questProgress, flags, inv)
+            val activeEvent = seasonalEventRepo.activeEvent()
+            val seasonalEmoji = if (activeEvent != null && "bounty" in activeEvent.pillars) activeEvent.iconEmoji else null
             extra.copy(
                 isLoading             = false,
                 skillLevels           = levels,
@@ -243,7 +246,8 @@ class SkillsViewModel @Inject constructor(
                     .mapValues { (_, lists) ->
                         lists.flatten()
                             .filter {
-                                it.category == QuestCategory.DAILY || it.category == QuestCategory.WEEKLY || it.category == QuestCategory.GUILD_DAILY
+                                it.category == QuestCategory.DAILY || it.category == QuestCategory.WEEKLY ||
+                                it.category == QuestCategory.SEASONAL || it.category == QuestCategory.GUILD_DAILY
                             }
                             // "any"-target quests add one indicator per matching activity
                             // (e.g. every buriable bone), so collapse back to one per quest.
@@ -253,7 +257,8 @@ class SkillsViewModel @Inject constructor(
                     .filterValues { it.isNotEmpty() },
                 showSessionEndTime    = flags.showSessionEndTime,
                 showQuestDots         = flags.showQuestDots,
-                sheetQuests           = computeSheetQuests(questProgress, flags, levels),
+                sheetQuests           = computeSheetQuests(questProgress, flags, levels, inv),
+                seasonalEventEmoji    = seasonalEmoji,
             )
         }
     }.flowOn(Dispatchers.Default)
@@ -1126,6 +1131,7 @@ class SkillsViewModel @Inject constructor(
         questProgress: List<com.fantasyidler.data.model.QuestProgress>,
         flags: PlayerFlags,
         skillLevels: Map<String, Int>,
+        inventory: Map<String, Int> = emptyMap(),
     ): Map<String, List<SheetQuestSummary>> {
         fun meetsLevel(type: String, skill: String, target: String): Boolean =
             (skillLevels[skill] ?: 1) >= sheetQuestLevelRequired(type, skill, target)
@@ -1187,6 +1193,24 @@ class SkillsViewModel @Inject constructor(
                 meetsLevel  = meetsLevel(wq.template.type, skill, wq.template.target),
             )
         }
+        for (bounty in seasonalEventRepo.getActiveBounties(flags, inventory)) {
+            val task = bounty.task
+            val skill = task.skill ?: continue
+            if (skill !in skillGuilds) continue
+            result.getOrPut(skill) { mutableListOf() } += SheetQuestSummary(
+                questId     = task.id,
+                questName   = task.displayName,
+                guild       = skill,
+                type        = task.type,
+                target      = task.target,
+                progress    = bounty.progress,
+                amount      = task.amount,
+                claimed     = false,
+                source      = SheetQuestSource.SEASONAL,
+                description = task.hint,
+                meetsLevel  = meetsLevel(task.type, skill, task.target),
+            )
+        }
         return result
     }
 
@@ -1237,9 +1261,10 @@ class SkillsViewModel @Inject constructor(
      * Craft-guild recipes are gated in CraftingViewModel.queueCraftForDaily instead.
      */
     private fun sheetQuestLevelRequired(type: String, guild: String, target: String): Int = when {
-        type == "gather" && guild == Skills.MINING      -> gameData.ores[target]?.levelRequired
-        type == "gather" && guild == Skills.WOODCUTTING -> gameData.trees.values.firstOrNull { it.logName == target }?.levelRequired
-        type == "gather" && guild == Skills.FISHING     -> gameData.fish[target]?.levelRequired
+        (type == "gather" || type == "turn_in") && guild == Skills.MINING      -> gameData.ores[target]?.levelRequired
+        (type == "gather" || type == "turn_in") && guild == Skills.WOODCUTTING -> gameData.trees.values.firstOrNull { it.logName == target }?.levelRequired
+        (type == "gather" || type == "turn_in") && guild == Skills.FISHING     -> gameData.fish[target]?.levelRequired
+        (type == "gather" || type == "turn_in") && guild == Skills.FARMING     -> gameData.crops[target]?.levelRequired
         type == "pickpocket"                            -> gameData.thievingNpcs[target]?.levelRequired
         type == "sessions" && guild == Skills.AGILITY   -> gameData.agilityCourses[target]?.levelRequired
         type == "craft" && guild == Skills.RUNECRAFTING -> gameData.runes[target]?.levelRequired
@@ -1261,7 +1286,7 @@ class SkillsViewModel @Inject constructor(
         val activeGuildDailyIds = flags.guildDailyIds.filter { it !in flags.guildDailyClaimed }
         val completedIds = progressById.entries.filter { it.value.completed }.map { it.key }.toSet()
 
-        fun addIndicator(key: String, skill: String, category: QuestCategory, remaining: Int, questId: String) {
+        fun addIndicator(key: String, skill: String, category: QuestCategory, remaining: Int, questId: String, customEmoji: String? = null) {
             val isCompletable = when (skill) {
                 Skills.RUNECRAFTING -> {
                     val rune = gameData.runes[key]
@@ -1292,7 +1317,7 @@ class SkillsViewModel @Inject constructor(
             // Prefixed by skill: some item keys (e.g. "ashes") are shared between skills
             // (Firemaking byproduct vs. Prayer buriable), and would otherwise leak
             // indicators across their sheets (issue #1014).
-            result.getOrPut("$skill:$key") { mutableListOf() }.add(QuestIndicator(category, isCompletable, questId))
+            result.getOrPut("$skill:$key") { mutableListOf() }.add(QuestIndicator(category, isCompletable, questId, customEmoji))
         }
 
         fun checkAndAdd(questId: String, questType: String, questSkill: String, questTarget: String, questAmount: Int, questProgressVal: Int, category: QuestCategory) {
@@ -1410,6 +1435,25 @@ class SkillsViewModel @Inject constructor(
             val template = guildPool[id] ?: continue
             val progress = flags.guildDailyProgress[id] ?: 0
             checkAndAdd(id, template.type, template.guild, template.target, template.amount, progress, QuestCategory.GUILD_DAILY)
+        }
+
+        // Seasonal Event Bounties
+        val eventEmoji = seasonalEventRepo.activeEvent()?.iconEmoji ?: QuestCategory.SEASONAL.emoji
+        for (bounty in seasonalEventRepo.getActiveBounties(flags, inventory)) {
+            val task = bounty.task
+            val remaining = task.amount - bounty.progress
+            if (remaining <= 0) continue
+            val skill = task.skill ?: continue
+            when (task.type) {
+                "gather", "craft" -> {
+                    addIndicator(task.target, skill, QuestCategory.SEASONAL, remaining, task.id, eventEmoji)
+                }
+                "turn_in" -> {
+                    val isCompletable = (inventory[task.target] ?: 0) >= task.amount
+                    result.getOrPut("$skill:${task.target}") { mutableListOf() }
+                        .add(QuestIndicator(QuestCategory.SEASONAL, isCompletable, task.id, eventEmoji))
+                }
+            }
         }
 
         return result

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -720,6 +720,7 @@
     <string name="quest_legend_title">Quest icons</string> <!-- untranslated -->
     <string name="quest_legend_daily">Daily quest</string> <!-- untranslated -->
     <string name="quest_legend_weekly">Weekly quest</string> <!-- untranslated -->
+    <string name="quest_legend_seasonal">Seasonal bounty</string> <!-- untranslated -->
     <string name="quest_legend_guild_daily">Guild daily</string> <!-- untranslated -->
     <string name="quest_legend_guild">Guild quest</string> <!-- untranslated -->
     <string name="quest_legend_quest">Quest</string> <!-- untranslated -->

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -720,6 +720,7 @@
     <string name="quest_legend_title">Quest icons</string> <!-- untranslated -->
     <string name="quest_legend_daily">Daily quest</string> <!-- untranslated -->
     <string name="quest_legend_weekly">Weekly quest</string> <!-- untranslated -->
+    <string name="quest_legend_seasonal">Seasonal bounty</string> <!-- untranslated -->
     <string name="quest_legend_guild_daily">Guild daily</string> <!-- untranslated -->
     <string name="quest_legend_guild">Guild quest</string> <!-- untranslated -->
     <string name="quest_legend_quest">Quest</string> <!-- untranslated -->

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -732,6 +732,7 @@
     <string name="quest_legend_title">Quest icons</string> <!-- untranslated -->
     <string name="quest_legend_daily">Daily quest</string> <!-- untranslated -->
     <string name="quest_legend_weekly">Weekly quest</string> <!-- untranslated -->
+    <string name="quest_legend_seasonal">Seasonal bounty</string> <!-- untranslated -->
     <string name="quest_legend_guild_daily">Guild daily</string> <!-- untranslated -->
     <string name="quest_legend_guild">Guild quest</string> <!-- untranslated -->
     <string name="quest_legend_quest">Quest</string> <!-- untranslated -->

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -720,6 +720,7 @@
     <string name="quest_legend_title">Quest-Symbole</string>
     <string name="quest_legend_daily">Tägliche Quest</string>
     <string name="quest_legend_weekly">Wöchentliche Quest</string>
+    <string name="quest_legend_seasonal">Seasonal bounty</string> <!-- untranslated -->
     <string name="quest_legend_guild_daily">Gilden-Tagesquest</string>
     <string name="quest_legend_guild">Gildenquest</string>
     <string name="quest_legend_quest">Aufgabe</string>

--- a/app/src/main/res/values-es-rES/strings.xml
+++ b/app/src/main/res/values-es-rES/strings.xml
@@ -720,6 +720,7 @@
     <string name="quest_legend_title">Quest icons</string> <!-- untranslated -->
     <string name="quest_legend_daily">Daily quest</string> <!-- untranslated -->
     <string name="quest_legend_weekly">Weekly quest</string> <!-- untranslated -->
+    <string name="quest_legend_seasonal">Seasonal bounty</string> <!-- untranslated -->
     <string name="quest_legend_guild_daily">Guild daily</string> <!-- untranslated -->
     <string name="quest_legend_guild">Guild quest</string> <!-- untranslated -->
     <string name="quest_legend_quest">Quest</string> <!-- untranslated -->

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -720,6 +720,7 @@
     <string name="quest_legend_title">Iconos de misiones</string>
     <string name="quest_legend_daily">Misión diaria</string>
     <string name="quest_legend_weekly">Misión semanal</string>
+    <string name="quest_legend_seasonal">Seasonal bounty</string> <!-- untranslated -->
     <string name="quest_legend_guild_daily">Diaria del gremio</string>
     <string name="quest_legend_guild">Misión del gremio</string>
     <string name="quest_legend_quest">Misión</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -721,6 +721,7 @@
     <string name="quest_legend_title">Icônes de quêtes</string>
     <string name="quest_legend_daily">Quête quotidienne</string>
     <string name="quest_legend_weekly">Quête hebdomadaire</string>
+    <string name="quest_legend_seasonal">Seasonal bounty</string> <!-- untranslated -->
     <string name="quest_legend_guild_daily">Quotidienne de guilde</string>
     <string name="quest_legend_guild">Quête de guilde</string>
     <string name="quest_legend_quest">Quête</string>

--- a/app/src/main/res/values-ga/strings.xml
+++ b/app/src/main/res/values-ga/strings.xml
@@ -748,6 +748,7 @@
     <string name="quest_legend_title">Quest icons</string> <!-- untranslated -->
     <string name="quest_legend_daily">Daily quest</string> <!-- untranslated -->
     <string name="quest_legend_weekly">Weekly quest</string> <!-- untranslated -->
+    <string name="quest_legend_seasonal">Seasonal bounty</string> <!-- untranslated -->
     <string name="quest_legend_guild_daily">Guild daily</string> <!-- untranslated -->
     <string name="quest_legend_guild">Guild quest</string> <!-- untranslated -->
     <string name="quest_legend_quest">Quest</string> <!-- untranslated -->

--- a/app/src/main/res/values-he/strings.xml
+++ b/app/src/main/res/values-he/strings.xml
@@ -720,6 +720,7 @@
     <string name="quest_legend_title">Quest icons</string> <!-- untranslated -->
     <string name="quest_legend_daily">Daily quest</string> <!-- untranslated -->
     <string name="quest_legend_weekly">Weekly quest</string> <!-- untranslated -->
+    <string name="quest_legend_seasonal">Seasonal bounty</string> <!-- untranslated -->
     <string name="quest_legend_guild_daily">Guild daily</string> <!-- untranslated -->
     <string name="quest_legend_guild">Guild quest</string> <!-- untranslated -->
     <string name="quest_legend_quest">Quest</string> <!-- untranslated -->

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -712,6 +712,7 @@
     <string name="quest_legend_title">Ikon quest</string>
     <string name="quest_legend_daily">Quest harian</string>
     <string name="quest_legend_weekly">Quest mingguan</string>
+    <string name="quest_legend_seasonal">Seasonal bounty</string> <!-- untranslated -->
     <string name="quest_legend_guild_daily">Harian guild</string>
     <string name="quest_legend_guild">Quest guild</string>
     <string name="quest_legend_quest">Quest</string> <!-- untranslated -->

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -720,6 +720,7 @@
     <string name="quest_legend_title">Icone delle missioni</string>
     <string name="quest_legend_daily">Missione giornaliera</string>
     <string name="quest_legend_weekly">Missione settimanale</string>
+    <string name="quest_legend_seasonal">Seasonal bounty</string> <!-- untranslated -->
     <string name="quest_legend_guild_daily">Giornaliera di gilda</string>
     <string name="quest_legend_guild">Missione di gilda</string>
     <string name="quest_legend_quest">Missione</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -720,6 +720,7 @@
     <string name="quest_legend_title">クエストアイコン</string>
     <string name="quest_legend_daily">デイリークエスト</string>
     <string name="quest_legend_weekly">ウィークリークエスト</string>
+    <string name="quest_legend_seasonal">Seasonal bounty</string> <!-- untranslated -->
     <string name="quest_legend_guild_daily">ギルドデイリー</string>
     <string name="quest_legend_guild">ギルドクエスト</string>
     <string name="quest_legend_quest">クエスト</string>

--- a/app/src/main/res/values-lt/strings.xml
+++ b/app/src/main/res/values-lt/strings.xml
@@ -720,6 +720,7 @@
     <string name="quest_legend_title">Quest icons</string> <!-- untranslated -->
     <string name="quest_legend_daily">Daily quest</string> <!-- untranslated -->
     <string name="quest_legend_weekly">Weekly quest</string> <!-- untranslated -->
+    <string name="quest_legend_seasonal">Seasonal bounty</string> <!-- untranslated -->
     <string name="quest_legend_guild_daily">Guild daily</string> <!-- untranslated -->
     <string name="quest_legend_guild">Guild quest</string> <!-- untranslated -->
     <string name="quest_legend_quest">Quest</string> <!-- untranslated -->

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -720,6 +720,7 @@
     <string name="quest_legend_title">Questpictogrammen</string>
     <string name="quest_legend_daily">Dagelijkse quest</string>
     <string name="quest_legend_weekly">Wekelijkse quest</string>
+    <string name="quest_legend_seasonal">Seasonal bounty</string> <!-- untranslated -->
     <string name="quest_legend_guild_daily">Dagelijkse gildequest</string>
     <string name="quest_legend_guild">Gildequest</string>
     <string name="quest_legend_quest">Quest</string> <!-- untranslated -->

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -736,6 +736,7 @@
     <string name="quest_legend_title">Ikony zadań</string>
     <string name="quest_legend_daily">Zadanie dzienne</string>
     <string name="quest_legend_weekly">Zadanie tygodniowe</string>
+    <string name="quest_legend_seasonal">Seasonal bounty</string> <!-- untranslated -->
     <string name="quest_legend_guild_daily">Dzienne gildii</string>
     <string name="quest_legend_guild">Zadanie gildii</string>
     <string name="quest_legend_quest">Zadanie</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -720,6 +720,7 @@
     <string name="quest_legend_title">Ícones de missões</string>
     <string name="quest_legend_daily">Missão diária</string>
     <string name="quest_legend_weekly">Missão semanal</string>
+    <string name="quest_legend_seasonal">Seasonal bounty</string> <!-- untranslated -->
     <string name="quest_legend_guild_daily">Diária da guilda</string>
     <string name="quest_legend_guild">Missão da guilda</string>
     <string name="quest_legend_quest">Missão</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -738,6 +738,7 @@
     <string name="quest_legend_title">Значки заданий</string>
     <string name="quest_legend_daily">Ежедневное задание</string>
     <string name="quest_legend_weekly">Еженедельное задание</string>
+    <string name="quest_legend_seasonal">Seasonal bounty</string> <!-- untranslated -->
     <string name="quest_legend_guild_daily">Ежедневное задание гильдии</string>
     <string name="quest_legend_guild">Задание гильдии</string>
     <string name="quest_legend_quest">Задание</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -720,6 +720,7 @@
     <string name="quest_legend_title">Görev simgeleri</string>
     <string name="quest_legend_daily">Günlük görev</string>
     <string name="quest_legend_weekly">Haftalık görev</string>
+    <string name="quest_legend_seasonal">Seasonal bounty</string> <!-- untranslated -->
     <string name="quest_legend_guild_daily">Lonca günlük görevi</string>
     <string name="quest_legend_guild">Lonca görevi</string>
     <string name="quest_legend_quest">Görev</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -720,6 +720,7 @@
     <string name="quest_legend_title">任务图标说明</string>
     <string name="quest_legend_daily">每日任务</string>
     <string name="quest_legend_weekly">每周任务</string>
+    <string name="quest_legend_seasonal">Seasonal bounty</string> <!-- untranslated -->
     <string name="quest_legend_guild_daily">公会每日</string>
     <string name="quest_legend_guild">公会任务</string>
     <string name="quest_legend_quest">任务</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -720,6 +720,7 @@
     <string name="quest_legend_title">Quest icons</string>
     <string name="quest_legend_daily">Daily quest</string>
     <string name="quest_legend_weekly">Weekly quest</string>
+    <string name="quest_legend_seasonal">Seasonal bounty</string>
     <string name="quest_legend_guild_daily">Guild daily</string>
     <string name="quest_legend_guild">Guild quest</string>
     <string name="quest_legend_quest">Quest</string>

--- a/app/src/test/kotlin/com/fantasyidler/ui/viewmodel/CraftingUiTest.kt
+++ b/app/src/test/kotlin/com/fantasyidler/ui/viewmodel/CraftingUiTest.kt
@@ -42,4 +42,23 @@ class CraftingUiTest {
 
         assertEquals(4, state.maxCraftable(recipe))
     }
+
+    @Test
+    fun `quest indicator falls back to category emoji when customEmoji is null`() {
+        val indicator = QuestIndicator(
+            category = QuestCategory.SEASONAL,
+            isCompletable = true,
+        )
+        assertEquals("🎯", indicator.emoji)
+    }
+
+    @Test
+    fun `quest indicator uses customEmoji when provided`() {
+        val indicator = QuestIndicator(
+            category = QuestCategory.SEASONAL,
+            isCompletable = true,
+            customEmoji = "☀️",
+        )
+        assertEquals("☀️", indicator.emoji)
+    }
 }

--- a/wiki/src/pages.py
+++ b/wiki/src/pages.py
@@ -825,6 +825,7 @@ def gen_quest_icons() -> str:
         skills_link=link("skills"),
         guilds_link=link("guilds"),
         quests_link=link("quests"),
+        seasonal_events_link=link("seasonal_events"),
     )
 
 

--- a/wiki/templates/skills/quest_icons.md
+++ b/wiki/templates/skills/quest_icons.md
@@ -10,6 +10,7 @@ Each quest category uses a distinct emoji for visual identification.
 |------|--------------------------|-------------------------------------------------------------------------------------------------------------------------|
 | ⏰    | Daily quests             | Complete daily quests for coins. Chance to receive Dwarven gear when missing pieces exist (resetting on each drop).     |
 | 📅   | Weekly quests            | Complete weekly quests for bonus rewards including Divine gear. Resets every Monday at the configured daily reset hour. |
+| 🎯   | Seasonal event bounties  | Complete bounties during active seasonal events to earn event tokens and rewards. Displays the event's theme icon (e.g., ☀️ for Sunspire Solstice, 🎃 for Gloomharvest) with 🎯 as a fallback. |
 | ⚒️   | Guild daily quests       | Complete guild daily quests through the Guild Hall to earn reputation and unlock new tiers.                             |
 | 🏰   | Guild progression quests | Progress through guild step quests to unlock new tiers and gain guild reputation.                                       |
 | 📜   | Main quests              | Progress through the main questline to unlock new mechanics, areas, and features.                                       |
@@ -25,3 +26,4 @@ Each quest category uses a distinct emoji for visual identification.
 - {skills_link} - Main skills documentation with skill icons
 - {quests_link} - Main quest list
 - {guilds_link} - Guild daily and progression quests
+- {seasonal_events_link} - Seasonal events and bounty board


### PR DESCRIPTION
## Before submitting

- [x] I've tested any changes with the appropriate tests (eg. Unit tests, validation scripts)
- [x] I've pulled and merged the latest changes from the repository

## Summary

Adds quest indicators for seasonal event bounties across skills, gathering, crafting, and farming sheets, matching the existing daily/weekly/guild quest indicator system. Also integrates active seasonal bounties into the skill sheet quest dialog with quick-queue support and adds the seasonal icon to the quest legend dialog.

Events can define their own theme icon (e.g. ☀️ for Solstice, 🎃 for Gloomharvest) with a 🎯 fallback.

## Related issue(s) or discussion(s)



## Changelog

- Added `icon_emoji` to seasonal event data with fallback to 🎯
- Added `QuestCategory.SEASONAL` and `customEmoji` support to quest indicators
- Added seasonal bounty indicators to skills overview, gathering, crafting, and farming
- Added seasonal bounties to the skill sheet quest dialog with quick-queue support
- Added seasonal bounty entry to the quest legend dialog
- Added and normalized `quest_legend_seasonal` across all languages
- Added seasonal bounties entry to the quest indicators wiki template

## Anything else?
