### PR TITLE
New: Remove quest dot feature as superceded by quest indicators

### DIFF
--- a/app/src/main/kotlin/com/fantasyidler/data/model/PlayerModels.kt
+++ b/app/src/main/kotlin/com/fantasyidler/data/model/PlayerModels.kt
@@ -175,8 +175,6 @@ data class PlayerFlags(
     @SerialName("profile_layout") val profileLayout: String = "rail",
     /** Whether session/queue countdowns append the predicted wall-clock completion time. */
     @SerialName("show_session_end_time") val showSessionEndTime: Boolean = true,
-    /** Gold quest dots on the Skills tab icons; some players prefer them off (discussion #1386). */
-    @SerialName("show_quest_dots") val showQuestDots: Boolean = true,
     /** Whether to abbreviate large item quantities/numbers (e.g. 2.46M vs 2,461,940). */
     @SerialName("compact_numbers") val compactNumbers: Boolean = false,
     /** Nav bar badge dots for combat/skill prestige availability. */

--- a/app/src/main/kotlin/com/fantasyidler/repository/PlayerRepository.kt
+++ b/app/src/main/kotlin/com/fantasyidler/repository/PlayerRepository.kt
@@ -1786,7 +1786,6 @@ class PlayerRepository @Inject constructor(
             compactNumbers            = carrySettingsFrom.compactNumbers,
             profileLayout             = carrySettingsFrom.profileLayout,
             showSessionEndTime        = carrySettingsFrom.showSessionEndTime,
-            showQuestDots             = carrySettingsFrom.showQuestDots,
             showPrestigeNotifications = carrySettingsFrom.showPrestigeNotifications,
             showRecentActivityLog     = carrySettingsFrom.showRecentActivityLog,
             showJournalButton         = carrySettingsFrom.showJournalButton,

--- a/app/src/main/kotlin/com/fantasyidler/ui/screen/SettingsScreen.kt
+++ b/app/src/main/kotlin/com/fantasyidler/ui/screen/SettingsScreen.kt
@@ -314,17 +314,6 @@ fun SettingsScreen(
                 subtitle = stringResource(R.string.settings_home_screen_desc),
                 onClick  = onNavigateToHomeScreenSettings,
             )
-            val showQuestDots by viewModel.showQuestDots.collectAsState()
-            SettingsRow(
-                title    = stringResource(R.string.settings_quest_dots),
-                subtitle = stringResource(R.string.settings_quest_dots_desc),
-                trailing = {
-                    Switch(
-                        checked         = showQuestDots,
-                        onCheckedChange = { viewModel.setShowQuestDots(it) },
-                    )
-                }
-            )
             val showPrestigeNotifications by viewModel.showPrestigeNotifications.collectAsState()
             SettingsRow(
                 title    = stringResource(R.string.settings_prestige_notifications),

--- a/app/src/main/kotlin/com/fantasyidler/ui/screen/SkillsScreen.kt
+++ b/app/src/main/kotlin/com/fantasyidler/ui/screen/SkillsScreen.kt
@@ -147,10 +147,6 @@ fun SkillsScreen(
                     ).forEach { (emoji, labelRes) ->
                         Text("$emoji  ${stringResource(labelRes)}")
                     }
-                    Row(verticalAlignment = Alignment.CenterVertically) {
-                        Text("●  ", color = MaterialTheme.colorScheme.primary)
-                        Text(stringResource(R.string.quest_legend_gold_dot))
-                    }
                     Spacer(Modifier.height(4.dp))
                     Text(
                         text  = stringResource(R.string.quest_legend_notes),
@@ -713,7 +709,6 @@ private fun SkillsTabContent(
                 prestigeLevel  = state.skillPrestige[key] ?: 0,
                 onOpenPrestige = { onNavigateToPrestige(key) },
                 cropsReady     = if (key == Skills.FARMING) state.cropsReadyCount else 0,
-                guildDailyOpen = state.showQuestDots && state.sheetQuests[key]?.any { !it.claimed && !(it.source == SheetQuestSource.GUILD && it.guildMaxed) } == true,
                 questIndicators = state.timedQuestsBySkill[key] ?: emptyList(),
             )
         }
@@ -736,7 +731,6 @@ private fun SkillsTabContent(
                 petBoostPct    = state.petBoostBySkill[key] ?: 0,
                 prestigeLevel  = state.skillPrestige[key] ?: 0,
                 onOpenPrestige = { onNavigateToPrestige(key) },
-                guildDailyOpen = state.showQuestDots && state.sheetQuests[key]?.any { !it.claimed && !(it.source == SheetQuestSource.GUILD && it.guildMaxed) } == true,
                 questIndicators = state.timedQuestsBySkill[key] ?: emptyList(),
             )
         }
@@ -753,7 +747,6 @@ private fun SkillsTabContent(
                 petBoostPct    = state.petBoostBySkill[key] ?: 0,
                 prestigeLevel  = state.skillPrestige[key] ?: 0,
                 onOpenPrestige = { onNavigateToPrestige(key) },
-                guildDailyOpen = state.showQuestDots && state.sheetQuests[key]?.any { !it.claimed && !(it.source == SheetQuestSource.GUILD && it.guildMaxed) } == true,
                 questIndicators = state.timedQuestsBySkill[key] ?: emptyList(),
             )
         }
@@ -769,7 +762,6 @@ private fun SkillsTabContent(
                 petBoostPct   = state.petBoostBySkill[Skills.SLAYER] ?: 0,
                 prestigeLevel = state.skillPrestige[Skills.SLAYER] ?: 0,
                 onOpenPrestige = { onNavigateToPrestige(Skills.SLAYER) },
-                guildDailyOpen = state.showQuestDots && state.sheetQuests[Skills.SLAYER]?.any { !it.claimed && !(it.source == SheetQuestSource.GUILD && it.guildMaxed) } == true,
                 questIndicators = state.timedQuestsBySkill[Skills.SLAYER] ?: emptyList(),
             )
         }
@@ -891,8 +883,6 @@ internal fun SkillRow(
     prestigeLevel: Int = 0,
     onOpenPrestige: (() -> Unit)? = null,
     cropsReady: Int = 0,
-    /** Shows a gold dot when this skill's guild daily is still open and worth doing (guild not maxed). */
-    guildDailyOpen: Boolean = false,
     /** Timed quest indicators (daily/weekly/guild daily) shown next to the skill name. */
     questIndicators: List<QuestIndicator> = emptyList(),
 ) {
@@ -950,12 +940,6 @@ internal fun SkillRow(
                 )
                 if (cropsReady > 0) {
                     Badge(modifier = Modifier.align(Alignment.TopEnd))
-                }
-                if (guildDailyOpen) {
-                    Badge(
-                        containerColor = MaterialTheme.colorScheme.primary,
-                        modifier       = Modifier.align(Alignment.TopStart),
-                    )
                 }
             }
 

--- a/app/src/main/kotlin/com/fantasyidler/ui/viewmodel/SettingsViewModel.kt
+++ b/app/src/main/kotlin/com/fantasyidler/ui/viewmodel/SettingsViewModel.kt
@@ -124,14 +124,6 @@ class SettingsViewModel @Inject constructor(
         }
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), true)
 
-    val showQuestDots: StateFlow<Boolean> = playerRepo.playerFlow
-        .map { player ->
-            if (player == null) return@map true
-            try { json.decodeFromString<PlayerFlags>(player.flags).showQuestDots }
-            catch (_: Exception) { true }
-        }
-        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), true)
-
     val compactNumbers: StateFlow<Boolean> = playerRepo.playerFlow
         .map { player ->
             if (player == null) return@map false
@@ -223,13 +215,6 @@ class SettingsViewModel @Inject constructor(
         viewModelScope.launch {
             val flags = playerRepo.getFlags()
             playerRepo.updateFlags(flags.copy(showRecentActivityLog = enabled))
-        }
-    }
-
-    fun setShowQuestDots(enabled: Boolean) {
-        viewModelScope.launch {
-            val flags = playerRepo.getFlags()
-            playerRepo.updateFlags(flags.copy(showQuestDots = enabled))
         }
     }
 

--- a/app/src/main/kotlin/com/fantasyidler/ui/viewmodel/SkillsViewModel.kt
+++ b/app/src/main/kotlin/com/fantasyidler/ui/viewmodel/SkillsViewModel.kt
@@ -107,7 +107,6 @@ data class SkillsUiState(
     /** Timed (daily/weekly/guild daily) quest indicators per skill, for the overview rows. */
     val timedQuestsBySkill: Map<String, List<QuestIndicator>> = emptyMap(),
     val showSessionEndTime: Boolean = true,
-    val showQuestDots: Boolean = true,
     /** Guild dailies plus daily/weekly quests for each sheet skill, keyed by skill (guild keys match skill keys). */
     val sheetQuests: Map<String, List<SheetQuestSummary>> = emptyMap(),
     val seasonalEventEmoji: String? = null,
@@ -259,7 +258,6 @@ class SkillsViewModel @Inject constructor(
                     }
                     .filterValues { it.isNotEmpty() },
                 showSessionEndTime    = flags.showSessionEndTime,
-                showQuestDots         = flags.showQuestDots,
                 sheetQuests           = computeSheetQuests(questProgress, flags, levels, inv),
                 seasonalEventEmoji    = seasonalEmoji,
             )
@@ -1404,6 +1402,8 @@ class SkillsViewModel @Inject constructor(
                         addIndicator("coins", questSkill, category, remaining, questId)
                     }
                 }
+                "slayer_task" -> addIndicator("task", Skills.SLAYER, category, remaining, questId)
+                "slayer_kill" -> addIndicator("kill", Skills.SLAYER, category, remaining, questId)
             }
         }
 
@@ -1451,6 +1451,8 @@ class SkillsViewModel @Inject constructor(
                 "gather", "craft" -> {
                     addIndicator(task.target, skill, QuestCategory.SEASONAL, remaining, task.id, eventEmoji)
                 }
+                "slayer_task" -> addIndicator("task", Skills.SLAYER, QuestCategory.SEASONAL, remaining, task.id, eventEmoji)
+                "slayer_kill" -> addIndicator("kill", Skills.SLAYER, QuestCategory.SEASONAL, remaining, task.id, eventEmoji)
                 "turn_in" -> {
                     val isCompletable = (inventory[task.target] ?: 0) >= task.amount
                     result.getOrPut("$skill:${task.target}") { mutableListOf() }

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -725,7 +725,6 @@
     <string name="quest_legend_guild_daily">Guild daily</string> <!-- untranslated -->
     <string name="quest_legend_guild">Guild quest</string> <!-- untranslated -->
     <string name="quest_legend_quest">Quest</string> <!-- untranslated -->
-    <string name="quest_legend_gold_dot">Timed quest is available.</string> <!-- untranslated -->
     <string name="quest_legend_notes">Dimmed icons can\'t be completed yet (missing level or materials). A small raised number means several quests of that type want the same thing.</string> <!-- untranslated -->
     <!-- Translator note: %1$s = quantity in inventory -->
     <string name="shop_qty_in_inv">×%1$s in inventory</string> <!-- untranslated -->

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -725,7 +725,6 @@
     <string name="quest_legend_guild_daily">Guild daily</string> <!-- untranslated -->
     <string name="quest_legend_guild">Guild quest</string> <!-- untranslated -->
     <string name="quest_legend_quest">Quest</string> <!-- untranslated -->
-    <string name="quest_legend_gold_dot">Timed quest is available.</string> <!-- untranslated -->
     <string name="quest_legend_notes">Dimmed icons can\'t be completed yet (missing level or materials). A small raised number means several quests of that type want the same thing.</string> <!-- untranslated -->
     <!-- Translator note: %1$s = quantity in inventory -->
     <string name="shop_qty_in_inv">×%1$s in inventory</string> <!-- untranslated -->

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -737,7 +737,6 @@
     <string name="quest_legend_guild_daily">Guild daily</string> <!-- untranslated -->
     <string name="quest_legend_guild">Guild quest</string> <!-- untranslated -->
     <string name="quest_legend_quest">Quest</string> <!-- untranslated -->
-    <string name="quest_legend_gold_dot">Timed quest is available.</string> <!-- untranslated -->
     <string name="quest_legend_notes">Dimmed icons can\'t be completed yet (missing level or materials). A small raised number means several quests of that type want the same thing.</string> <!-- untranslated -->
     <!-- Translator note: %1$s = quantity in inventory -->
     <string name="shop_qty_in_inv">×%1$s in inventory</string> <!-- untranslated -->

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -725,7 +725,6 @@
     <string name="quest_legend_guild_daily">Gilden-Tagesquest</string>
     <string name="quest_legend_guild">Gildenquest</string>
     <string name="quest_legend_quest">Aufgabe</string>
-    <string name="quest_legend_gold_dot">Aufgabe mit Zeitbegrenzung ist verfügbar.</string>
     <string name="quest_legend_notes">Abgeblendete Symbole können noch nicht abgeschlossen werden (Level oder Materialien fehlen). Eine kleine hochgestellte Zahl bedeutet, dass mehrere Quests dieses Typs dasselbe Ziel haben.</string>
     <!-- Translator note: %1$s = quantity in inventory -->
     <string name="shop_qty_in_inv">×%1$s im Inventar</string>

--- a/app/src/main/res/values-es-rES/strings.xml
+++ b/app/src/main/res/values-es-rES/strings.xml
@@ -725,7 +725,6 @@
     <string name="quest_legend_guild_daily">Guild daily</string> <!-- untranslated -->
     <string name="quest_legend_guild">Guild quest</string> <!-- untranslated -->
     <string name="quest_legend_quest">Quest</string> <!-- untranslated -->
-    <string name="quest_legend_gold_dot">Timed quest is available.</string> <!-- untranslated -->
     <string name="quest_legend_notes">Dimmed icons can\'t be completed yet (missing level or materials). A small raised number means several quests of that type want the same thing.</string> <!-- untranslated -->
     <!-- Translator note: %1$s = quantity in inventory -->
     <string name="shop_qty_in_inv">×%1$s en inventario</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -725,7 +725,6 @@
     <string name="quest_legend_guild_daily">Diaria del gremio</string>
     <string name="quest_legend_guild">Misión del gremio</string>
     <string name="quest_legend_quest">Misión</string>
-    <string name="quest_legend_gold_dot">Timed quest is available.</string> <!-- untranslated -->
     <string name="quest_legend_notes">Los iconos atenuados aún no se pueden completar (falta nivel o materiales). Un pequeño número elevado indica que varias misiones de ese tipo piden lo mismo.</string>
     <!-- Translator note: %1$s = quantity in inventory -->
     <string name="shop_qty_in_inv">×%1$s en inventario</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -726,7 +726,6 @@
     <string name="quest_legend_guild_daily">Quotidienne de guilde</string>
     <string name="quest_legend_guild">Quête de guilde</string>
     <string name="quest_legend_quest">Quête</string>
-    <string name="quest_legend_gold_dot">Une quête temporaire est disponible.</string>
     <string name="quest_legend_notes">Les icônes estompées ne peuvent pas encore être terminées (niveau ou matériaux manquants). Un petit chiffre en exposant indique que plusieurs quêtes de ce type visent la même chose.</string>
     <!-- Translator note: %1$s = quantity in inventory -->
     <string name="shop_qty_in_inv">×%1$s dans l\'inventaire</string>

--- a/app/src/main/res/values-ga/strings.xml
+++ b/app/src/main/res/values-ga/strings.xml
@@ -753,7 +753,6 @@
     <string name="quest_legend_guild_daily">Guild daily</string> <!-- untranslated -->
     <string name="quest_legend_guild">Guild quest</string> <!-- untranslated -->
     <string name="quest_legend_quest">Quest</string> <!-- untranslated -->
-    <string name="quest_legend_gold_dot">Timed quest is available.</string> <!-- untranslated -->
     <string name="quest_legend_notes">Dimmed icons can\'t be completed yet (missing level or materials). A small raised number means several quests of that type want the same thing.</string> <!-- untranslated -->
     <!-- Translator note: %1$s = quantity in inventory -->
     <string name="shop_qty_in_inv">×%1$s in inventory</string> <!-- untranslated -->

--- a/app/src/main/res/values-he/strings.xml
+++ b/app/src/main/res/values-he/strings.xml
@@ -725,7 +725,6 @@
     <string name="quest_legend_guild_daily">Guild daily</string> <!-- untranslated -->
     <string name="quest_legend_guild">Guild quest</string> <!-- untranslated -->
     <string name="quest_legend_quest">Quest</string> <!-- untranslated -->
-    <string name="quest_legend_gold_dot">Timed quest is available.</string> <!-- untranslated -->
     <string name="quest_legend_notes">Dimmed icons can\'t be completed yet (missing level or materials). A small raised number means several quests of that type want the same thing.</string> <!-- untranslated -->
     <!-- Translator note: %1$s = quantity in inventory -->
     <string name="shop_qty_in_inv">×%1$s in inventory</string> <!-- untranslated -->

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -717,7 +717,6 @@
     <string name="quest_legend_guild_daily">Harian guild</string>
     <string name="quest_legend_guild">Quest guild</string>
     <string name="quest_legend_quest">Quest</string> <!-- untranslated -->
-    <string name="quest_legend_gold_dot">Timed quest is available.</string> <!-- untranslated -->
     <string name="quest_legend_notes">Ikon redup belum bisa diselesaikan (level atau bahan kurang). Angka kecil di atas berarti beberapa quest jenis itu menginginkan hal yang sama.</string>
     <!-- Translator note: %1$s = quantity in inventory -->
     <string name="shop_qty_in_inv">×%1$s di inventaris</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -725,7 +725,6 @@
     <string name="quest_legend_guild_daily">Giornaliera di gilda</string>
     <string name="quest_legend_guild">Missione di gilda</string>
     <string name="quest_legend_quest">Missione</string>
-    <string name="quest_legend_gold_dot">Una missione a tempo è disponibile.</string>
     <string name="quest_legend_notes">Le missioni con icone attenuate non possono ancora essere completate (livello o materiali mancanti). Un numerino in apice indica che più missioni richiedono la stessa azione.</string>
     <!-- Translator note: %1$s = quantity in inventory -->
     <string name="shop_qty_in_inv">Hai ×%1$s</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -725,7 +725,6 @@
     <string name="quest_legend_guild_daily">ギルドデイリー</string>
     <string name="quest_legend_guild">ギルドクエスト</string>
     <string name="quest_legend_quest">クエスト</string>
-    <string name="quest_legend_gold_dot">Timed quest is available.</string> <!-- untranslated -->
     <string name="quest_legend_notes">薄いアイコンはまだ達成できません（レベルや素材が不足）。小さな上付き数字は、同じ対象を求めるクエストがその種類に複数あることを示します。</string>
     <!-- Translator note: %1$s = quantity in inventory -->
     <string name="shop_qty_in_inv">インベントリ所持数: ×%1$s</string>

--- a/app/src/main/res/values-lt/strings.xml
+++ b/app/src/main/res/values-lt/strings.xml
@@ -725,7 +725,6 @@
     <string name="quest_legend_guild_daily">Guild daily</string> <!-- untranslated -->
     <string name="quest_legend_guild">Guild quest</string> <!-- untranslated -->
     <string name="quest_legend_quest">Quest</string> <!-- untranslated -->
-    <string name="quest_legend_gold_dot">Timed quest is available.</string> <!-- untranslated -->
     <string name="quest_legend_notes">Dimmed icons can\'t be completed yet (missing level or materials). A small raised number means several quests of that type want the same thing.</string> <!-- untranslated -->
     <!-- Translator note: %1$s = quantity in inventory -->
     <string name="shop_qty_in_inv">×%1$s in inventory</string> <!-- untranslated -->

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -725,7 +725,6 @@
     <string name="quest_legend_guild_daily">Dagelijkse gildequest</string>
     <string name="quest_legend_guild">Gildequest</string>
     <string name="quest_legend_quest">Quest</string> <!-- untranslated -->
-    <string name="quest_legend_gold_dot">Timed quest is available.</string> <!-- untranslated -->
     <string name="quest_legend_notes">Gedimde pictogrammen kunnen nog niet voltooid worden (level of materialen ontbreken). Een klein verhoogd cijfer betekent dat meerdere quests van dat type hetzelfde willen.</string>
     <!-- Translator note: %1$s = quantity in inventory -->
     <string name="shop_qty_in_inv">×%1$s in inventaris</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -741,7 +741,6 @@
     <string name="quest_legend_guild_daily">Dzienne gildii</string>
     <string name="quest_legend_guild">Zadanie gildii</string>
     <string name="quest_legend_quest">Zadanie</string>
-    <string name="quest_legend_gold_dot">Dostępne jest zadanie na czas.</string>
     <string name="quest_legend_notes">Przyciemnione ikony nie mogą być jeszcze ukończone (brak poziomu lub materiałów). Mała podniesiona cyfra oznacza, że kilka zadań tego typu dotyczy tego samego.</string>
     <!-- Translator note: %1$s = quantity in inventory -->
     <string name="shop_qty_in_inv">×%1$s w ekwipunku</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -725,7 +725,6 @@
     <string name="quest_legend_guild_daily">Diária da guilda</string>
     <string name="quest_legend_guild">Missão da guilda</string>
     <string name="quest_legend_quest">Missão</string>
-    <string name="quest_legend_gold_dot">Timed quest is available.</string> <!-- untranslated -->
     <string name="quest_legend_notes">Ícones esmaecidos ainda não podem ser concluídos (falta nível ou materiais). Um pequeno número elevado indica que várias missões desse tipo pedem a mesma coisa.</string>
     <!-- Translator note: %1$s = quantity in inventory -->
     <string name="shop_qty_in_inv">×%1$s no inventário</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -743,7 +743,6 @@
     <string name="quest_legend_guild_daily">Ежедневное задание гильдии</string>
     <string name="quest_legend_guild">Задание гильдии</string>
     <string name="quest_legend_quest">Задание</string>
-    <string name="quest_legend_gold_dot">Доступно временное задание.</string>
     <string name="quest_legend_notes">Тусклые значки пока нельзя выполнить (не хватает уровня или материалов). Маленькая надстрочная цифра означает, что несколько заданий этого типа требуют одного и того же.</string>
     <!-- Translator note: %1$s = quantity in inventory -->
     <string name="shop_qty_in_inv">×%1$s в инвентаре</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -725,7 +725,6 @@
     <string name="quest_legend_guild_daily">Lonca günlük görevi</string>
     <string name="quest_legend_guild">Lonca görevi</string>
     <string name="quest_legend_quest">Görev</string>
-    <string name="quest_legend_gold_dot">Timed quest is available.</string> <!-- untranslated -->
     <string name="quest_legend_notes">Soluk simgeler henüz tamamlanamaz (seviye veya malzeme eksik). Küçük üst simge sayı, aynı hedefi isteyen birden fazla görev olduğunu gösterir.</string>
     <!-- Translator note: %1$s = quantity in inventory -->
     <string name="shop_qty_in_inv">Envanterde ×%1$s adet</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -725,7 +725,6 @@
     <string name="quest_legend_guild_daily">公会每日</string>
     <string name="quest_legend_guild">公会任务</string>
     <string name="quest_legend_quest">任务</string>
-    <string name="quest_legend_gold_dot">有定时任务可接。</string>
     <string name="quest_legend_notes">灰色图标暂不可完成（缺少等级或材料）。小数字表示多个同类任务需要相同物品。</string>
     <!-- Translator note: %1$s = quantity in inventory -->
     <string name="shop_qty_in_inv">背包×%1$s</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -725,7 +725,6 @@
     <string name="quest_legend_guild_daily">Guild daily</string>
     <string name="quest_legend_guild">Guild quest</string>
     <string name="quest_legend_quest">Quest</string>
-    <string name="quest_legend_gold_dot">Timed quest is available.</string>
     <string name="quest_legend_notes">Dimmed icons can\'t be completed yet (missing level or materials). A small raised number means several quests of that type want the same thing.</string>
     <!-- Translator note: %1$s = quantity in inventory -->
     <string name="shop_qty_in_inv">×%1$s in inventory</string>


### PR DESCRIPTION
## Before submitting

- [x] I've tested any changes with the appropriate tests (eg. Unit tests, validation scripts)
- [x] I've pulled and merged the latest changes from the repository

## Summary

<!-- Short summary of the pull request and what it changes -->

Providews an implementation of a suggestion which removes the quest indicator dot as this has been effectively superceded by the quest indicator icons which shows all daily/guild quests. This relates to to the suggested changes in the referenced issues/discussions. Can be closed if not desired

## Related issue(s) or discussion(s)

<!-- Prepend issues with "Fixes" if this should close the issue, e.g. Fixes #283, Relates to #284 -->

Relates to closed issue #1703, Closes #1705 (discussion)

## Changelog

<!-- Concise list of changes, e.g.
- Fix time-slot bug causing XP gains to not show in notification banner
- Added ellipsis for quests XP gains exceeding screen width
-->

- Remove the quest indicator dot and related settings/info
- Add missing guild daily indicators to the slayer task

## Anything else?

The quest indicator dots that were removed:
<img width="235" height="108" alt="image" src="https://github.com/user-attachments/assets/1c263b03-459f-4a6d-aec0-17e09f88ea9c" />

Guild daily icons added:
<img width="445" height="113" alt="image" src="https://github.com/user-attachments/assets/c76a3c98-ab64-49b1-89cc-84c99f287b6d" />
