### PR TITLE
feature: show total amount of items for gloomharvest for tithe bounties

### DIFF
--- a/app/src/main/kotlin/com/fantasyidler/repository/SeasonalEventRepository.kt
+++ b/app/src/main/kotlin/com/fantasyidler/repository/SeasonalEventRepository.kt
@@ -14,7 +14,7 @@ import kotlinx.coroutines.sync.withLock
 
 data class SeasonalBountyTaskWithProgress(
     val task: SeasonalBountyTaskData,
-    /** For "turn_in" tasks this is how many of the target the player currently holds (capped at the ask). */
+    /** For "turn_in" tasks this is how many of the target the player currently holds. */
     val progress: Int,
     /** Non-null while this slot is waiting for a new task to rotate in after a claim. */
     val cooldownUntilMs: Long?,
@@ -49,7 +49,7 @@ class SeasonalEventRepository @Inject constructor(
             val task = byId[taskId] ?: return@mapIndexedNotNull null
             SeasonalBountyTaskWithProgress(
                 task            = task,
-                progress        = if (task.type == "turn_in") minOf(inventory[task.target] ?: 0, task.amount)
+                progress        = if (task.type == "turn_in") inventory[task.target] ?: 0
                                   else flags.seasonalBountyProgress[taskId] ?: 0,
                 cooldownUntilMs = flags.seasonalBountySlotCooldownUntil[index.toString()],
             )


### PR DESCRIPTION
## Before submitting

- [x] I've tested any changes with the appropriate tests (eg. Unit tests, validation scripts)
- [x] I've pulled and merged the latest changes from the repository

## Summary

<!-- Short summary of the pull request and what it changes -->

- show total number of items for gloomharvest event only for Tithe bounties. I think this is a better UX experience for users.

<img width="903" height="428" alt="image" src="https://github.com/user-attachments/assets/0073dea7-6fd5-4f72-9a39-77c5da25b279" />

## Related issue(s) or discussion(s)

<!-- Prepend issues with "Fixes" if this should close the issue, e.g. Fixes #283, Relates to #284 -->


## Changelog

<!-- Concise list of changes, e.g.
- Fix time-slot bug causing XP gains to not show in notification banner
- Added ellipsis for quests XP gains exceeding screen width
-->

- Show total number of items for gloomharvest Title bounties


## Anything else?

