### PR TITLE
[testing stacked PRs] Fix remaining guild navigation and remove allowlist

### DIFF
--- a/app/src/main/kotlin/com/fantasyidler/data/model/PlayerModels.kt
+++ b/app/src/main/kotlin/com/fantasyidler/data/model/PlayerModels.kt
@@ -678,3 +678,17 @@ object Skills {
     val DEFAULT_LEVELS: Map<String, Int> = ALL.associateWith { 1 }
     val DEFAULT_XP: Map<String, Long> = ALL.associateWith { 0L }
 }
+
+object CombatGuilds {
+    const val WARRIORS = "warriors"
+    const val ARCHERS   = "archers"
+    const val MAGES     = "mages"
+
+    val ALL = listOf(WARRIORS, ARCHERS, MAGES)
+
+    fun guildFor(combatStyle: String): String = when (combatStyle) {
+        "ranged" -> ARCHERS
+        "magic"  -> MAGES
+        else     -> WARRIORS
+    }
+}

--- a/app/src/main/kotlin/com/fantasyidler/repository/GuildRepository.kt
+++ b/app/src/main/kotlin/com/fantasyidler/repository/GuildRepository.kt
@@ -4,6 +4,7 @@ import com.fantasyidler.data.db.dao.QuestProgressDao
 import com.fantasyidler.data.json.GuildDailyTemplate
 import com.fantasyidler.data.json.GuildQuestData
 import com.fantasyidler.data.json.GuildQuestRewards
+import com.fantasyidler.data.model.CombatGuilds
 import com.fantasyidler.data.model.PlayerFlags
 import com.fantasyidler.data.model.QuestProgress
 import java.util.Calendar
@@ -13,7 +14,6 @@ import javax.inject.Singleton
 import kotlin.random.Random
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.sync.withLock
-import kotlin.random.nextLong
 
 data class GuildQuestWithProgress(
     val quest: GuildQuestData,
@@ -109,12 +109,6 @@ class GuildRepository @Inject constructor(
             "warriors", "archers", "mages", "slayer", "prayer", "mercantile",
         )
 
-        fun combatStyleToGuild(combatStyle: String): String = when (combatStyle) {
-            "ranged" -> "archers"
-            "magic"  -> "mages"
-            else     -> "warriors"
-        }
-
         val POTION_SUBSTITUTES: Map<String, List<String>> = mapOf(
             "strength_potion"       to listOf("super_strength_potion", "overload_potion"),
             "attack_potion"         to listOf("super_attack_potion",   "overload_potion"),
@@ -193,7 +187,7 @@ class GuildRepository @Inject constructor(
 
     /** Called when a combat session is collected. */
     suspend fun recordGuildCombat(killsByEnemy: Map<String, Int>, combatStyle: String) = playerRepo.playerMutex.withLock {
-        val guild = combatStyleToGuild(combatStyle)
+        val guild = CombatGuilds.guildFor(combatStyle)
         val totalKills = killsByEnemy.values.sum()
         var flags = ensureGuildDailiesRefreshedUnlocked()
         if (totalKills > 0) {

--- a/app/src/main/kotlin/com/fantasyidler/ui/navigation/AppNavigation.kt
+++ b/app/src/main/kotlin/com/fantasyidler/ui/navigation/AppNavigation.kt
@@ -227,6 +227,17 @@ fun AppNavigation(
                     onNavigateToPrestige  = { skill -> navController.navigate(Screen.PrestigeDetail.createRoute(skill)) },
                 )
             }
+            paneComposable(
+                route     = Screen.Skills.openSkillRoute,
+                arguments = listOf(navArgument("openSkill") { type = NavType.StringType }),
+            ) { entry ->
+                SkillsScreen(
+                    openSkill             = entry.arguments?.getString("openSkill"),
+                    onNavigateToSlayer    = { navController.navigate(Screen.Slayer.route) },
+                    onNavigateToBoneAltar = { navController.navigate(Screen.BoneAltar.route) },
+                    onNavigateToPrestige  = { skill -> navController.navigate(Screen.PrestigeDetail.createRoute(skill)) },
+                )
+            }
             paneComposable(Screen.Farming.route) { entry ->
                 FarmingScreen(onBack = { if (navController.currentBackStackEntry == entry) navController.popBackStack() })
             }
@@ -362,7 +373,8 @@ fun AppNavigation(
             }
             paneComposable(Screen.GuildDetail.route) { entry ->
                 GuildDetailScreen(
-                    onBack = { if (navController.currentBackStackEntry == entry) navController.popBackStack() },
+                    onBack             = { if (navController.currentBackStackEntry == entry) navController.popBackStack() },
+                    onNavigateToSkill  = { skill -> navController.navigate(Screen.Skills.routeWithSkill(skill)) },
                 )
             }
             paneComposable(Screen.Church.route) { entry ->

--- a/app/src/main/kotlin/com/fantasyidler/ui/navigation/AppNavigation.kt
+++ b/app/src/main/kotlin/com/fantasyidler/ui/navigation/AppNavigation.kt
@@ -43,8 +43,9 @@ import androidx.navigation.compose.rememberNavController
 import androidx.navigation.navArgument
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
-import androidx.compose.runtime.getValue
 import androidx.hilt.navigation.compose.hiltViewModel
+import com.fantasyidler.data.model.CombatGuilds
+import com.fantasyidler.data.model.Skills
 import com.fantasyidler.notification.SessionNotificationManager
 import com.fantasyidler.ui.screen.AppBannerHost
 import com.fantasyidler.ui.screen.BoneAltarScreen
@@ -272,6 +273,7 @@ fun AppNavigation(
                 )
             }
             paneComposable(Screen.Combat.gearRoute) { CombatScreen(startOnGear = true) }
+            paneComposable(Screen.Combat.dungeonsRoute) { CombatScreen(startOnDungeons = true) }
             paneComposable(
                 route     = Screen.Combat.presetDungeonRoute,
                 arguments = listOf(navArgument("dungeonKey") { type = NavType.StringType }),
@@ -374,7 +376,13 @@ fun AppNavigation(
             paneComposable(Screen.GuildDetail.route) { entry ->
                 GuildDetailScreen(
                     onBack             = { if (navController.currentBackStackEntry == entry) navController.popBackStack() },
-                    onNavigateToSkill  = { skill -> navController.navigate(Screen.Skills.routeWithSkill(skill)) },
+                    onNavigateToSkill  = { skill ->
+                        when (skill) {
+                            Skills.SLAYER -> navController.navigate(Screen.Slayer.route)
+                            in CombatGuilds.ALL -> navController.navigate(Screen.Combat.dungeonsRoute)
+                            else -> navController.navigate(Screen.Skills.routeWithSkill(skill))
+                        }
+                    },
                 )
             }
             paneComposable(Screen.Church.route) { entry ->

--- a/app/src/main/kotlin/com/fantasyidler/ui/navigation/Screen.kt
+++ b/app/src/main/kotlin/com/fantasyidler/ui/navigation/Screen.kt
@@ -39,7 +39,10 @@ sealed class Screen(
         labelRes     = R.string.nav_skills,
         icon         = Icons.AutoMirrored.Outlined.ShowChart,
         selectedIcon = Icons.AutoMirrored.Filled.ShowChart,
-    )
+    ) {
+        const val openSkillRoute = "skills/open/{openSkill}"
+        fun routeWithSkill(skill: String) = "skills/open/$skill"
+    }
     object Combat : Screen(
         route        = "combat",
         labelRes     = R.string.nav_combat,

--- a/app/src/main/kotlin/com/fantasyidler/ui/navigation/Screen.kt
+++ b/app/src/main/kotlin/com/fantasyidler/ui/navigation/Screen.kt
@@ -50,6 +50,7 @@ sealed class Screen(
         selectedIcon = Icons.Filled.Shield,
     ) {
         const val gearRoute = "combat/gear"
+        const val dungeonsRoute = "combat/dungeons"
         const val presetDungeonRoute = "combat/preset_dungeon/{dungeonKey}"
         fun presetDungeonRoute(key: String) = "combat/preset_dungeon/$key"
         const val presetBossRoute = "combat/preset_boss/{bossKey}"

--- a/app/src/main/kotlin/com/fantasyidler/ui/screen/CombatScreen.kt
+++ b/app/src/main/kotlin/com/fantasyidler/ui/screen/CombatScreen.kt
@@ -104,6 +104,7 @@ fun CombatScreen(
     viewModel:          CombatViewModel    = hiltViewModel(),
     inventoryVm:        InventoryViewModel = hiltViewModel(),
     startOnGear:        Boolean            = false,
+    startOnDungeons:    Boolean            = false,
     initialDungeonKey:  String?            = null,
     initialBossKey:     String?            = null,
     onNavigateToTower:  () -> Unit         = {},
@@ -170,7 +171,7 @@ fun CombatScreen(
         else
             stringResource(R.string.label_skills)
         if (combatSession != null) {
-            var savedPage by rememberSaveable { mutableIntStateOf(if (startOnGear) 2 else 0) }
+            var savedPage by rememberSaveable { mutableIntStateOf(if (startOnGear) 2 else if (startOnDungeons) 1 else 0) }
             val pagerState = rememberPagerState(initialPage = savedPage, pageCount = { 4 })
             LaunchedEffect(Unit) {
                 if (pagerState.currentPage != savedPage) pagerState.scrollToPage(savedPage)

--- a/app/src/main/kotlin/com/fantasyidler/ui/screen/GuildDetailScreen.kt
+++ b/app/src/main/kotlin/com/fantasyidler/ui/screen/GuildDetailScreen.kt
@@ -9,7 +9,9 @@ import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.WindowInsetsSides
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.safeDrawing
@@ -24,6 +26,7 @@ import androidx.compose.material3.Button
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Switch
+import androidx.compose.material3.TextButton
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
@@ -44,19 +47,26 @@ import androidx.compose.runtime.rememberCoroutineScope
 import kotlinx.coroutines.launch
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.fantasyidler.R
+import com.fantasyidler.data.model.Skills
 import com.fantasyidler.repository.GuildDailyWithProgress
 import com.fantasyidler.repository.GuildQuestWithProgress
 import com.fantasyidler.ui.viewmodel.GuildDetailViewModel
 import com.fantasyidler.util.GameStrings
 import com.fantasyidler.util.dailyResetClockTime
 import com.fantasyidler.util.formatCoins
+
+/**
+ * TEMP: guilds works for the following and have not figured out how to deal with the other guilds yet.
+ */
+private val NAVIGABLE_SKILL_GUILDS = setOf(
+    Skills.SMITHING, Skills.COOKING, Skills.FLETCHING, Skills.CRAFTING, Skills.HERBLORE, Skills.CONSTRUCTION,
+)
 
 @Composable
 internal fun localizedQuestDesc(type: String, target: String, amount: Int, guild: String): String {
@@ -85,6 +95,7 @@ internal fun localizedQuestDesc(type: String, target: String, amount: Int, guild
 @Composable
 fun GuildDetailScreen(
     onBack: () -> Unit = {},
+    onNavigateToSkill: (String) -> Unit = {},
     viewModel: GuildDetailViewModel = hiltViewModel(),
 ) {
     val context = LocalContext.current
@@ -177,6 +188,7 @@ fun GuildDetailScreen(
                         hideCompleted = state.hideCompleted,
                         onClaim       = { viewModel.claimGuildQuest(it) },
                         onContribute  = { viewModel.contributeFarmingQuest(it) },
+                        onNavigateToSkill = onNavigateToSkill,
                     )
                     else -> GuildDailiesTab(
                         dailies       = state.dailies,
@@ -186,6 +198,7 @@ fun GuildDetailScreen(
                         hideCompleted = state.hideCompleted,
                         onClaim       = { viewModel.claimGuildDaily(it) },
                         onContribute  = { viewModel.contributeFarmingDaily(it) },
+                        onNavigateToSkill = onNavigateToSkill,
                     )
                 }
             }
@@ -275,6 +288,7 @@ private fun GuildQuestsTab(
     hideCompleted: Boolean = false,
     onClaim: (String) -> Unit,
     onContribute: (String) -> Unit,
+    onNavigateToSkill: (String) -> Unit,
 ) {
     val visibleQuests = if (hideCompleted) quests.filter { !it.completed } else quests
     LazyColumn(Modifier.fillMaxSize()) {
@@ -294,12 +308,13 @@ private fun GuildQuestsTab(
         } else {
             items(visibleQuests, key = { it.quest.id }) { qwp ->
                 GuildQuestRow(
-                    qwp          = qwp,
-                    guildLevel   = guildLevel,
-                    inventoryQty = if (qwp.quest.guild == "farming" && qwp.quest.type == "gather")
+                    qwp             = qwp,
+                    guildLevel      = guildLevel,
+                    inventoryQty    = if (qwp.quest.guild == "farming" && qwp.quest.type == "gather")
                         inventory[qwp.quest.target] ?: 0 else 0,
-                    onClaim      = { onClaim(qwp.quest.id) },
-                    onContribute = { onContribute(qwp.quest.id) },
+                    onClaim         = { onClaim(qwp.quest.id) },
+                    onContribute    = { onContribute(qwp.quest.id) },
+                    onNavigateToSkill = onNavigateToSkill,
                 )
                 HorizontalDivider(modifier = Modifier.padding(horizontal = 16.dp))
             }
@@ -315,6 +330,7 @@ private fun GuildQuestRow(
     inventoryQty: Int = 0,
     onClaim: () -> Unit,
     onContribute: () -> Unit = {},
+    onNavigateToSkill: (String) -> Unit = {},
 ) {
     val locked   = guildLevel < qwp.quest.guildLevelRequired
     val dimColor = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.38f)
@@ -338,7 +354,17 @@ private fun GuildQuestRow(
                 style      = MaterialTheme.typography.bodyLarge,
                 fontWeight = FontWeight.SemiBold,
                 color      = if (locked) dimColor else MaterialTheme.colorScheme.onSurface,
+                modifier   = Modifier.weight(1f),
             )
+            if (qwp.quest.guild in NAVIGABLE_SKILL_GUILDS) {
+                TextButton(
+                    onClick        = { onNavigateToSkill(qwp.quest.guild) },
+                    modifier       = Modifier.heightIn(max = 24.dp),
+                    contentPadding = PaddingValues(horizontal = 8.dp, vertical = 0.dp),
+                ) {
+                    Text(stringResource(R.string.guild_go_to_skill))
+                }
+            }
         }
         Spacer(Modifier.height(2.dp))
         Text(
@@ -414,6 +440,7 @@ private fun GuildDailiesTab(
     hideCompleted: Boolean = false,
     onClaim: (String) -> Unit,
     onContribute: (String) -> Unit,
+    onNavigateToSkill: (String) -> Unit,
 ) {
     val visibleDailies = if (hideCompleted) dailies.filter { !it.claimed } else dailies
     LazyColumn(Modifier.fillMaxSize()) {
@@ -436,11 +463,12 @@ private fun GuildDailiesTab(
         } else {
             items(visibleDailies, key = { it.template.id }) { dwp ->
                 GuildDailyCard(
-                    dwp          = dwp,
-                    inventoryQty = if (dwp.template.guild == "farming" && dwp.template.type == "gather")
+                    dwp             = dwp,
+                    inventoryQty    = if (dwp.template.guild == "farming" && dwp.template.type == "gather")
                         inventory[dwp.template.target] ?: 0 else 0,
-                    onClaim      = { onClaim(dwp.template.id) },
-                    onContribute = { onContribute(dwp.template.id) },
+                    onClaim         = { onClaim(dwp.template.id) },
+                    onContribute    = { onContribute(dwp.template.id) },
+                    onNavigateToSkill = onNavigateToSkill,
                 )
                 HorizontalDivider(modifier = Modifier.padding(horizontal = 16.dp))
             }
@@ -465,6 +493,7 @@ private fun GuildDailyCard(
     inventoryQty: Int = 0,
     onClaim: () -> Unit,
     onContribute: () -> Unit = {},
+    onNavigateToSkill: (String) -> Unit = {},
 ) {
     val isComplete = dwp.progress >= dwp.template.amount
     val isClaimed  = dwp.claimed
@@ -474,11 +503,23 @@ private fun GuildDailyCard(
             .fillMaxWidth()
             .padding(horizontal = 16.dp, vertical = 12.dp),
     ) {
-        Text(
-            text       = GameStrings.questName(LocalContext.current, dwp.template.id, dwp.template.name),
-            style      = MaterialTheme.typography.bodyLarge,
-            fontWeight = FontWeight.SemiBold,
-        )
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            Text(
+                text       = GameStrings.questName(LocalContext.current, dwp.template.id, dwp.template.name),
+                style      = MaterialTheme.typography.bodyLarge,
+                fontWeight = FontWeight.SemiBold,
+                modifier   = Modifier.weight(1f),
+            )
+            if (dwp.template.guild in NAVIGABLE_SKILL_GUILDS) {
+                TextButton(
+                    onClick        = { onNavigateToSkill(dwp.template.guild) },
+                    modifier       = Modifier.heightIn(max = 24.dp),
+                    contentPadding = PaddingValues(horizontal = 8.dp, vertical = 0.dp),
+                ) {
+                    Text(stringResource(R.string.guild_go_to_skill))
+                }
+            }
+        }
         Spacer(Modifier.height(2.dp))
         Text(
             text  = localizedQuestDesc(dwp.template.type, dwp.template.target, dwp.template.amount, dwp.template.guild),

--- a/app/src/main/kotlin/com/fantasyidler/ui/screen/GuildDetailScreen.kt
+++ b/app/src/main/kotlin/com/fantasyidler/ui/screen/GuildDetailScreen.kt
@@ -53,6 +53,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.fantasyidler.R
+import com.fantasyidler.data.model.CombatGuilds
 import com.fantasyidler.data.model.Skills
 import com.fantasyidler.repository.GuildDailyWithProgress
 import com.fantasyidler.repository.GuildQuestWithProgress
@@ -66,6 +67,8 @@ import com.fantasyidler.util.formatCoins
  */
 private val NAVIGABLE_SKILL_GUILDS = setOf(
     Skills.SMITHING, Skills.COOKING, Skills.FLETCHING, Skills.CRAFTING, Skills.HERBLORE, Skills.CONSTRUCTION,
+    Skills.SLAYER, Skills.PRAYER, Skills.MERCANTILE, Skills.FARMING,
+    CombatGuilds.ARCHERS, CombatGuilds.MAGES, CombatGuilds.WARRIORS,
 )
 
 @Composable

--- a/app/src/main/kotlin/com/fantasyidler/ui/screen/GuildDetailScreen.kt
+++ b/app/src/main/kotlin/com/fantasyidler/ui/screen/GuildDetailScreen.kt
@@ -53,8 +53,6 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.fantasyidler.R
-import com.fantasyidler.data.model.CombatGuilds
-import com.fantasyidler.data.model.Skills
 import com.fantasyidler.repository.GuildDailyWithProgress
 import com.fantasyidler.repository.GuildQuestWithProgress
 import com.fantasyidler.ui.viewmodel.GuildDetailViewModel
@@ -62,14 +60,6 @@ import com.fantasyidler.util.GameStrings
 import com.fantasyidler.util.dailyResetClockTime
 import com.fantasyidler.util.formatCoins
 
-/**
- * TEMP: guilds works for the following and have not figured out how to deal with the other guilds yet.
- */
-private val NAVIGABLE_SKILL_GUILDS = setOf(
-    Skills.SMITHING, Skills.COOKING, Skills.FLETCHING, Skills.CRAFTING, Skills.HERBLORE, Skills.CONSTRUCTION,
-    Skills.SLAYER, Skills.PRAYER, Skills.MERCANTILE, Skills.FARMING,
-    CombatGuilds.ARCHERS, CombatGuilds.MAGES, CombatGuilds.WARRIORS,
-)
 
 @Composable
 internal fun localizedQuestDesc(type: String, target: String, amount: Int, guild: String): String {
@@ -359,14 +349,12 @@ private fun GuildQuestRow(
                 color      = if (locked) dimColor else MaterialTheme.colorScheme.onSurface,
                 modifier   = Modifier.weight(1f),
             )
-            if (qwp.quest.guild in NAVIGABLE_SKILL_GUILDS) {
-                TextButton(
-                    onClick        = { onNavigateToSkill(qwp.quest.guild) },
-                    modifier       = Modifier.heightIn(max = 24.dp),
-                    contentPadding = PaddingValues(horizontal = 8.dp, vertical = 0.dp),
-                ) {
-                    Text(stringResource(R.string.guild_go_to_skill))
-                }
+            TextButton(
+                onClick        = { onNavigateToSkill(qwp.quest.guild) },
+                modifier       = Modifier.heightIn(max = 24.dp),
+                contentPadding = PaddingValues(horizontal = 8.dp, vertical = 0.dp),
+            ) {
+                Text(stringResource(R.string.guild_go_to_skill))
             }
         }
         Spacer(Modifier.height(2.dp))
@@ -513,14 +501,12 @@ private fun GuildDailyCard(
                 fontWeight = FontWeight.SemiBold,
                 modifier   = Modifier.weight(1f),
             )
-            if (dwp.template.guild in NAVIGABLE_SKILL_GUILDS) {
-                TextButton(
-                    onClick        = { onNavigateToSkill(dwp.template.guild) },
-                    modifier       = Modifier.heightIn(max = 24.dp),
-                    contentPadding = PaddingValues(horizontal = 8.dp, vertical = 0.dp),
-                ) {
-                    Text(stringResource(R.string.guild_go_to_skill))
-                }
+            TextButton(
+                onClick        = { onNavigateToSkill(dwp.template.guild) },
+                modifier       = Modifier.heightIn(max = 24.dp),
+                contentPadding = PaddingValues(horizontal = 8.dp, vertical = 0.dp),
+            ) {
+                Text(stringResource(R.string.guild_go_to_skill))
             }
         }
         Spacer(Modifier.height(2.dp))

--- a/app/src/main/kotlin/com/fantasyidler/ui/screen/SkillsScreen.kt
+++ b/app/src/main/kotlin/com/fantasyidler/ui/screen/SkillsScreen.kt
@@ -120,8 +120,13 @@ fun SkillsScreen(
     AppBannerEffect(state.snackbarMessage, viewModel::snackbarConsumed)
     AppBannerEffect(craftSnackState.snackbarMessage, craftingViewModel::snackbarConsumed)
 
-    LaunchedEffect(openSkill) {
-        if (openSkill != null) viewModel.onSkillTapped(openSkill)
+    // onSkillTapped reads uiState.value synchronously, so deep-linking here must wait for isLoading to show correct skill level.
+    var openedInitialSkill by remember { mutableStateOf(false) }
+    LaunchedEffect(openSkill, state.isLoading) {
+        if (openSkill != null && !state.isLoading && !openedInitialSkill) {
+            openedInitialSkill = true
+            viewModel.onSkillTapped(openSkill)
+        }
     }
 
     var showLegend by remember { mutableStateOf(false) }

--- a/app/src/main/kotlin/com/fantasyidler/ui/screen/SkillsScreen.kt
+++ b/app/src/main/kotlin/com/fantasyidler/ui/screen/SkillsScreen.kt
@@ -105,6 +105,7 @@ private val NON_COMBAT_PRESTIGE_SKILLS = Skills.GATHERING + Skills.CRAFTING_SKIL
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun SkillsScreen(
+    openSkill: String? = null,
     onNavigateToSlayer: () -> Unit = {},
     onNavigateToBoneAltar: () -> Unit = {},
     onNavigateToPrestige: (String) -> Unit = {},
@@ -118,6 +119,10 @@ fun SkillsScreen(
 
     AppBannerEffect(state.snackbarMessage, viewModel::snackbarConsumed)
     AppBannerEffect(craftSnackState.snackbarMessage, craftingViewModel::snackbarConsumed)
+
+    LaunchedEffect(openSkill) {
+        if (openSkill != null) viewModel.onSkillTapped(openSkill)
+    }
 
     var showLegend by remember { mutableStateOf(false) }
     if (showLegend) {

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -969,6 +969,7 @@
     <string name="guild_no_dailies">Complete guild quests to unlock daily requests.</string> <!-- untranslated -->
     <string name="guild_dailies_all_done">All of today\'s daily requests are complete. Come back after the daily reset.</string> <!-- untranslated -->
     <string name="guild_contribute_inventory">Contribute from inventory (%1$d available)</string> <!-- untranslated -->
+    <string name="guild_go_to_skill">Go to Skill</string> <!-- untranslated -->
     <string name="guild_quest_desc_gather">%1$s %2$d %3$s for the %4$s.</string> <!-- untranslated -->
     <string name="guild_quest_desc_kill">Defeat %1$d enemies using %2$s combat.</string> <!-- untranslated -->
     <string name="guild_quest_desc_prayer">Bury %1$d bones for the %2$s.</string> <!-- untranslated -->

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -969,6 +969,7 @@
     <string name="guild_no_dailies">Complete guild quests to unlock daily requests.</string> <!-- untranslated -->
     <string name="guild_dailies_all_done">All of today\'s daily requests are complete. Come back after the daily reset.</string> <!-- untranslated -->
     <string name="guild_contribute_inventory">Contribute from inventory (%1$d available)</string> <!-- untranslated -->
+    <string name="guild_go_to_skill">Go to Skill</string> <!-- untranslated -->
     <string name="guild_quest_desc_gather">%1$s %2$d %3$s for the %4$s.</string> <!-- untranslated -->
     <string name="guild_quest_desc_kill">Defeat %1$d enemies using %2$s combat.</string> <!-- untranslated -->
     <string name="guild_quest_desc_prayer">Bury %1$d bones for the %2$s.</string> <!-- untranslated -->

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -981,6 +981,7 @@
     <string name="guild_no_dailies">Complete guild quests to unlock daily requests.</string> <!-- untranslated -->
     <string name="guild_dailies_all_done">All of today\'s daily requests are complete. Come back after the daily reset.</string> <!-- untranslated -->
     <string name="guild_contribute_inventory">Contribute from inventory (%1$d available)</string> <!-- untranslated -->
+    <string name="guild_go_to_skill">Go to Skill</string> <!-- untranslated -->
     <string name="guild_quest_desc_gather">%1$s %2$d %3$s for the %4$s.</string> <!-- untranslated -->
     <string name="guild_quest_desc_kill">Defeat %1$d enemies using %2$s combat.</string> <!-- untranslated -->
     <string name="guild_quest_desc_prayer">Bury %1$d bones for the %2$s.</string> <!-- untranslated -->

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -969,6 +969,7 @@
     <string name="guild_no_dailies">Schließt Gildenmissionen ab, um Tagesaufgaben freizuschalten. (Oder Ihr habt Eure Tagesaufgaben schon erfüllt.)</string>
     <string name="guild_dailies_all_done">Alle heutigen täglichen Aufgaben sind erledigt. Schau nach dem täglichen Reset wieder vorbei.</string>
     <string name="guild_contribute_inventory">Aus Inventar beisteuern (%1$d verfügbar)</string>
+    <string name="guild_go_to_skill">Go to Skill</string> <!-- untranslated -->
     <string name="guild_quest_desc_gather">%1$s %2$d %3$s für die %4$s.</string>
     <string name="guild_quest_desc_kill">Besiegt %1$d Feinde im %2$s-Kampf.</string>
     <string name="guild_quest_desc_prayer">Vergrabt %1$d Knochen für die %2$s.</string>

--- a/app/src/main/res/values-es-rES/strings.xml
+++ b/app/src/main/res/values-es-rES/strings.xml
@@ -969,6 +969,7 @@
     <string name="guild_no_dailies">Complete guild quests to earn reputation and unlock daily requests.</string>
     <string name="guild_dailies_all_done">All of today\'s daily requests are complete. Come back after the daily reset.</string> <!-- untranslated -->
     <string name="guild_contribute_inventory">Contribute from inventory (%1$d available)</string> <!-- untranslated -->
+    <string name="guild_go_to_skill">Go to Skill</string> <!-- untranslated -->
     <string name="guild_quest_desc_gather">%1$s %2$d %3$s for the %4$s.</string> <!-- untranslated -->
     <string name="guild_quest_desc_kill">Defeat %1$d enemies using %2$s combat.</string> <!-- untranslated -->
     <string name="guild_quest_desc_prayer">Bury %1$d bones for the %2$s.</string> <!-- untranslated -->

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -969,6 +969,7 @@
     <string name="guild_no_dailies">Completa misiones de gremio para desbloquear solicitudes diarias.</string>
     <string name="guild_dailies_all_done">All of today\'s daily requests are complete. Come back after the daily reset.</string> <!-- untranslated -->
     <string name="guild_contribute_inventory">Contribuir desde el inventario (%1$d disponible)</string>
+    <string name="guild_go_to_skill">Go to Skill</string> <!-- untranslated -->
     <string name="guild_quest_desc_gather">%1$s %2$d %3$s para el %4$s.</string>
     <string name="guild_quest_desc_kill">Derrota %1$d enemigos usando combate %2$s.</string>
     <string name="guild_quest_desc_prayer">Entierra %1$d huesos para el %2$s.</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -970,6 +970,7 @@
     <string name="guild_no_dailies">Terminez des quêtes de guilde pour débloquer les requêtes quotidiennes.</string>
     <string name="guild_dailies_all_done">Toutes les requêtes quotidiennes sont finies. Revenez après la réinitialisation quotidienne.</string>
     <string name="guild_contribute_inventory">Contribuer depuis l\'inventaire (%1$d disponible)</string>
+    <string name="guild_go_to_skill">Go to Skill</string> <!-- untranslated -->
     <string name="guild_quest_desc_gather">%1$s %2$d %3$s pour la %4$s.</string>
     <string name="guild_quest_desc_kill">Éliminez %1$d ennemis en combat %2$s.</string>
     <string name="guild_quest_desc_prayer">Enterrez %1$d os pour la %2$s.</string>

--- a/app/src/main/res/values-ga/strings.xml
+++ b/app/src/main/res/values-ga/strings.xml
@@ -997,6 +997,7 @@
     <string name="guild_no_dailies">Complete guild quests to unlock daily requests.</string> <!-- untranslated -->
     <string name="guild_dailies_all_done">All of today\'s daily requests are complete. Come back after the daily reset.</string> <!-- untranslated -->
     <string name="guild_contribute_inventory">Contribute from inventory (%1$d available)</string> <!-- untranslated -->
+    <string name="guild_go_to_skill">Go to Skill</string> <!-- untranslated -->
     <string name="guild_quest_desc_gather">%1$s %2$d %3$s for the %4$s.</string> <!-- untranslated -->
     <string name="guild_quest_desc_kill">Defeat %1$d enemies using %2$s combat.</string> <!-- untranslated -->
     <string name="guild_quest_desc_prayer">Bury %1$d bones for the %2$s.</string> <!-- untranslated -->

--- a/app/src/main/res/values-he/strings.xml
+++ b/app/src/main/res/values-he/strings.xml
@@ -969,6 +969,7 @@
     <string name="guild_no_dailies">Complete guild quests to unlock daily requests.</string> <!-- untranslated -->
     <string name="guild_dailies_all_done">All of today\'s daily requests are complete. Come back after the daily reset.</string> <!-- untranslated -->
     <string name="guild_contribute_inventory">Contribute from inventory (%1$d available)</string> <!-- untranslated -->
+    <string name="guild_go_to_skill">Go to Skill</string> <!-- untranslated -->
     <string name="guild_quest_desc_gather">%1$s %2$d %3$s for the %4$s.</string> <!-- untranslated -->
     <string name="guild_quest_desc_kill">Defeat %1$d enemies using %2$s combat.</string> <!-- untranslated -->
     <string name="guild_quest_desc_prayer">Bury %1$d bones for the %2$s.</string> <!-- untranslated -->

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -961,6 +961,7 @@
     <string name="guild_no_dailies">Selesaikan Tugas Serikat untuk membuka permintaan harian.</string>
     <string name="guild_dailies_all_done">All of today\'s daily requests are complete. Come back after the daily reset.</string> <!-- untranslated -->
     <string name="guild_contribute_inventory">Kontribusi di inventaris (%1$d tersedia)</string>
+    <string name="guild_go_to_skill">Go to Skill</string> <!-- untranslated -->
     <string name="guild_quest_desc_gather">%1$s %2$d %3$s untuk %4$s.</string>
     <string name="guild_quest_desc_kill">Kalahkan %1$d musuh menggunakan %2$s pertempuran.</string>
     <string name="guild_quest_desc_prayer">Kubur tulang %1$d untuk %2$s.</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -969,6 +969,7 @@
     <string name="guild_no_dailies">Completa missioni della gilda per sbloccare le richieste del giorno.</string>
     <string name="guild_dailies_all_done">Hai completato tutte le richieste giornaliere. Torna dopo l\'orario di ripristino.</string>
     <string name="guild_contribute_inventory">Contribuisci con i tuoi oggetti (%1$d disponibile)</string>
+    <string name="guild_go_to_skill">Go to Skill</string> <!-- untranslated -->
     <string name="guild_quest_desc_gather">%1$s %2$d %3$s per la %4$s.</string>
     <string name="guild_quest_desc_kill">Sconfiggi %1$d nemici in combattimento %2$s.</string>
     <string name="guild_quest_desc_prayer">Seppellisci %1$d ossa per la %2$s.</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -969,6 +969,7 @@
     <string name="guild_no_dailies">デイリー依頼を解放するには、ギルドクエストを完了してください。</string>
     <string name="guild_dailies_all_done">All of today\'s daily requests are complete. Come back after the daily reset.</string> <!-- untranslated -->
     <string name="guild_contribute_inventory">インベントリから納品（所持数: %1$d）</string>
+    <string name="guild_go_to_skill">Go to Skill</string> <!-- untranslated -->
     <string name="guild_quest_desc_gather">%4$sのために%3$sを%2$d個%1$sする。</string>
     <string name="guild_quest_desc_kill">%2$s戦闘を使用して敵を%1$d体倒す。</string>
     <string name="guild_quest_desc_prayer">%2$sのために骨を%1$d個埋葬する。</string>

--- a/app/src/main/res/values-lt/strings.xml
+++ b/app/src/main/res/values-lt/strings.xml
@@ -969,6 +969,7 @@
     <string name="guild_no_dailies">Complete guild quests to unlock daily requests.</string> <!-- untranslated -->
     <string name="guild_dailies_all_done">All of today\'s daily requests are complete. Come back after the daily reset.</string> <!-- untranslated -->
     <string name="guild_contribute_inventory">Contribute from inventory (%1$d available)</string> <!-- untranslated -->
+    <string name="guild_go_to_skill">Go to Skill</string> <!-- untranslated -->
     <string name="guild_quest_desc_gather">%1$s %2$d %3$s for the %4$s.</string> <!-- untranslated -->
     <string name="guild_quest_desc_kill">Defeat %1$d enemies using %2$s combat.</string> <!-- untranslated -->
     <string name="guild_quest_desc_prayer">Bury %1$d bones for the %2$s.</string> <!-- untranslated -->

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -969,6 +969,7 @@
     <string name="guild_no_dailies">Voltooi gildequests om dagelijkse Quests te ontgrendelen.</string>
     <string name="guild_dailies_all_done">All of today\'s daily requests are complete. Come back after the daily reset.</string> <!-- untranslated -->
     <string name="guild_contribute_inventory">Bijdragen vanuit inventaris (%1$d beschikbaar)</string>
+    <string name="guild_go_to_skill">Go to Skill</string> <!-- untranslated -->
     <string name="guild_quest_desc_gather">%1$s %2$d %3$s voor het %4$s.</string>
     <string name="guild_quest_desc_kill">Versla %1$d vijanden met %2$s gevecht.</string>
     <string name="guild_quest_desc_prayer">Begraaf %1$d botten voor het %2$s.</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -985,6 +985,7 @@
     <string name="guild_no_dailies">Ukończ zadania gildii, by odblokować codzienne prośby.</string>
     <string name="guild_dailies_all_done">Wszystkie dzisiejsze codzienne prośby zostały wykonane. Wróć po codziennym resetowaniu.</string>
     <string name="guild_contribute_inventory">Wnieś z ekwipunku (dostępnych: %1$d)</string>
+    <string name="guild_go_to_skill">Go to Skill</string> <!-- untranslated -->
     <string name="guild_quest_desc_gather">%1$s %2$d %3$s dla %4$s.</string>
     <string name="guild_quest_desc_kill">Pokonaj %1$d wrogów, używając walki %2$s.</string>
     <string name="guild_quest_desc_prayer">Zakop %1$d kości dla %2$s.</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -969,6 +969,7 @@
     <string name="guild_no_dailies">Complete missões da guilda para desbloquear pedidos diários.</string>
     <string name="guild_dailies_all_done">All of today\'s daily requests are complete. Come back after the daily reset.</string> <!-- untranslated -->
     <string name="guild_contribute_inventory">Contribuir do inventário (%1$d disponível)</string>
+    <string name="guild_go_to_skill">Go to Skill</string> <!-- untranslated -->
     <string name="guild_quest_desc_gather">%1$s %2$d %3$s para a %4$s.</string>
     <string name="guild_quest_desc_kill">Derrote %1$d inimigos usando combate %2$s.</string>
     <string name="guild_quest_desc_prayer">Enterre %1$d ossos para a %2$s.</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -987,6 +987,7 @@
     <string name="guild_no_dailies">Завершайте задания гильдии, чтобы открывать ежедневные поручения.</string>
     <string name="guild_dailies_all_done">Все ежедневные поручения на сегодняшний день выполнены. Завтра они снова обновятся.</string>
     <string name="guild_contribute_inventory">Передать из инвентаря (%1$d доступно)</string>
+    <string name="guild_go_to_skill">Go to Skill</string> <!-- untranslated -->
     <string name="guild_quest_desc_gather">%1$s %2$d %3$s для %4$s.</string>
     <string name="guild_quest_desc_kill">Победить %1$d врагов в ближнем бою (%2$s).</string>
     <string name="guild_quest_desc_prayer">Захоронить %1$d костей для %2$s.</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -969,6 +969,7 @@
     <string name="guild_no_dailies">Günlük isteklerin kilidini açmak için lonca görevlerini tamamlayın.</string>
     <string name="guild_dailies_all_done">All of today\'s daily requests are complete. Come back after the daily reset.</string> <!-- untranslated -->
     <string name="guild_contribute_inventory">Envanterden katkıda bulun (%1$d mevcut)</string>
+    <string name="guild_go_to_skill">Go to Skill</string> <!-- untranslated -->
     <string name="guild_quest_desc_gather">%4$s için %2$d %3$s %1$s.</string>
     <string name="guild_quest_desc_kill">%2$s dövüşünde %1$d düşmanı yenin.</string>
     <string name="guild_quest_desc_prayer">%2$s için %1$d kemik gömün.</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -969,6 +969,7 @@
     <string name="guild_no_dailies">完成公会任务以解锁每日请求。</string>
     <string name="guild_dailies_all_done">今天的所有日常任务都完成了。日常重置后再来吧。</string>
     <string name="guild_contribute_inventory">从背包捐献（可用 %1$d）</string>
+    <string name="guild_go_to_skill">Go to Skill</string> <!-- untranslated -->
     <string name="guild_quest_desc_gather">为 %4$s %1$s %2$d 个 %3$s。</string>
     <string name="guild_quest_desc_kill">使用 %2$s 战斗击败 %1$d 个敌人。</string>
     <string name="guild_quest_desc_prayer">为 %2$s 掩埋 %1$d 根骸骨。</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -969,6 +969,7 @@
     <string name="guild_no_dailies">Complete guild quests to unlock daily requests.</string>
     <string name="guild_dailies_all_done">All of today\'s daily requests are complete. Come back after the daily reset.</string>
     <string name="guild_contribute_inventory">Contribute from inventory (%1$d available)</string>
+    <string name="guild_go_to_skill">Go to Skill</string>
     <string name="guild_quest_desc_gather">%1$s %2$d %3$s for the %4$s.</string>
     <string name="guild_quest_desc_kill">Defeat %1$d enemies using %2$s combat.</string>
     <string name="guild_quest_desc_prayer">Bury %1$d bones for the %2$s.</string>


### PR DESCRIPTION
❗Raised and closed this PR to see if stacked PRs are possible as stated by @CiaranGruber. But unfortunately, I do not have collaborator access to this repo.

## Before submitting

- [ ] I've tested any changes with the appropriate tests (eg. Unit tests, validation scripts)
- [ ] I've pulled and merged the latest changes from the repository

## Summary

Stacked on #1700 (which is stacked on #1699) — fixes the remaining guilds' "Go to Skill" navigation and removes the guild allowlist now that every guild works.

## Related issue(s) or discussion(s)

Depends on #1700 and #1699 — please review/merge those first. This PR's diff includes their commits until they merge.

## Changelog

- Fixed guild sheets opening at level 1 by waiting for player data to load before building the sheet
- Enabled "Go to Skill" for Firemaking, Runecrafting, Mining, Fishing, Woodcutting, Agility, and Thieving
- Removed the guild allowlist — the button now always shows, since every guild navigates correctly

## Anything else?

Draft — third of a stack (crafting → combat → gathering); blocked on #1700 and #1699 merging first.

