### PR TITLE
Remove non-destructive confirmation dialogs

### DIFF
--- a/app/src/main/kotlin/com/fantasyidler/ui/screen/ChurchScreen.kt
+++ b/app/src/main/kotlin/com/fantasyidler/ui/screen/ChurchScreen.kt
@@ -1,6 +1,5 @@
 package com.fantasyidler.ui.screen
 
-import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
@@ -32,10 +31,8 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
@@ -60,54 +57,6 @@ fun ChurchScreen(
     val state by viewModel.uiState.collectAsState()
 
     AppBannerEffect(state.snackbarMessage, viewModel::snackbarConsumed)
-
-    // Confirmation dialog
-    state.pendingBlessingKey?.let { key ->
-        val blessing = ChurchRepository.ALL_BLESSINGS.find { it.key == key }
-        if (blessing != null) {
-            val context   = LocalContext.current
-            val nameResId = context.resources.getIdentifier(
-                "blessing_${blessing.key}_name", "string", context.packageName,
-            )
-            val name      = if (nameResId != 0) stringResource(nameResId) else blessing.key
-            val cost      = ChurchRepository.discountedBoneCost(blessing, state.blessingCostMult)
-            val hasEnough = state.totalBoneEquivalent >= cost
-            AlertDialog(
-                onDismissRequest = viewModel::dismissConfirm,
-                title = { Text(stringResource(R.string.church_confirm_title), fontWeight = FontWeight.Bold) },
-                text = {
-                    Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
-                        Text(text = name, style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.Bold)
-                        Text(
-                            text = blessingEffectText(blessing, state.blessingDuration, state.prayerCapeMult),
-                            style = MaterialTheme.typography.bodyMedium
-                        )
-                        Spacer(Modifier.height(4.dp))
-                        Text(
-                            text  = stringResource(R.string.church_cost_bones, cost),
-                            style = MaterialTheme.typography.bodyMedium,
-                        )
-                        Text(
-                            text  = stringResource(R.string.church_bones_available, state.totalBoneCount, state.totalBoneEquivalent),
-                            style = MaterialTheme.typography.bodySmall,
-                            color = if (hasEnough) MaterialTheme.colorScheme.onSurfaceVariant
-                                    else MaterialTheme.colorScheme.error,
-                        )
-                    }
-                },
-                confirmButton = {
-                    Button(onClick = viewModel::confirmActivate, enabled = hasEnough) {
-                        Text(stringResource(R.string.church_activate))
-                    }
-                },
-                dismissButton = {
-                    OutlinedButton(onClick = viewModel::dismissConfirm) {
-                        Text(stringResource(R.string.btn_cancel))
-                    }
-                },
-            )
-        }
-    }
 
     if (state.showDeactivateConfirm) {
         AlertDialog(

--- a/app/src/main/kotlin/com/fantasyidler/ui/screen/skills/AgilitySheet.kt
+++ b/app/src/main/kotlin/com/fantasyidler/ui/screen/skills/AgilitySheet.kt
@@ -1,111 +1,24 @@
 package com.fantasyidler.ui.screen
 
 
-import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.items
-import androidx.compose.foundation.horizontalScroll
-import androidx.compose.foundation.pager.HorizontalPager
-import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
-import androidx.compose.foundation.shape.CircleShape
-import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material3.AlertDialog
-import androidx.compose.material3.Badge
-import androidx.compose.material3.BottomSheetDefaults
-import androidx.compose.material3.Tab
-import androidx.compose.material3.TabRow
-import androidx.compose.material3.Button
-import androidx.compose.material3.FilterChip
-import androidx.compose.material3.CircularProgressIndicator
-import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
-import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.ModalBottomSheet
-import androidx.compose.material3.Scaffold
-import androidx.compose.material3.SnackbarHost
-import androidx.compose.material3.SnackbarHostState
-import androidx.compose.material3.Surface
-import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
-import androidx.compose.material3.TextButton
-import androidx.compose.material3.TopAppBar
-import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.collectAsState
-import androidx.compose.runtime.getValue
-import androidx.compose.foundation.text.KeyboardActions
-import androidx.compose.foundation.text.KeyboardOptions
-import androidx.compose.material3.OutlinedTextField
-import androidx.compose.runtime.mutableLongStateOf
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberCoroutineScope
-import androidx.compose.runtime.setValue
-import kotlinx.coroutines.launch
-import androidx.compose.ui.text.input.ImeAction
-import androidx.compose.ui.text.input.KeyboardType
-import kotlinx.coroutines.delay
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
-import androidx.hilt.navigation.compose.hiltViewModel
-import com.fantasyidler.BuildConfig
 import com.fantasyidler.R
-import com.fantasyidler.ui.viewmodel.ExpeditionsViewModel
 import com.fantasyidler.data.json.AgilityCourseData
-import com.fantasyidler.data.json.BoneData
-import com.fantasyidler.data.json.FishData
-import com.fantasyidler.data.json.LogData
-import com.fantasyidler.data.json.OreData
-import com.fantasyidler.data.json.ThievingNpcData
-import com.fantasyidler.data.json.TreeData
 import com.fantasyidler.data.model.Skills
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Add
-import androidx.compose.material.icons.filled.Remove
-import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
-import androidx.compose.ui.text.style.TextAlign
-import com.fantasyidler.ui.viewmodel.CraftableRecipe
-import com.fantasyidler.ui.viewmodel.CraftingUiState
-import com.fantasyidler.ui.viewmodel.CraftingViewModel
-import com.fantasyidler.ui.viewmodel.SheetState
-import com.fantasyidler.ui.viewmodel.levelDisplay
-import com.fantasyidler.ui.viewmodel.SkillsUiState
-import com.fantasyidler.ui.viewmodel.SkillsViewModel
-import com.fantasyidler.ui.viewmodel.xpProgressFraction
-import com.fantasyidler.ui.viewmodel.nextLevelThreshold
-import com.fantasyidler.ui.viewmodel.xpToNextLevel
 import com.fantasyidler.simulator.SkillSimulator
 import com.fantasyidler.simulator.XpTable
 import com.fantasyidler.util.GameStrings
-import com.fantasyidler.util.toTitleCase
-import com.fantasyidler.util.formatDurationMs
-import com.fantasyidler.util.formatXp
-import com.fantasyidler.util.toCountdown
-import java.util.Locale
-import com.fantasyidler.ui.viewmodel.QuestFillSuggestion
 import com.fantasyidler.ui.viewmodel.QuestIndicator
 
 
@@ -125,7 +38,6 @@ internal fun AgilitySheet(
     onSelect: (String) -> Unit,
 ) {
     val context = LocalContext.current
-    var selectedKey by remember { mutableStateOf<String?>(null) }
     val scrollState = rememberScrollState()
     val currentAgilityLevel = XpTable.levelForXp(currentXp)
     Column(Modifier.padding(bottom = 24.dp)) {
@@ -163,22 +75,10 @@ internal fun AgilitySheet(
                         hasActiveSession = hasActiveSession,
                         isQueueFull      = isQueueFull,
                         questIndicators  = activeQuests["${Skills.AGILITY}:$key"] ?: emptyList(),
-                        onClick          = { selectedKey = key },
+                        onClick          = { onSelect(key) },
                     )
                 }
         }
-    }
-    selectedKey?.let { key ->
-        val course = courses[key] ?: return@let
-        ActivityDetailDialog(
-            name             = GameStrings.agilityCourse(context, key),
-            detail           = context.getString(R.string.skills_agility_course_detail, course.levelRequired, course.xpPerSuccess),
-            description      = GameStrings.agilityCourseDesc(context, key),
-            hasActiveSession = hasActiveSession,
-            isQueueFull      = isQueueFull,
-            onConfirm        = { onSelect(key) },
-            onDismiss        = { selectedKey = null },
-        )
     }
 }
 

--- a/app/src/main/kotlin/com/fantasyidler/ui/screen/skills/GatheringSheets.kt
+++ b/app/src/main/kotlin/com/fantasyidler/ui/screen/skills/GatheringSheets.kt
@@ -1,116 +1,36 @@
 package com.fantasyidler.ui.screen
 
 
-import android.util.Log
-import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.items
-import androidx.compose.foundation.horizontalScroll
-import androidx.compose.foundation.pager.HorizontalPager
-import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
-import androidx.compose.foundation.shape.CircleShape
-import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material3.AlertDialog
-import androidx.compose.material3.Badge
-import androidx.compose.material3.BottomSheetDefaults
-import androidx.compose.material3.Tab
-import androidx.compose.material3.TabRow
-import androidx.compose.material3.Button
-import androidx.compose.material3.FilterChip
 import androidx.compose.material3.CircularProgressIndicator
-import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
-import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.ModalBottomSheet
-import androidx.compose.material3.Scaffold
-import androidx.compose.material3.SnackbarHost
-import androidx.compose.material3.SnackbarHostState
-import androidx.compose.material3.Surface
-import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
-import androidx.compose.material3.TextButton
-import androidx.compose.material3.TopAppBar
-import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.collectAsState
-import androidx.compose.runtime.getValue
-import androidx.compose.foundation.text.KeyboardActions
-import androidx.compose.foundation.text.KeyboardOptions
-import androidx.compose.material3.OutlinedTextField
-import androidx.compose.runtime.mutableLongStateOf
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberCoroutineScope
-import androidx.compose.runtime.setValue
-import kotlinx.coroutines.launch
-import androidx.compose.ui.text.input.ImeAction
-import androidx.compose.ui.text.input.KeyboardType
-import kotlinx.coroutines.delay
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
-import androidx.hilt.navigation.compose.hiltViewModel
-import com.fantasyidler.BuildConfig
 import com.fantasyidler.R
-import com.fantasyidler.ui.screen.QuestIndicatorIcons
-import com.fantasyidler.ui.viewmodel.ExpeditionsViewModel
-import com.fantasyidler.data.json.AgilityCourseData
-import com.fantasyidler.data.json.BoneData
 import com.fantasyidler.data.json.FishData
-import com.fantasyidler.data.json.LogData
 import com.fantasyidler.data.json.OreData
-import com.fantasyidler.data.json.ThievingNpcData
 import com.fantasyidler.data.json.TreeData
 import com.fantasyidler.data.model.Skills
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Add
-import androidx.compose.material.icons.filled.Remove
-import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
-import androidx.compose.ui.text.style.TextAlign
-import com.fantasyidler.ui.viewmodel.CraftableRecipe
-import com.fantasyidler.ui.viewmodel.CraftingUiState
-import com.fantasyidler.ui.viewmodel.CraftingViewModel
-import com.fantasyidler.ui.viewmodel.SheetState
-import com.fantasyidler.ui.viewmodel.levelDisplay
-import com.fantasyidler.ui.viewmodel.SkillsUiState
-import com.fantasyidler.ui.viewmodel.SkillsViewModel
-import com.fantasyidler.ui.viewmodel.xpProgressFraction
-import com.fantasyidler.ui.viewmodel.nextLevelThreshold
-import com.fantasyidler.ui.viewmodel.xpToNextLevel
 import com.fantasyidler.simulator.SkillSimulator
 import com.fantasyidler.simulator.XpTable
 import com.fantasyidler.util.GameStrings
-import com.fantasyidler.util.toTitleCase
-import com.fantasyidler.util.formatDurationMs
 import com.fantasyidler.util.formatXp
-import com.fantasyidler.util.toCountdown
-import java.util.Locale
-import com.fantasyidler.ui.viewmodel.QuestFillSuggestion
-import com.fantasyidler.ui.viewmodel.QuestCategory
 import com.fantasyidler.ui.viewmodel.QuestIndicator
-import androidx.compose.ui.draw.alpha
 
 
 @Composable
@@ -130,7 +50,6 @@ internal fun MiningSheet(
     onSelect: (String) -> Unit,
 ) {
     val context = LocalContext.current
-    var selectedKey by remember { mutableStateOf<String?>(null) }
     val scrollState = rememberScrollState()
     Column(Modifier.padding(bottom = 24.dp)) {
         Text(
@@ -174,22 +93,10 @@ internal fun MiningSheet(
                         isQueueFull      = isQueueFull,
                         questIndicators  = activeQuests["${Skills.MINING}:$key"] ?: emptyList(),
                         ownedQty         = inventory[key] ?: 0,
-                        onClick          = { selectedKey = key },
+                        onClick          = { onSelect(key) },
                     )
                 }
         }
-    }
-    selectedKey?.let { key ->
-        val ore = ores[key] ?: return@let
-        ActivityDetailDialog(
-            name             = GameStrings.itemName(context, key),
-            detail           = stringResource(R.string.skills_level_req_xp, ore.levelRequired, ore.xpPerOre),
-            description      = GameStrings.itemDesc(context, key),
-            hasActiveSession = hasActiveSession,
-            isQueueFull      = isQueueFull,
-            onConfirm        = { onSelect(key) },
-            onDismiss        = { selectedKey = null },
-        )
     }
 }
 
@@ -210,7 +117,6 @@ internal fun WoodcuttingSheet(
     onSelect: (String) -> Unit,
 ) {
     val context = LocalContext.current
-    var selectedKey by remember { mutableStateOf<String?>(null) }
     val scrollState = rememberScrollState()
     Column(Modifier.padding(bottom = 24.dp)) {
         Text(
@@ -248,22 +154,10 @@ internal fun WoodcuttingSheet(
                         isQueueFull      = isQueueFull,
                         questIndicators  = activeQuests["${Skills.WOODCUTTING}:${tree.logName}"] ?: emptyList(),
                         ownedQty         = inventory[tree.logName] ?: 0,
-                        onClick          = { selectedKey = key },
+                        onClick          = { onSelect(key) },
                     )
                 }
         }
-    }
-    selectedKey?.let { key ->
-        val tree = trees[key] ?: return@let
-        ActivityDetailDialog(
-            name             = GameStrings.itemName(context, tree.logName),
-            detail           = stringResource(R.string.skills_log_desc, tree.levelRequired, tree.xpPerLog),
-            description      = GameStrings.itemDesc(context, tree.logName),
-            hasActiveSession = hasActiveSession,
-            isQueueFull      = isQueueFull,
-            onConfirm        = { onSelect(key) },
-            onDismiss        = { selectedKey = null },
-        )
     }
 }
 
@@ -284,7 +178,6 @@ internal fun FishingSheet(
     onSelect: (String) -> Unit,
 ) {
     val context = LocalContext.current
-    var selectedKey by remember { mutableStateOf<String?>(null) }
     val scrollState = rememberScrollState()
     Column(Modifier.padding(bottom = 24.dp)) {
         Text(
@@ -322,22 +215,10 @@ internal fun FishingSheet(
                         isQueueFull      = isQueueFull,
                         questIndicators  = activeQuests["${Skills.FISHING}:$key"] ?: emptyList(),
                         ownedQty         = inventory[key] ?: 0,
-                        onClick          = { selectedKey = key },
+                        onClick          = { onSelect(key) },
                     )
                 }
         }
-    }
-    selectedKey?.let { key ->
-        val f = fish[key] ?: return@let
-        ActivityDetailDialog(
-            name             = GameStrings.itemName(context, key),
-            detail           = stringResource(R.string.skills_fish_desc, f.levelRequired, f.xpPerCatch),
-            description      = GameStrings.itemDesc(context, key),
-            hasActiveSession = hasActiveSession,
-            isQueueFull      = isQueueFull,
-            onConfirm        = { onSelect(key) },
-            onDismiss        = { selectedKey = null },
-        )
     }
 }
 
@@ -441,48 +322,6 @@ internal fun ActivityRow(
         }
     }
     HorizontalDivider(modifier = Modifier.padding(horizontal = 16.dp))
-}
-
-@Composable
-internal fun ActivityDetailDialog(
-    name: String,
-    detail: String,
-    description: String,
-    hasActiveSession: Boolean,
-    isQueueFull: Boolean,
-    onConfirm: () -> Unit,
-    onDismiss: () -> Unit,
-) {
-    AlertDialog(
-        onDismissRequest = onDismiss,
-        title = { Text(name) },
-        text = {
-            Column {
-                Text(detail, style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
-                if (description.isNotBlank()) {
-                    Spacer(Modifier.height(12.dp))
-                    Text(description, style = MaterialTheme.typography.bodyMedium)
-                }
-            }
-        },
-        confirmButton = {
-            val queueFullMessage = stringResource(R.string.snackbar_queue_full)
-            Button(
-                onClick = {
-                    if (isQueueFull) {
-                        AppBannerCenter.enqueue(queueFullMessage)
-                    } else {
-                        onConfirm(); onDismiss()
-                    }
-                },
-            ) {
-               Text(if (hasActiveSession) stringResource(R.string.skills_add_queue_short) else stringResource(R.string.btn_start_session))
-            }
-        },
-        dismissButton = {
-            TextButton(onClick = onDismiss) { Text(stringResource(R.string.btn_cancel)) }
-        },
-    )
 }
 
 // ---------------------------------------------------------------------------

--- a/app/src/main/kotlin/com/fantasyidler/ui/screen/skills/ThievingSheet.kt
+++ b/app/src/main/kotlin/com/fantasyidler/ui/screen/skills/ThievingSheet.kt
@@ -1,111 +1,21 @@
 package com.fantasyidler.ui.screen
 
 import android.content.Context
-import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.items
-import androidx.compose.foundation.horizontalScroll
-import androidx.compose.foundation.pager.HorizontalPager
-import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
-import androidx.compose.foundation.shape.CircleShape
-import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material3.AlertDialog
-import androidx.compose.material3.Badge
-import androidx.compose.material3.BottomSheetDefaults
-import androidx.compose.material3.Tab
-import androidx.compose.material3.TabRow
-import androidx.compose.material3.Button
-import androidx.compose.material3.FilterChip
-import androidx.compose.material3.CircularProgressIndicator
-import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
-import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.ModalBottomSheet
-import androidx.compose.material3.Scaffold
-import androidx.compose.material3.SnackbarHost
-import androidx.compose.material3.SnackbarHostState
-import androidx.compose.material3.Surface
-import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
-import androidx.compose.material3.TextButton
-import androidx.compose.material3.TopAppBar
-import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.collectAsState
-import androidx.compose.runtime.getValue
-import androidx.compose.foundation.text.KeyboardActions
-import androidx.compose.foundation.text.KeyboardOptions
-import androidx.compose.material3.OutlinedTextField
-import androidx.compose.runtime.mutableLongStateOf
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberCoroutineScope
-import androidx.compose.runtime.setValue
-import kotlinx.coroutines.launch
-import androidx.compose.ui.text.input.ImeAction
-import androidx.compose.ui.text.input.KeyboardType
-import kotlinx.coroutines.delay
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
-import androidx.hilt.navigation.compose.hiltViewModel
-import com.fantasyidler.BuildConfig
 import com.fantasyidler.R
-import com.fantasyidler.ui.viewmodel.ExpeditionsViewModel
-import com.fantasyidler.data.json.AgilityCourseData
-import com.fantasyidler.data.json.BoneData
-import com.fantasyidler.data.json.FishData
-import com.fantasyidler.data.json.LogData
-import com.fantasyidler.data.json.OreData
 import com.fantasyidler.data.json.ThievingNpcData
-import com.fantasyidler.data.json.TreeData
 import com.fantasyidler.data.model.Skills
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Add
-import androidx.compose.material.icons.filled.Remove
-import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
-import androidx.compose.ui.text.style.TextAlign
-import com.fantasyidler.ui.viewmodel.CraftableRecipe
-import com.fantasyidler.ui.viewmodel.CraftingUiState
-import com.fantasyidler.ui.viewmodel.CraftingViewModel
-import com.fantasyidler.ui.viewmodel.SheetState
-import com.fantasyidler.ui.viewmodel.levelDisplay
-import com.fantasyidler.ui.viewmodel.SkillsUiState
-import com.fantasyidler.ui.viewmodel.SkillsViewModel
-import com.fantasyidler.ui.viewmodel.xpProgressFraction
-import com.fantasyidler.ui.viewmodel.nextLevelThreshold
-import com.fantasyidler.ui.viewmodel.xpToNextLevel
-import com.fantasyidler.simulator.SkillSimulator
-import com.fantasyidler.simulator.XpTable
 import com.fantasyidler.util.GameStrings
-import com.fantasyidler.util.toTitleCase
-import com.fantasyidler.util.formatDurationMs
-import com.fantasyidler.util.formatXp
-import com.fantasyidler.util.toCountdown
-import java.util.Locale
-import com.fantasyidler.ui.viewmodel.QuestFillSuggestion
 import com.fantasyidler.ui.viewmodel.QuestIndicator
 
 
@@ -123,7 +33,6 @@ internal fun ThievingSheet(
     activeQuests: Map<String, List<QuestIndicator>> = emptyMap(),
     onSelect: (String) -> Unit,
 ) {
-    var selectedKey by remember { mutableStateOf<String?>(null) }
     val scrollState = rememberScrollState()
     Column(Modifier.padding(bottom = 24.dp)) {
         Text(
@@ -167,32 +76,9 @@ internal fun ThievingSheet(
                         hasActiveSession = hasActiveSession,
                         isQueueFull      = isQueueFull,
                         questIndicators  = activeQuests["${Skills.THIEVING}:${npc.key}"] ?: emptyList(),
-                        onClick          = { selectedKey = npc.key },
+                        onClick          = { onSelect(npc.key) },
                     )
                 }
         }
-    }
-    selectedKey?.let { key ->
-        val npc = npcs[key] ?: return@let
-        val successChance = ((0.40 + (thievingLevel - npc.levelRequired) * 0.02)
-            .coerceIn(0.10, 0.95) * 100).toInt()
-        ActivityDetailDialog(
-            name             = GameStrings.thievingNpcName(context, npc.key),
-            detail           = stringResource(
-                R.string.thieving_npc_detail,
-                npc.levelRequired,
-                npc.baseXp,
-                successChance,
-            ),
-            description      = stringResource(
-                R.string.thieving_npc_coins,
-                npc.coinsMin,
-                npc.coinsMax,
-            ),
-            hasActiveSession = hasActiveSession,
-            isQueueFull      = isQueueFull,
-            onConfirm        = { onSelect(key) },
-            onDismiss        = { selectedKey = null },
-        )
     }
 }

--- a/app/src/main/kotlin/com/fantasyidler/ui/viewmodel/ChurchViewModel.kt
+++ b/app/src/main/kotlin/com/fantasyidler/ui/viewmodel/ChurchViewModel.kt
@@ -39,7 +39,6 @@ data class ChurchUiState(
     val prayerCapeMult: Float = 1f,
     val totalBoneEquivalent: Int = 0,
     val totalBoneCount: Int = 0,
-    val pendingBlessingKey: String? = null,
     val showDeactivateConfirm: Boolean = false,
     val snackbarMessage: String? = null,
     /** Ironman characters can only use defensive blessings. */
@@ -90,12 +89,6 @@ class ChurchViewModel @Inject constructor(
     }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), ChurchUiState())
 
     fun activateBlessing(key: String) {
-        _extra.update { it.copy(pendingBlessingKey = key) }
-    }
-
-    fun confirmActivate() {
-        val key = _extra.value.pendingBlessingKey ?: return
-        _extra.update { it.copy(pendingBlessingKey = null) }
         viewModelScope.launch {
             when (val result = churchRepo.activateBlessing(key)) {
                 is BlessingActivateResult.Success -> {}
@@ -110,8 +103,6 @@ class ChurchViewModel @Inject constructor(
             }
         }
     }
-
-    fun dismissConfirm() = _extra.update { it.copy(pendingBlessingKey = null) }
 
     fun deactivateBlessing() {
         _extra.update { it.copy(showDeactivateConfirm = true) }

--- a/app/src/main/kotlin/com/fantasyidler/ui/viewmodel/SkillsViewModel.kt
+++ b/app/src/main/kotlin/com/fantasyidler/ui/viewmodel/SkillsViewModel.kt
@@ -813,6 +813,15 @@ class SkillsViewModel @Inject constructor(
                     durationMs       = result.durationMs,
                     skillDisplayName = "Thieving",
                 )
+                _uiState.update {
+                    it.copy(
+                        snackbarMessage = context.withAppLocale().getString(
+                            R.string.skill_added_to_queue_activity,
+                            GameStrings.skillName(context, Skills.THIEVING),
+                            GameStrings.thievingNpcName(context, npcKey),
+                        ),
+                    )
+                }
             } catch (e: Exception) {
                 _uiState.update { it.copy(snackbarMessage = context.withAppLocale().getString(R.string.skill_session_start_failed, e.message ?: "")) }
             } finally {
@@ -833,6 +842,7 @@ class SkillsViewModel @Inject constructor(
             // loop over startSession instead -- concurrent launches would race the
             // getActiveSession check and start several live sessions.
             var toQueue = count
+            var startedLive = false
             if (sessionRepo.getActiveSession() == null) {
                 _uiState.update { it.copy(startingSession = true) }
                 try {
@@ -849,6 +859,7 @@ class SkillsViewModel @Inject constructor(
                         skillDisplayName = skillName.replaceFirstChar { it.uppercase() },
                     )
                     toQueue -= 1
+                    startedLive = true
                 } catch (e: Exception) {
                     _uiState.update {
                         it.copy(snackbarMessage = context.withAppLocale().getString(R.string.skill_session_start_failed, e.message ?: ""))
@@ -858,10 +869,24 @@ class SkillsViewModel @Inject constructor(
                     _uiState.update { it.copy(startingSession = false) }
                 }
             }
-            if (toQueue <= 0) return@launch
 
             val displayName  = GameStrings.skillName(context, skillName)
             val actDisplay   = GameStrings.activityName(context, skillName, activityKey)
+
+            if (toQueue <= 0) {
+                if (startedLive) {
+                    _uiState.update {
+                        it.copy(
+                            snackbarMessage = if (activityKey.isNotEmpty())
+                                context.withAppLocale().getString(R.string.skill_added_to_queue_activity, displayName, actDisplay)
+                            else
+                                context.withAppLocale().getString(R.string.slayer_queue_added, displayName),
+                        )
+                    }
+                }
+                return@launch
+            }
+
             val player       = playerRepo.getOrCreatePlayer()
             val gatherLevels: Map<String, Int> = json.decodeFromString(player.skillLevels)
             val agility      = gatherLevels[Skills.AGILITY] ?: 1
@@ -909,6 +934,7 @@ class SkillsViewModel @Inject constructor(
                 if (!enqueued) break
                 enqueuedAny = true
             }
+
             if (enqueuedAny) queuedSessionStarter.startNextQueued()
             _uiState.update {
                 it.copy(


### PR DESCRIPTION
## Before submitting

- [x] I've tested any changes with the appropriate tests (eg. Unit tests, validation scripts)
- [x] I've pulled and merged the latest changes from the repository

## Summary

Removes two confirmation `AlertDialog`s that guarded non-destructive actions, so those actions now happen on the first tap:

- Church → Activate blessing
- Skill → Add to queue


## Related issue(s) or discussion(s)


## Changelog

- Removed the "Activate Blessing?" confirmation dialog - activating a blessing is now a single tap
- Removed the activity detail dialog from the Mining, Woodcutting, Fishing, Agility, and Thieving pickers - tapping an activity starts/queues it directly
- Fixed the "Added to queue" app banner not appearing when starting a skill session with no active session

## Anything else?
