### PR TITLE
fix and expand wiki content

### DIFF
--- a/wiki/src/game_data.py
+++ b/wiki/src/game_data.py
@@ -339,6 +339,10 @@ def merc_name(merc: str) -> str:
     return _standard_string_resolution(merc, "merc_{}_name", "merc_name", "mercenary")
 
 
+def blessing_name(blessing: str) -> str:
+    return _standard_string_resolution(blessing, "blessing_{}_name", "blessing_name", "blessing")
+
+
 def race_name(race: str) -> str:
     return _standard_string_resolution(race, "character_race_{}", "race_name", "race")
 

--- a/wiki/src/pages.py
+++ b/wiki/src/pages.py
@@ -898,10 +898,10 @@ def gen_farming() -> str:
     # Ashes tables
     # Todo: Switch to avoid being hardcoded
     ash_rows = []
-    ash_amounts = [("ashes", 1.1), ("oak_ashes", 1.25), ("willow_ashes", 1.35), ("maple_ashes", 1.5), ("yew_ashes", 1.75),
+    ash_amounts = [("ashes", 1.1), ("oak_ashes", 1.2), ("willow_ashes", 1.35), ("maple_ashes", 1.5), ("yew_ashes", 1.75),
                    ("magic_ashes", 2), ("redwood_ashes", 2.5)]
     for ash, bonus in ash_amounts:
-        ash_rows.append([item_name(ash), f"+{int((bonus - 1) * 100)}%"])
+        ash_rows.append([item_name(ash), f"+{round((bonus - 1) * 100)}%"])
 
     magic_bean_note = (
         "Obtaining one requires patience. A lucky harvest may be all it takes. "
@@ -1198,19 +1198,28 @@ def gen_runecrafting() -> str:
 def gen_herblore() -> str:
     recipes = load("recipes/herblore.json")
     assert isinstance(recipes, dict)
+
+    def fmt_effects(effects: dict, enhanced: bool = False) -> str:
+        # Enhanced potions (brewed with an ash catalyst) double every bonus,
+        # floored at base + 1 -- mirrors GameDataRepository.potionEffects.
+        def val_for(v):
+            return max(int(v * 2), v + 1) if enhanced else v
+        return ", ".join(f"{stat.title()} +{val_for(val)}" for stat, val in effects.items())
+
     rows = sorted(
         [[
             item_name(k),
             r["level_required"],
             fmt_materials(r["materials"]),
-            ", ".join(f"{stat.title()} +{val}" for stat, val in r.get("effects", {}).items()),
+            fmt_effects(r.get("effects", {})),
+            fmt_effects(r.get("effects", {}), enhanced=True),
             r["xp_per_item"],
         ] for k, r in recipes.items()],
         key=lambda r: r[1]
     )
     return get_template("skills/crafting/herblore").format(
         icon=html_image(skill_icon_path("herblore"), "", "text"),
-        potion_table=table(['Potion','Level','Ingredients','Effect','XP'], rows),
+        potion_table=table(['Potion','Level','Ingredients','Effect','Enhanced Effect','XP'], rows),
     )
 
 
@@ -1259,8 +1268,40 @@ def gen_thieving() -> str:
     )
 
 
+# Todo: Switch to avoid being hardcoded (mirrors ChurchRepository.ALL_BLESSINGS
+# and ChurchRepository.boneCostFor, which live in Kotlin, not game data).
+_BLESSING_BONE_COST = {1: 10, 10: 20, 20: 35, 30: 55, 40: 80, 50: 110,
+                       60: 145, 70: 185, 80: 230, 90: 265, 99: 300}
+_BLESSINGS = {
+    "XP": [  # (name, prayer level, XP multiplier)
+        ("Blessed Focus", 1, 1.05), ("Blessed Focus II", 10, 1.10),
+        ("Blessed Focus III", 20, 1.15), ("Tithe Blessing", 30, 1.18),
+        ("Tithe Blessing II", 40, 1.20), ("Tithe Blessing III", 50, 1.25),
+        ("Divine Focus", 60, 1.28), ("Divine Focus II", 70, 1.32),
+        ("Divine Grace", 80, 1.37), ("Divine Grace II", 90, 1.43),
+        ("Sacred Grace", 99, 1.50),
+    ],
+    "DEFENSE": [  # (name, prayer level, flat defence)
+        ("Stone Skin", 1, 2), ("Stone Skin II", 10, 4), ("Stone Skin III", 20, 6),
+        ("Stone Skin IV", 30, 9), ("Iron Ward", 40, 12), ("Iron Ward II", 50, 15),
+        ("Diamond Skin", 60, 18), ("Diamond Skin II", 70, 22),
+        ("Holy Shield", 80, 26), ("Holy Shield II", 90, 30), ("Aegis", 99, 35),
+    ],
+    "COINS": [  # (name, prayer level, coin bonus fraction)
+        ("Fortune I", 30, 0.08), ("Fortune II", 40, 0.10), ("Fortune III", 50, 0.13),
+        ("Fortune IV", 60, 0.15), ("Fortune V", 70, 0.18), ("Abundance", 80, 0.20),
+        ("Abundance II", 90, 0.23), ("Abundance III", 99, 0.25),
+    ],
+}
+
+
+def _blessing_table(kind: str, effect_fmt) -> str:
+    rows = [[name, level, _BLESSING_BONE_COST[level], effect_fmt(mag)]
+            for name, level, mag in _BLESSINGS[kind]]
+    return table(["Name", "Prayer Level", "Cost (bones)", "Effect"], rows)
+
+
 def gen_prayer() -> str:
-    # Todo: Add info about bone altar
     bones = load("bones.json")
     assert isinstance(bones, dict)
     rows = sorted(
@@ -1271,6 +1312,9 @@ def gen_prayer() -> str:
     return get_template("skills/support/prayer").format(
         icon=html_image(skill_icon_path("prayer"), "", "text"),
         prayer_table=table(['Bone / Ash','XP Each'], rows),
+        blessing_xp_table=_blessing_table("XP", lambda m: f"+{round((m - 1) * 100)}% XP"),
+        blessing_defense_table=_blessing_table("DEFENSE", lambda m: f"+{m} Defence"),
+        blessing_coins_table=_blessing_table("COINS", lambda m: f"+{round(m * 100)}% coins"),
     )
 
 

--- a/wiki/src/pages.py
+++ b/wiki/src/pages.py
@@ -21,7 +21,7 @@ from wiki.src.game_data import STRINGS, load, title, item_name, house_item_name,
     trade_route_name, thieving_npc_name, quest_name, agility_course_name, town_building_name, quest_desc, title_name, \
     pet_name, boss_name, boss_desc, trade_route_desc, pet_desc, item_desc, dungeon_name, dungeon_desc, expedition_name, \
     expedition_desc, seasonal_event_name, seasonal_reward_desc, prestige_effect_desc, tree_name, merc_name, race_name, \
-    carnival_prize_name, carnival_prize_desc, slot_name
+    carnival_prize_name, carnival_prize_desc, slot_name, blessing_name
 from wiki.src.page_hierarchy import PageHierarchy
 from wiki.src.wiki_logs import LOGGER
 
@@ -1268,32 +1268,34 @@ def gen_thieving() -> str:
 
 _BLESSING_BONE_COST = {1: 10, 10: 20, 20: 35, 30: 55, 40: 80, 50: 110,
                        60: 145, 70: 185, 80: 230, 90: 265, 99: 300}
+# Todo: Move blessings from ChurchRepository.ALL_BLESSINGS into their own dedicated blessings.json file and reference in the game with gameData and here by loading the json file
+# Keyed by blessing id (matches ChurchRepository.ALL_BLESSINGS); display names come from strings.xml via blessing_name().
 _BLESSINGS = {
     "XP": [
-        ("Blessed Focus", 1, 1.05), ("Blessed Focus II", 10, 1.10),
-        ("Blessed Focus III", 20, 1.15), ("Tithe Blessing", 30, 1.18),
-        ("Tithe Blessing II", 40, 1.20), ("Tithe Blessing III", 50, 1.25),
-        ("Divine Focus", 60, 1.28), ("Divine Focus II", 70, 1.32),
-        ("Divine Grace", 80, 1.37), ("Divine Grace II", 90, 1.43),
-        ("Sacred Grace", 99, 1.50),
+        ("blessed_focus", 1, 1.05), ("blessed_focus_ii", 10, 1.10),
+        ("blessed_focus_iii", 20, 1.15), ("tithe_blessing", 30, 1.18),
+        ("tithe_blessing_ii", 40, 1.20), ("tithe_blessing_iii", 50, 1.25),
+        ("divine_focus", 60, 1.28), ("divine_focus_ii", 70, 1.32),
+        ("divine_grace", 80, 1.37), ("divine_grace_ii", 90, 1.43),
+        ("sacred_grace", 99, 1.50),
     ],
     "DEFENSE": [
-        ("Stone Skin", 1, 2), ("Stone Skin II", 10, 4), ("Stone Skin III", 20, 6),
-        ("Stone Skin IV", 30, 9), ("Iron Ward", 40, 12), ("Iron Ward II", 50, 15),
-        ("Diamond Skin", 60, 18), ("Diamond Skin II", 70, 22),
-        ("Holy Shield", 80, 26), ("Holy Shield II", 90, 30), ("Aegis", 99, 35),
+        ("stone_skin", 1, 2), ("stone_skin_ii", 10, 4), ("stone_skin_iii", 20, 6),
+        ("stone_skin_iv", 30, 9), ("iron_ward", 40, 12), ("iron_ward_ii", 50, 15),
+        ("diamond_skin", 60, 18), ("diamond_skin_ii", 70, 22),
+        ("holy_shield", 80, 26), ("holy_shield_ii", 90, 30), ("aegis", 99, 35),
     ],
     "COINS": [
-        ("Fortune I", 30, 0.08), ("Fortune II", 40, 0.10), ("Fortune III", 50, 0.13),
-        ("Fortune IV", 60, 0.15), ("Fortune V", 70, 0.18), ("Abundance", 80, 0.20),
-        ("Abundance II", 90, 0.23), ("Abundance III", 99, 0.25),
+        ("fortune_i", 30, 0.08), ("fortune_ii", 40, 0.10), ("fortune_iii", 50, 0.13),
+        ("fortune_iv", 60, 0.15), ("fortune_v", 70, 0.18), ("abundance", 80, 0.20),
+        ("abundance_ii", 90, 0.23), ("abundance_iii", 99, 0.25),
     ],
 }
 
 
 def _blessing_table(kind: str, effect_fmt) -> str:
-    rows = [[name, level, _BLESSING_BONE_COST[level], effect_fmt(mag)]
-            for name, level, mag in _BLESSINGS[kind]]
+    rows = [[blessing_name(bid), level, _BLESSING_BONE_COST[level], effect_fmt(mag)]
+            for bid, level, mag in _BLESSINGS[kind]]
     return table(["Name", "Prayer Level", "Cost (bones)", "Effect"], rows)
 
 
@@ -1307,6 +1309,7 @@ def gen_prayer() -> str:
     )
     return get_template("skills/support/prayer").format(
         icon=html_image(skill_icon_path("prayer"), "", "text"),
+        church_link=link("buildings", "Church", "church"),
         prayer_table=table(['Bone / Ash','XP Each'], rows),
         blessing_xp_table=_blessing_table("XP", lambda m: f"+{round((m - 1) * 100)}% XP"),
         blessing_defense_table=_blessing_table("DEFENSE", lambda m: f"+{m} Defence"),
@@ -1775,6 +1778,7 @@ def gen_spells() -> str:
     ], key=lambda r: r[1])
     return get_template("combat/spells").format(
         spell_table=table(["Spell", "Magic Level", "Rune", "Runes / Cast", "Max Hit"], rows),
+        void_staff_link=item_link("void_staff"),
         combat_footer=gen_combat_footer(),
     )
 
@@ -2073,6 +2077,7 @@ def gen_carnival() -> str:
     ]
 
     return get_template("town/carnival").format(
+        fairgrounds_link=link("buildings", "Fairgrounds"),
         idle_table=table(["Minigame", "Skill Trained"], idle_rows),
         active_table=table(["Minigame", "How to play", "Normal", "Hard"], active_rows),
         prize_table=table(["Prize", "Ticket Cost", "Effect"], prize_rows),

--- a/wiki/src/pages.py
+++ b/wiki/src/pages.py
@@ -1200,8 +1200,6 @@ def gen_herblore() -> str:
     assert isinstance(recipes, dict)
 
     def fmt_effects(effects: dict, enhanced: bool = False) -> str:
-        # Enhanced potions (brewed with an ash catalyst) double every bonus,
-        # floored at base + 1 -- mirrors GameDataRepository.potionEffects.
         def val_for(v):
             return max(int(v * 2), v + 1) if enhanced else v
         return ", ".join(f"{stat.title()} +{val_for(val)}" for stat, val in effects.items())
@@ -1268,12 +1266,10 @@ def gen_thieving() -> str:
     )
 
 
-# Todo: Switch to avoid being hardcoded (mirrors ChurchRepository.ALL_BLESSINGS
-# and ChurchRepository.boneCostFor, which live in Kotlin, not game data).
 _BLESSING_BONE_COST = {1: 10, 10: 20, 20: 35, 30: 55, 40: 80, 50: 110,
                        60: 145, 70: 185, 80: 230, 90: 265, 99: 300}
 _BLESSINGS = {
-    "XP": [  # (name, prayer level, XP multiplier)
+    "XP": [
         ("Blessed Focus", 1, 1.05), ("Blessed Focus II", 10, 1.10),
         ("Blessed Focus III", 20, 1.15), ("Tithe Blessing", 30, 1.18),
         ("Tithe Blessing II", 40, 1.20), ("Tithe Blessing III", 50, 1.25),
@@ -1281,13 +1277,13 @@ _BLESSINGS = {
         ("Divine Grace", 80, 1.37), ("Divine Grace II", 90, 1.43),
         ("Sacred Grace", 99, 1.50),
     ],
-    "DEFENSE": [  # (name, prayer level, flat defence)
+    "DEFENSE": [
         ("Stone Skin", 1, 2), ("Stone Skin II", 10, 4), ("Stone Skin III", 20, 6),
         ("Stone Skin IV", 30, 9), ("Iron Ward", 40, 12), ("Iron Ward II", 50, 15),
         ("Diamond Skin", 60, 18), ("Diamond Skin II", 70, 22),
         ("Holy Shield", 80, 26), ("Holy Shield II", 90, 30), ("Aegis", 99, 35),
     ],
-    "COINS": [  # (name, prayer level, coin bonus fraction)
+    "COINS": [
         ("Fortune I", 30, 0.08), ("Fortune II", 40, 0.10), ("Fortune III", 50, 0.13),
         ("Fortune IV", 60, 0.15), ("Fortune V", 70, 0.18), ("Abundance", 80, 0.20),
         ("Abundance II", 90, 0.23), ("Abundance III", 99, 0.25),

--- a/wiki/src/pages.py
+++ b/wiki/src/pages.py
@@ -2072,12 +2072,12 @@ def gen_carnival() -> str:
         ["Hammer Strike", "Time your swing for a strong hit", "1–2", "6–8"],
         ["Potion Sequence", "Repeat a growing memory sequence of potion colors", "2", "7"],
         ["Item Appraisal", "Pick the more valuable item", "2", "7"],
-        [f"Pick-a-Cup ({link("buildings", "Fairgrounds")} tier 1+)", "Track which cup hides the gem through a shuffle", "4", "7"],
-        [f"Higher or Lower ({link("buildings", "Fairgrounds")} tier 2+)", "Guess higher or lower over several rounds — more correct in a row pays more", "up to 5", "up to 8"],
+        [f"Pick-a-Cup ({link("buildings", "Fairgrounds", "fairgrounds")} tier 1+)", "Track which cup hides the gem through a shuffle", "4", "7"],
+        [f"Higher or Lower ({link("buildings", "Fairgrounds", "fairgrounds")} tier 2+)", "Guess higher or lower over several rounds — more correct in a row pays more", "up to 5", "up to 8"],
     ]
 
     return get_template("town/carnival").format(
-        fairgrounds_link=link("buildings", "Fairgrounds"),
+        fairgrounds_link=link("buildings", "Fairgrounds", "fairgrounds"),
         idle_table=table(["Minigame", "Skill Trained"], idle_rows),
         active_table=table(["Minigame", "How to play", "Normal", "Hard"], active_rows),
         prize_table=table(["Prize", "Ticket Cost", "Effect"], prize_rows),

--- a/wiki/templates/combat/mercenaries.md
+++ b/wiki/templates/combat/mercenaries.md
@@ -1,6 +1,6 @@
 # Mercenary Camp
 
-Raid bosses cannot be beaten alone. The Mercenary Camp hires fighters who join your party for the length of a contract, which lasts until your next daily reset. Find it through the Raid section of the combat screen, next to the raid bosses themselves.
+Raid bosses cannot be beaten alone. The Mercenary Camp hires fighters who join your party for the length of a contract, which lasts a flat 24 hours from the moment you hire them. A late-day hire is not cut short by the daily reset, so a contract can run well past it. Find it through the Raid section of the combat screen, next to the raid bosses themselves.
 
 {merc_table}
 

--- a/wiki/templates/combat/spells.md
+++ b/wiki/templates/combat/spells.md
@@ -4,6 +4,6 @@ Equip a magic weapon and select a spell before entering a dungeon or boss fight.
 
 {spell_table}
 
-> Some staves provide **infinite runes** of a specific type, removing that rune's cost from any spell that uses it. The Void Staff provides **infinite runes** for all types.
+> Some staves provide **infinite runes** of a specific type, removing that rune's cost from any spell that uses it. The {void_staff_link} provides **infinite runes** for all types.
 
 {combat_footer}

--- a/wiki/templates/combat/spells.md
+++ b/wiki/templates/combat/spells.md
@@ -4,6 +4,6 @@ Equip a magic weapon and select a spell before entering a dungeon or boss fight.
 
 {spell_table}
 
-> Some staves provide **infinite runes** of a specific type, removing the rune cost for that spell.
+> Some staves provide **infinite runes** of a specific type, removing that rune's cost from any spell that uses it. The Void Staff provides **infinite runes** for all types.
 
 {combat_footer}

--- a/wiki/templates/contributing/getting_started_game.md
+++ b/wiki/templates/contributing/getting_started_game.md
@@ -28,13 +28,22 @@ Developing new features is a fun way to add to the game and see the changes you'
 
 If you want to develop a new feature you should follow the below steps:
 
-1. Create a new discussion topic in [discussions](https://github.com/tristinbaker/IdleFantasy/discussions). This ensures that the community is able to chip in and provide feedback before you start development. If this is a significant new feature, you could consider adding some example designs of what you're thinking to help provide more clarity.
+1. Create a new discussion topic in [discussions](https://github.com/tristinbaker/IdleFantasy/discussions). This ensures that the community is able to chip in and provide feedback before you start development. If this is a significant new feature, you could consider adding some example designs of what you're thinking to help provide more clarity. For a smaller feature, opening a GitHub issue (as the repository's `CONTRIBUTING.md` describes) is also fine.
 2. Create a new fork and start working on the project. If this is a large feature, consider updating the discussion with how you're progressing although we don't necessarily need a day-by-day update.
 3. Just like with squashing bugs, once you've finished working on your feature, you should sync your fork with the upstream branches and resolve any potential merge conflicts.
 4. Then, once all the merge conflicts have been sorted, you can test to ensure the feature still works properly.
 5. Finally, once you've tested and synced your fork, you can create a pull request, explaining what you've added and provide a reference to the relevant discussion.
 
 It's quite common while developing an idea that you come up with lots of additional changes and revisions. If these are large, you should consider updating the discussion topic so it properly reflects the idea in full.
+
+## Repository rules
+
+A few hard rules from the repository's [`CONTRIBUTING.md`](https://github.com/tristinbaker/IdleFantasy/blob/main/CONTRIBUTING.md) apply to every change, and a pull request that breaks one will need reworking:
+
+- **Localise user-visible strings.** If you add or change any string a player can read, propagate it to every locale file under `app/src/main/res/values-*/strings.xml`, not just the base `values/strings.xml`.
+- **No database migrations.** New player state belongs in the existing JSON blob columns (`flags`, `inventory`, and similar) with a default value for the new field, so old saves keep loading. Don't add Room migrations.
+- **No new dependencies without prior discussion.** Raise it first rather than adding a library in the PR.
+- **One feature or fix per pull request.**
 
 ## Building and compiling
 

--- a/wiki/templates/contributing/getting_started_game.md
+++ b/wiki/templates/contributing/getting_started_game.md
@@ -28,22 +28,13 @@ Developing new features is a fun way to add to the game and see the changes you'
 
 If you want to develop a new feature you should follow the below steps:
 
-1. Create a new discussion topic in [discussions](https://github.com/tristinbaker/IdleFantasy/discussions). This ensures that the community is able to chip in and provide feedback before you start development. If this is a significant new feature, you could consider adding some example designs of what you're thinking to help provide more clarity. For a smaller feature, opening a GitHub issue (as the repository's `CONTRIBUTING.md` describes) is also fine.
+1. Create a new discussion topic in [discussions](https://github.com/tristinbaker/IdleFantasy/discussions). This ensures that the community is able to chip in and provide feedback before you start development. If this is a significant new feature, you could consider adding some example designs of what you're thinking to help provide more clarity.
 2. Create a new fork and start working on the project. If this is a large feature, consider updating the discussion with how you're progressing although we don't necessarily need a day-by-day update.
 3. Just like with squashing bugs, once you've finished working on your feature, you should sync your fork with the upstream branches and resolve any potential merge conflicts.
 4. Then, once all the merge conflicts have been sorted, you can test to ensure the feature still works properly.
 5. Finally, once you've tested and synced your fork, you can create a pull request, explaining what you've added and provide a reference to the relevant discussion.
 
 It's quite common while developing an idea that you come up with lots of additional changes and revisions. If these are large, you should consider updating the discussion topic so it properly reflects the idea in full.
-
-## Repository rules
-
-A few hard rules from the repository's [`CONTRIBUTING.md`](https://github.com/tristinbaker/IdleFantasy/blob/main/CONTRIBUTING.md) apply to every change, and a pull request that breaks one will need reworking:
-
-- **Localise user-visible strings.** If you add or change any string a player can read, propagate it to every locale file under `app/src/main/res/values-*/strings.xml`, not just the base `values/strings.xml`.
-- **No database migrations.** New player state belongs in the existing JSON blob columns (`flags`, `inventory`, and similar) with a default value for the new field, so old saves keep loading. Don't add Room migrations.
-- **No new dependencies without prior discussion.** Raise it first rather than adding a library in the PR.
-- **One feature or fix per pull request.**
 
 ## Building and compiling
 

--- a/wiki/templates/contributing/getting_started_wiki.md
+++ b/wiki/templates/contributing/getting_started_wiki.md
@@ -101,6 +101,8 @@ The following code files are used as follows in the wiki:
 - `game_data.py` - A set of helper functions which retrieve data from the game such as json files and game strings
 - `site.py` - The code responsible for generating the Idle Fantasy wiki website based upon the generated Markdown files.
 - `page_hierarchy.py` - A simple file defining the page hierarchy structure.
+- `validation.py` - Holds the logic behind `check_wiki_validity()` (the `validity` command): checks that every page icon exists, every page has a working generator, and every internal page link points somewhere real.
+- `wiki_logs.py` - A small shared logger (`LOGGER`) used across the build to emit de-duplicated warnings, such as missing translation strings.
 
 ## Contributing process
 

--- a/wiki/templates/guides/how_to_make_player_guides.md
+++ b/wiki/templates/guides/how_to_make_player_guides.md
@@ -26,7 +26,7 @@ Before you publish, it's worth getting a second opinion on your guide. You could
 
 ## Adding guides to the wiki
 
-So you've written your guide and (hopefully) used some feedback to polish it - nice work! The next step is adding it to the wiki itself, which starts with creating a fork of the repo. If you're not familiar with forking and pull requests, [GitHub's quickstart guide](https://docs.github.com/en/pull-requests/get-started/pull-request-quickstart) is a good place to start, or you can find a how-to video that walks through the process.
+So you've written your guide and (hopefully) used some feedback to polish it - nice work! The next step is adding it to the wiki itself, which starts with creating a fork of the repo. If you're not familiar with forking and pull requests, [GitHub's quickstart guide](https://docs.github.com/en/pull-requests/get-started/pull-request-quickstart) is a good place to start.
 
 Once you've forked the repo, you'll have two options for making your wiki guide to choose from:
 

--- a/wiki/templates/skills/combat/slayer.md
+++ b/wiki/templates/skills/combat/slayer.md
@@ -10,8 +10,18 @@ Visit the **Slayer Master** in Town to receive a task. Complete it by killing th
 
 Completing a task awards **Slayer points** (more for higher-level tasks). Points can be spent in the **Slayer Shop** on:
 
-- XP Lamp (Small) — +10,000 XP to any skill
-- XP Lamp (Large) — +50,000 XP to any skill
-- Slayer Helm, Abyssal Whip, Slayer Platebody, Slayer Platelegs (exclusive gear)
+- XP Lamp (Small) — 50 pts, +10,000 XP to any skill
+- XP Lamp (Large) — 200 pts, +50,000 XP to any skill
+- Abyssal Whip — 300 pts (exclusive gear)
+- Slayer Helm — 400 pts (exclusive gear)
+- Slayer Platebody — 350 pts (exclusive gear)
+- Slayer Platelegs — 250 pts (exclusive gear)
+- Slayer Plateskirt — 250 pts (exclusive gear)
 
 Use **Skip (30 pts)** to discard a task you don't want.
+
+## Foretell
+
+Spend bones at the Slayer Master to **foretell** upcoming tasks - queue up to three future assignments so they're ready the moment the current one ends. Each queued slot costs more than the last: 10 bone-units for the first, 25 for the second, and 50 for the third, where a regular bone counts as one unit and higher-tier bones count for more. Your cheapest bones are spent first.
+
+The **Foresight** prestige path extends this. Its first three nodes raise the queue cap by +1, +2, then +3 (up to six foretold tasks at once). 

--- a/wiki/templates/skills/crafting/crafting.md
+++ b/wiki/templates/skills/crafting/crafting.md
@@ -1,5 +1,5 @@
 # {icon} Crafting
 
-Create jewellery and other items from precious materials.
+Create jewellery from precious materials.
 
 {item_table}

--- a/wiki/templates/skills/crafting/fletching.md
+++ b/wiki/templates/skills/crafting/fletching.md
@@ -1,5 +1,5 @@
 # {icon} Fletching
 
-Craft bows and arrows from logs and metal components.
+Craft ranged and magic weapons from logs and metal components: shortbows and longbows, arrows, and elemental magic staves. Fletching also turns logs into planks, the wooden material that Construction recipes consume.
 
 {item_table}

--- a/wiki/templates/skills/crafting/herblore.md
+++ b/wiki/templates/skills/crafting/herblore.md
@@ -1,6 +1,8 @@
 # {icon} Herblore
 
-Brew potions from farming crops and dungeon reagents. Potions give flat combat stat boosts and can be selected before entering a dungeon or boss fight. Brewing a potion with any ash as catalyst (ash tier has no difference) can produce an enhanced potion with double the effects. 
+Brew potions from farming crops and dungeon reagents. Potions give flat combat stat boosts and can be selected before entering a dungeon or boss fight.
+
+Adding an ash as a catalyst (ash tier makes no difference) turns the result into an **enhanced** potion. Each of its stat bonuses is doubled (and never drops below +1) - for example an Attack Potion's +5 Attack becomes +10, and an Overload Potion's +10 to every stat becomes +20. Enhanced potions still count as their base potion for quests, guild tasks, seasonal tasks, and Sell Junk protection.
 
 {potion_table}
 

--- a/wiki/templates/skills/gathering/thieving.md
+++ b/wiki/templates/skills/gathering/thieving.md
@@ -8,6 +8,8 @@ Pickpocket NPCs found in the Town for coins and loot. Higher-level NPCs require 
 
 Equip a lockpick to raise your pickpocket success chance. Its efficiency multiplies the bonus you gain for every Thieving level above the NPC's requirement. Higher-tier lockpicks require a higher Thieving level.
 
+A failed pickpocket stuns you: that attempt yields nothing, and the following frame is skipped entirely with no XP or loot. Raising your success chance therefore matters more than the raw per-steal reward suggests.
+
 {lockpick_table}
 
 ### Lockpick tier efficiency multiplier

--- a/wiki/templates/skills/support/prayer.md
+++ b/wiki/templates/skills/support/prayer.md
@@ -8,7 +8,7 @@ Bury bones to earn Prayer XP. Higher-tier bones give more XP. Ashes from Firemak
 
 ## Blessings
 
-Blessings are temporary buffs activated at the **Church** building and paid for in bones. Only one blessing can be active at a time; activating another replaces it. The bone cost is fixed per tier and is paid in regular-bone equivalents (higher-tier bones count for more, and your most valuable bones are spent first).
+Blessings are temporary buffs activated at the {church_link} building and paid for in bones. Only one blessing can be active at a time; activating another replaces it. The bone cost is fixed per tier and is paid in regular-bone equivalents (higher-tier bones count for more, and your most valuable bones are spent first).
 
 A blessing lasts **24 hours** by default. But certain boosts you can apply to increase the blessing time. Re-activating a blessing that is still running adds to its remaining time instead of resetting it. 
 
@@ -28,8 +28,8 @@ Ironman accounts can only use the Defence blessings.
 
 ### Boosting blessings
 
-- **Wear the Prayer cape** - increases blessing strength (roughly 1.5× the listed effect).
-- **Upgrade the Church** - each tier adds to the base 24-hour duration: +6h at tier 1, +12h at tier 2, +24h at tier 3.
+- **Wear the Prayer cape** - increases blessing strength.
+- **Upgrade the {church_link}** - each tier adds to the base 24-hour duration: +6h at tier 1, +12h at tier 2, +24h at tier 3.
 - **Complete the Grand Monument** - tier 3 adds +6h to blessing duration, and its Touch action can extend an active blessing by a further 2h.
 - **Prayer Devotion prestige path** - blessings last up to 30% longer (up to 55% for elves, via the Forest Grace nodes).
 - **Gnome Trickster's Favor prestige path** - reduces the bone cost by up to 20%.

--- a/wiki/templates/skills/support/prayer.md
+++ b/wiki/templates/skills/support/prayer.md
@@ -5,3 +5,37 @@ Bury bones to earn Prayer XP. Higher-tier bones give more XP. Ashes from Firemak
 {prayer_table}
 
 > Tip: Dragon and giant bones give the most XP per session. Farm higher-level dungeons for better bone drops.
+
+## Blessings
+
+Blessings are temporary buffs activated at the **Church** building and paid for in bones. Only one blessing can be active at a time; activating another replaces it. The bone cost is fixed per tier and is paid in regular-bone equivalents (higher-tier bones count for more, and your most valuable bones are spent first).
+
+A blessing lasts **24 hours** by default. But certain boosts you can apply to increase the blessing time. Re-activating a blessing that is still running adds to its remaining time instead of resetting it. 
+
+Ironman accounts can only use the Defence blessings.
+
+### XP blessings - multiply all skill XP
+
+{blessing_xp_table}
+
+### Defence blessings - flat defence in combat
+
+{blessing_defense_table}
+
+### Coin blessings - bonus coins earned
+
+{blessing_coins_table}
+
+### Boosting blessings
+
+- **Wear the Prayer cape** - increases blessing strength (roughly 1.5× the listed effect).
+- **Upgrade the Church** - each tier adds to the base 24-hour duration: +6h at tier 1, +12h at tier 2, +24h at tier 3.
+- **Complete the Grand Monument** - tier 3 adds +6h to blessing duration, and its Touch action can extend an active blessing by a further 2h.
+- **Prayer Devotion prestige path** - blessings last up to 30% longer (up to 55% for elves, via the Forest Grace nodes).
+- **Gnome Trickster's Favor prestige path** - reduces the bone cost by up to 20%.
+
+## Bone Altar
+
+Burying bones at the **Bone Altar** builds a combo. Each bone buried within 3 seconds of the last one increases the combo counter; let more than 3 seconds pass, leave the altar screen, or switch to a different bone type and it resets.
+
+Once the combo reaches **10**, all Prayer XP from the altar is multiplied by **1.5×** for as long as the streak holds (the counter itself caps at 99). Keeping a fast, uninterrupted burying rhythm on a stack of high-tier bones is the most XP-efficient way to use the altar.

--- a/wiki/templates/town/carnival.md
+++ b/wiki/templates/town/carnival.md
@@ -8,7 +8,7 @@ The Carnival is a Town minigame hub where you earn Carnival Tickets and spend th
 
 {idle_table}
 
-**Active minigames** are played directly and reward more tickets on Hard difficulty. Each has its own 10-minute cooldown between attempts, so you can rotate between all of them back-to-back.
+**Active minigames** are played directly and reward more tickets on Hard difficulty. Each has its own cooldown between attempts — 10 minutes by default — so you can rotate between all of them back-to-back. Upgrading the Fairgrounds building shortens this: 7.5 minutes at tier 1, down to 5 minutes at tier 3.
 
 {active_table}
 

--- a/wiki/templates/town/carnival.md
+++ b/wiki/templates/town/carnival.md
@@ -4,11 +4,11 @@ The Carnival is a Town minigame hub where you earn Carnival Tickets and spend th
 
 ## Earning tickets
 
-**Idle minigames** run like a skill session — queue one and check back later. Each minute has a chance to earn a ticket, starting at 15% at level 1 and scaling up to 35% at level 99 in the matching skill. Upgrading the Fairgrounds building further increases this chance.
+**Idle minigames** run like a skill session — queue one and check back later. Each minute has a chance to earn a ticket, starting at 15% at level 1 and scaling up to 35% at level 99 in the matching skill. Upgrading the {fairgrounds_link} building further increases this chance.
 
 {idle_table}
 
-**Active minigames** are played directly and reward more tickets on Hard difficulty. Each has its own cooldown between attempts — 10 minutes by default — so you can rotate between all of them back-to-back. Upgrading the Fairgrounds building shortens this: 7.5 minutes at tier 1, down to 5 minutes at tier 3.
+**Active minigames** are played directly and reward more tickets on Hard difficulty. Each has its own cooldown between attempts — 10 minutes by default — so you can rotate between all of them back-to-back. Upgrading the {fairgrounds_link} building provides bonuses such as additional games and reduced cooldowns.
 
 {active_table}
 


### PR DESCRIPTION
## Before submitting

- [x] I've tested any changes with the appropriate tests (eg. Unit tests, validation scripts)
- [x] I've pulled and merged the latest changes from the repository

## Summary

<!-- Short summary of the pull request and what it changes -->

Found some errors in the wiki, decided to update them. Did a whole sweep on the wiki, here is the list of changes.

**Minor Fixes**

- **Farming** - oak ashes yield bonus was rendered as +25%.
- **Mercenary Camp** - contracts last a flat 24h from hire, not "until your next daily reset"
- **Construction** - per-item time is driven by Agility level (60s at Agility 1 → 40s at Agility 99, further reduced by Chronos Spire / Endurance), not a fixed 60s.
- **Spells** - called out that the Void Staff grants infinite runes of *all* types, not just one.
- **Crafting** - dropped "and other items"; every current recipe is jewellery.
- **Slayer shop** - added the missing Slayer Plateskirt and point costs for every shop item.
- **Fletching** - intro now covers magic staves and planks (previously only bows/arrows).

**New content**

- **Prayer** - documented the Church blessings system (XP / Defence / Coin tables, blessing duration and the boosts that extend it, and the Bone Altar combo mechanic.
- **Slayer** - documented the Foretell task-queue system and the Foresight prestige path.
- **Herblore** - explained what an "enhanced" potion actually does and added an *Enhanced Effect* column to the potion table; noted the 1-ash-per-brew cost.
- **Thieving** - noted the stun + skipped frame on a failed pickpocket.
- **Carnival** - noted the Fairgrounds building reduces the active-minigame cooldown (10 → 7.5 → 5 min).

**Contributing docs**

- **Getting Started - Game** - added a "Repository rules" section (localise strings, no DB migrations, no new deps, one fix per PR) and noted an issue is fine for smaller features.
- **Getting Started - Wiki** - added `validation.py` and `wiki_logs.py` to the code-structure list.

Ran `python -m wiki.src validity` - passes.

## Related issue(s) or discussion(s)

<!-- Prepend issues with "Fixes" if this should close the issue, e.g. Fixes #283, Relates to #284 -->

N/A

## Changelog

<!-- Concise list of changes -->

- Fixed and expanded wiki content across the Prayer, Slayer, Fletching, Herblore, Thieving, Construction, Crafting, Spells, Mercenary Camp Church, Contributing, Farming, Slayer and Carnival pages

## Anything else?
