### PR TITLE
Add ordering options to sell screen

### DIFF
--- a/app/src/main/kotlin/com/fantasyidler/simulator/CombatSimulator.kt
+++ b/app/src/main/kotlin/com/fantasyidler/simulator/CombatSimulator.kt
@@ -266,8 +266,8 @@ object CombatSimulator {
                     break
                 }
 
-                // Always eat the best-tier food still in stock first; only fall back to a
-                // weaker tier once the best one runs out, up to 300 items total.
+                // Eats food based on the selected order, and move to next in list
+                // when the current selected one runs out, up to 300 items total.
                 val hpBeforeEating = currentHp
                 var ate = true
                 while (ate && totalFoodEaten < 300) {
@@ -660,8 +660,8 @@ object CombatSimulator {
                     break@outer
                 }
 
-                // Always eat the best-tier food still in stock first; only fall back to a
-                // weaker tier once the best one runs out, up to 300 items total.
+                // Eats food based on the selected order, and move to next in list
+                // when the current selected one runs out, up to 300 items total.
                 val hpBeforeEating = currentHp
                 var ate = true
                 while (ate && totalFoodEaten < 300) {

--- a/app/src/main/kotlin/com/fantasyidler/ui/screen/ShopScreen.kt
+++ b/app/src/main/kotlin/com/fantasyidler/ui/screen/ShopScreen.kt
@@ -356,6 +356,12 @@ private fun BuyList(
 
 private val SELL_CATEGORY_ORDER = listOf("Weapons", "Armor", "Tools", "Food", "Materials", "Misc")
 
+private enum class SellOrder(val labelRes: Int) {
+    DEFAULT(R.string.shop_order_default),
+    HIGHEST_AMOUNT(R.string.shop_order_highest_amount),
+    HIGHEST_PRICE(R.string.shop_order_highest_price),
+}
+
 @OptIn(ExperimentalLayoutApi::class, ExperimentalFoundationApi::class)
 @Composable
 private fun SellList(
@@ -376,6 +382,7 @@ private fun SellList(
 ) {
     var query by remember { mutableStateOf("") }
     var selectedCategory by remember { mutableStateOf<String?>(null) }
+    var selectedOrder by remember { mutableStateOf(SellOrder.DEFAULT) }
     var showReceipts by remember { mutableStateOf(false) }
 
     if (showReceipts) {
@@ -417,7 +424,12 @@ private fun SellList(
         )
     }
 
-    val grouped = remember(inventory, query, selectedCategory) {
+    val grouped = remember(inventory, query, selectedCategory, selectedOrder) {
+        val comparator = when (selectedOrder) {
+            SellOrder.DEFAULT -> compareBy<Triple<String, Int, String>> { it.third }
+            SellOrder.HIGHEST_AMOUNT -> compareByDescending<Triple<String, Int, String>> { it.second }
+            SellOrder.HIGHEST_PRICE -> compareByDescending<Triple<String, Int, String>> { priceFor(it.first) }
+        }
         inventory.entries
             .filter { it.key != "coins" }
             .map { Triple(it.key, it.value, GameStrings.itemName(context, it.key)) }
@@ -426,7 +438,9 @@ private fun SellList(
             .filterKeys { selectedCategory == null || it == selectedCategory }
             .entries
             .sortedBy { SELL_CATEGORY_ORDER.indexOf(it.key).let { i -> if (i < 0) Int.MAX_VALUE else i } }
-            .map { (category, entries) -> category to entries.sortedBy { (_, _, name) -> name } }
+            .map { (category, entries) ->
+                category to entries.sortedWith(comparator.thenBy { it.third }.thenBy { it.first })
+            }
     }
     val presentCategories = remember(inventory) {
         inventory.keys.filter { it != "coins" }.map(categoryFor).distinct()
@@ -497,6 +511,21 @@ private fun SellList(
                         selected = selectedCategory == category,
                         onClick  = { selectedCategory = if (selectedCategory == category) null else category },
                         label    = { Text(localizedCategory(context, category)) },
+                    )
+                }
+            }
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .horizontalScroll(rememberScrollState())
+                    .padding(horizontal = 16.dp),
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
+                SellOrder.entries.forEach { order ->
+                    FilterChip(
+                        selected = selectedOrder == order,
+                        onClick = { selectedOrder = order },
+                        label = { Text(stringResource(order.labelRes)) },
                     )
                 }
             }

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -713,6 +713,9 @@
     <string name="shop_keep_one_toggle">Keep one of each item</string> <!-- untranslated -->
     <string name="shop_search_hint">Search items</string> <!-- untranslated -->
     <string name="shop_filter_all">All</string> <!-- untranslated -->
+    <string name="shop_order_default">Default</string> <!-- untranslated -->
+    <string name="shop_order_highest_amount">Quantity</string> <!-- untranslated -->
+    <string name="shop_order_highest_price">Price</string> <!-- untranslated -->
     <string name="shop_sell_blocked_equipped">%1$s is equipped. Unequip it first to sell.</string> <!-- untranslated -->
     <string name="shop_sell_blocked_reserved">%1$s is reserved for a queued task.</string> <!-- untranslated -->
     <string name="shop_sell_blocked_keep_one">Keeping your last %1$s (Keep one of each item is on).</string> <!-- untranslated -->

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -713,6 +713,9 @@
     <string name="shop_keep_one_toggle">Keep one of each item</string> <!-- untranslated -->
     <string name="shop_search_hint">Search items</string> <!-- untranslated -->
     <string name="shop_filter_all">All</string> <!-- untranslated -->
+    <string name="shop_order_default">Default</string> <!-- untranslated -->
+    <string name="shop_order_highest_amount">Quantity</string> <!-- untranslated -->
+    <string name="shop_order_highest_price">Price</string> <!-- untranslated -->
     <string name="shop_sell_blocked_equipped">%1$s is equipped. Unequip it first to sell.</string> <!-- untranslated -->
     <string name="shop_sell_blocked_reserved">%1$s is reserved for a queued task.</string> <!-- untranslated -->
     <string name="shop_sell_blocked_keep_one">Keeping your last %1$s (Keep one of each item is on).</string> <!-- untranslated -->

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -725,6 +725,9 @@
     <string name="shop_keep_one_toggle">Keep one of each item</string> <!-- untranslated -->
     <string name="shop_search_hint">Search items</string> <!-- untranslated -->
     <string name="shop_filter_all">All</string> <!-- untranslated -->
+    <string name="shop_order_default">Default</string> <!-- untranslated -->
+    <string name="shop_order_highest_amount">Quantity</string> <!-- untranslated -->
+    <string name="shop_order_highest_price">Price</string> <!-- untranslated -->
     <string name="shop_sell_blocked_equipped">%1$s is equipped. Unequip it first to sell.</string> <!-- untranslated -->
     <string name="shop_sell_blocked_reserved">%1$s is reserved for a queued task.</string> <!-- untranslated -->
     <string name="shop_sell_blocked_keep_one">Keeping your last %1$s (Keep one of each item is on).</string> <!-- untranslated -->

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -713,6 +713,9 @@
     <string name="shop_keep_one_toggle">Eins von jedem Gegenstand behalten</string>
     <string name="shop_search_hint">Gegenstand suchen</string>
     <string name="shop_filter_all">Alles</string>
+    <string name="shop_order_default">Default</string> <!-- untranslated -->
+    <string name="shop_order_highest_amount">Quantity</string> <!-- untranslated -->
+    <string name="shop_order_highest_price">Price</string> <!-- untranslated -->
     <string name="shop_sell_blocked_equipped">%1$s ist ausgerüstet. Vor dem Verkauf muss es abgelegt werden.</string>
     <string name="shop_sell_blocked_reserved">%1$s ist für Auftrag in Warteschlange reserviert.</string>
     <string name="shop_sell_blocked_keep_one">Den letzten %1$s behalten (Eins von jedem Gegenstand behalten ist aktiv).</string>

--- a/app/src/main/res/values-es-rES/strings.xml
+++ b/app/src/main/res/values-es-rES/strings.xml
@@ -713,6 +713,9 @@
     <string name="shop_keep_one_toggle">Keep one of each item</string> <!-- untranslated -->
     <string name="shop_search_hint">Search items</string> <!-- untranslated -->
     <string name="shop_filter_all">All</string> <!-- untranslated -->
+    <string name="shop_order_default">Default</string> <!-- untranslated -->
+    <string name="shop_order_highest_amount">Quantity</string> <!-- untranslated -->
+    <string name="shop_order_highest_price">Price</string> <!-- untranslated -->
     <string name="shop_sell_blocked_equipped">%1$s is equipped. Unequip it first to sell.</string> <!-- untranslated -->
     <string name="shop_sell_blocked_reserved">%1$s is reserved for a queued task.</string> <!-- untranslated -->
     <string name="shop_sell_blocked_keep_one">Keeping your last %1$s (Keep one of each item is on).</string> <!-- untranslated -->

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -713,6 +713,9 @@
     <string name="shop_keep_one_toggle">Keep one of each item</string> <!-- untranslated -->
     <string name="shop_search_hint">Search items</string> <!-- untranslated -->
     <string name="shop_filter_all">All</string> <!-- untranslated -->
+    <string name="shop_order_default">Default</string> <!-- untranslated -->
+    <string name="shop_order_highest_amount">Quantity</string> <!-- untranslated -->
+    <string name="shop_order_highest_price">Price</string> <!-- untranslated -->
     <string name="shop_sell_blocked_equipped">%1$s is equipped. Unequip it first to sell.</string> <!-- untranslated -->
     <string name="shop_sell_blocked_reserved">%1$s is reserved for a queued task.</string> <!-- untranslated -->
     <string name="shop_sell_blocked_keep_one">Keeping your last %1$s (Keep one of each item is on).</string> <!-- untranslated -->

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -714,6 +714,9 @@
     <string name="shop_keep_one_toggle">Garder un objet de chaque</string>
     <string name="shop_search_hint">Chercher les objets</string>
     <string name="shop_filter_all">Tout</string>
+    <string name="shop_order_default">Default</string> <!-- untranslated -->
+    <string name="shop_order_highest_amount">Quantity</string> <!-- untranslated -->
+    <string name="shop_order_highest_price">Price</string> <!-- untranslated -->
     <string name="shop_sell_blocked_equipped">%1$s est équipé. Déséquipez-le d\'abord pour le vendre.</string>
     <string name="shop_sell_blocked_reserved">%1$s est réservé pour une tâche en attente.</string>
     <string name="shop_sell_blocked_keep_one">Gardez votre dernière %1$s (Garder un objet de chaque est activé).</string>

--- a/app/src/main/res/values-ga/strings.xml
+++ b/app/src/main/res/values-ga/strings.xml
@@ -741,6 +741,9 @@
     <string name="shop_keep_one_toggle">Keep one of each item</string> <!-- untranslated -->
     <string name="shop_search_hint">Search items</string> <!-- untranslated -->
     <string name="shop_filter_all">All</string> <!-- untranslated -->
+    <string name="shop_order_default">Default</string> <!-- untranslated -->
+    <string name="shop_order_highest_amount">Quantity</string> <!-- untranslated -->
+    <string name="shop_order_highest_price">Price</string> <!-- untranslated -->
     <string name="shop_sell_blocked_equipped">%1$s is equipped. Unequip it first to sell.</string> <!-- untranslated -->
     <string name="shop_sell_blocked_reserved">%1$s is reserved for a queued task.</string> <!-- untranslated -->
     <string name="shop_sell_blocked_keep_one">Keeping your last %1$s (Keep one of each item is on).</string> <!-- untranslated -->

--- a/app/src/main/res/values-he/strings.xml
+++ b/app/src/main/res/values-he/strings.xml
@@ -713,6 +713,9 @@
     <string name="shop_keep_one_toggle">Keep one of each item</string> <!-- untranslated -->
     <string name="shop_search_hint">Search items</string> <!-- untranslated -->
     <string name="shop_filter_all">All</string> <!-- untranslated -->
+    <string name="shop_order_default">Default</string> <!-- untranslated -->
+    <string name="shop_order_highest_amount">Quantity</string> <!-- untranslated -->
+    <string name="shop_order_highest_price">Price</string> <!-- untranslated -->
     <string name="shop_sell_blocked_equipped">%1$s is equipped. Unequip it first to sell.</string> <!-- untranslated -->
     <string name="shop_sell_blocked_reserved">%1$s is reserved for a queued task.</string> <!-- untranslated -->
     <string name="shop_sell_blocked_keep_one">Keeping your last %1$s (Keep one of each item is on).</string> <!-- untranslated -->

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -705,6 +705,9 @@
     <string name="shop_keep_one_toggle">Keep one of each item</string> <!-- untranslated -->
     <string name="shop_search_hint">Search items</string> <!-- untranslated -->
     <string name="shop_filter_all">All</string> <!-- untranslated -->
+    <string name="shop_order_default">Default</string> <!-- untranslated -->
+    <string name="shop_order_highest_amount">Quantity</string> <!-- untranslated -->
+    <string name="shop_order_highest_price">Price</string> <!-- untranslated -->
     <string name="shop_sell_blocked_equipped">%1$s is equipped. Unequip it first to sell.</string> <!-- untranslated -->
     <string name="shop_sell_blocked_reserved">%1$s is reserved for a queued task.</string> <!-- untranslated -->
     <string name="shop_sell_blocked_keep_one">Keeping your last %1$s (Keep one of each item is on).</string> <!-- untranslated -->

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -713,6 +713,9 @@
     <string name="shop_keep_one_toggle">Mantieni una copia per ogni oggetto</string>
     <string name="shop_search_hint">Cerca oggetti</string>
     <string name="shop_filter_all">Tutti</string>
+    <string name="shop_order_default">Default</string> <!-- untranslated -->
+    <string name="shop_order_highest_amount">Quantity</string> <!-- untranslated -->
+    <string name="shop_order_highest_price">Price</string> <!-- untranslated -->
     <string name="shop_sell_blocked_equipped">Stai usando %1$s. Non puoi venderlo finché non lo lasci.</string>
     <string name="shop_sell_blocked_reserved">%1$s è di riserva per un\'azione in coda.</string>
     <string name="shop_sell_blocked_keep_one">Una copia di %1$s è rimasta (L\'opzione è abilitata).</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -713,6 +713,9 @@
     <string name="shop_keep_one_toggle">Keep one of each item</string> <!-- untranslated -->
     <string name="shop_search_hint">Search items</string> <!-- untranslated -->
     <string name="shop_filter_all">All</string> <!-- untranslated -->
+    <string name="shop_order_default">Default</string> <!-- untranslated -->
+    <string name="shop_order_highest_amount">Quantity</string> <!-- untranslated -->
+    <string name="shop_order_highest_price">Price</string> <!-- untranslated -->
     <string name="shop_sell_blocked_equipped">%1$s is equipped. Unequip it first to sell.</string> <!-- untranslated -->
     <string name="shop_sell_blocked_reserved">%1$s is reserved for a queued task.</string> <!-- untranslated -->
     <string name="shop_sell_blocked_keep_one">Keeping your last %1$s (Keep one of each item is on).</string> <!-- untranslated -->

--- a/app/src/main/res/values-lt/strings.xml
+++ b/app/src/main/res/values-lt/strings.xml
@@ -713,6 +713,9 @@
     <string name="shop_keep_one_toggle">Keep one of each item</string> <!-- untranslated -->
     <string name="shop_search_hint">Search items</string> <!-- untranslated -->
     <string name="shop_filter_all">All</string> <!-- untranslated -->
+    <string name="shop_order_default">Default</string> <!-- untranslated -->
+    <string name="shop_order_highest_amount">Quantity</string> <!-- untranslated -->
+    <string name="shop_order_highest_price">Price</string> <!-- untranslated -->
     <string name="shop_sell_blocked_equipped">%1$s is equipped. Unequip it first to sell.</string> <!-- untranslated -->
     <string name="shop_sell_blocked_reserved">%1$s is reserved for a queued task.</string> <!-- untranslated -->
     <string name="shop_sell_blocked_keep_one">Keeping your last %1$s (Keep one of each item is on).</string> <!-- untranslated -->

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -713,6 +713,9 @@
     <string name="shop_keep_one_toggle">Keep one of each item</string> <!-- untranslated -->
     <string name="shop_search_hint">Search items</string> <!-- untranslated -->
     <string name="shop_filter_all">All</string> <!-- untranslated -->
+    <string name="shop_order_default">Default</string> <!-- untranslated -->
+    <string name="shop_order_highest_amount">Quantity</string> <!-- untranslated -->
+    <string name="shop_order_highest_price">Price</string> <!-- untranslated -->
     <string name="shop_sell_blocked_equipped">%1$s is equipped. Unequip it first to sell.</string> <!-- untranslated -->
     <string name="shop_sell_blocked_reserved">%1$s is reserved for a queued task.</string> <!-- untranslated -->
     <string name="shop_sell_blocked_keep_one">Keeping your last %1$s (Keep one of each item is on).</string> <!-- untranslated -->

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -729,6 +729,9 @@
     <string name="shop_keep_one_toggle">Zachowaj po jednym z każdego przedmiotu</string>
     <string name="shop_search_hint">Wyszukaj przedmioty</string>
     <string name="shop_filter_all">Wszystko</string>
+    <string name="shop_order_default">Default</string> <!-- untranslated -->
+    <string name="shop_order_highest_amount">Quantity</string> <!-- untranslated -->
+    <string name="shop_order_highest_price">Price</string> <!-- untranslated -->
     <string name="shop_sell_blocked_equipped">%1$s jest wyposażony. Najpierw go zdejmij, aby sprzedać.</string>
     <string name="shop_sell_blocked_reserved">%1$s jest zarezerwowany dla zadania w kolejce.</string>
     <string name="shop_sell_blocked_keep_one">Keeping your last %1$s (Keep one of each item is on).</string> <!-- untranslated -->

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -713,6 +713,9 @@
     <string name="shop_keep_one_toggle">Keep one of each item</string> <!-- untranslated -->
     <string name="shop_search_hint">Search items</string> <!-- untranslated -->
     <string name="shop_filter_all">All</string> <!-- untranslated -->
+    <string name="shop_order_default">Default</string> <!-- untranslated -->
+    <string name="shop_order_highest_amount">Quantity</string> <!-- untranslated -->
+    <string name="shop_order_highest_price">Price</string> <!-- untranslated -->
     <string name="shop_sell_blocked_equipped">%1$s is equipped. Unequip it first to sell.</string> <!-- untranslated -->
     <string name="shop_sell_blocked_reserved">%1$s is reserved for a queued task.</string> <!-- untranslated -->
     <string name="shop_sell_blocked_keep_one">Keeping your last %1$s (Keep one of each item is on).</string> <!-- untranslated -->

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -731,6 +731,9 @@
     <string name="shop_keep_one_toggle">Оставлять по одному предмету</string>
     <string name="shop_search_hint">Искать предметы</string>
     <string name="shop_filter_all">Все</string>
+    <string name="shop_order_default">Default</string> <!-- untranslated -->
+    <string name="shop_order_highest_amount">Quantity</string> <!-- untranslated -->
+    <string name="shop_order_highest_price">Price</string> <!-- untranslated -->
     <string name="shop_sell_blocked_equipped">%1$s предмет надет. Чтобы продать, нужно сначала снять предмет.</string>
     <string name="shop_sell_blocked_reserved">%1$s зарезервирован для задачи в очереди</string>
     <string name="shop_sell_blocked_keep_one">Оставляем последний %1$s (Оставлять по одному предмету включено).</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -713,6 +713,9 @@
     <string name="shop_keep_one_toggle">Keep one of each item</string> <!-- untranslated -->
     <string name="shop_search_hint">Search items</string> <!-- untranslated -->
     <string name="shop_filter_all">All</string> <!-- untranslated -->
+    <string name="shop_order_default">Default</string> <!-- untranslated -->
+    <string name="shop_order_highest_amount">Quantity</string> <!-- untranslated -->
+    <string name="shop_order_highest_price">Price</string> <!-- untranslated -->
     <string name="shop_sell_blocked_equipped">%1$s is equipped. Unequip it first to sell.</string> <!-- untranslated -->
     <string name="shop_sell_blocked_reserved">%1$s is reserved for a queued task.</string> <!-- untranslated -->
     <string name="shop_sell_blocked_keep_one">Keeping your last %1$s (Keep one of each item is on).</string> <!-- untranslated -->

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -713,6 +713,9 @@
     <string name="shop_keep_one_toggle">每种物品保留一个</string>
     <string name="shop_search_hint">搜索物品</string>
     <string name="shop_filter_all">全部</string>
+    <string name="shop_order_default">Default</string> <!-- untranslated -->
+    <string name="shop_order_highest_amount">Quantity</string> <!-- untranslated -->
+    <string name="shop_order_highest_price">Price</string> <!-- untranslated -->
     <string name="shop_sell_blocked_equipped">%1$s 已装备，请先卸下再出售。</string>
     <string name="shop_sell_blocked_reserved">%1$s 被排队任务占用。</string>
     <string name="shop_sell_blocked_keep_one">保留最后一件 %1$s（每种保留一个已开启）。</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -713,6 +713,9 @@
     <string name="shop_keep_one_toggle">Keep one of each item</string>
     <string name="shop_search_hint">Search items</string>
     <string name="shop_filter_all">All</string>
+    <string name="shop_order_default">Default</string>
+    <string name="shop_order_highest_amount">Quantity</string>
+    <string name="shop_order_highest_price">Price</string>
     <string name="shop_sell_blocked_equipped">%1$s is equipped. Unequip it first to sell.</string>
     <string name="shop_sell_blocked_reserved">%1$s is reserved for a queued task.</string>
     <string name="shop_sell_blocked_keep_one">Keeping your last %1$s (Keep one of each item is on).</string>


### PR DESCRIPTION
## Before submitting

- [x] I've tested any changes with the appropriate tests (eg. Unit tests, validation scripts)
- [x] I've pulled and merged the latest changes from the repository

## Summary

Added two options to order by highest value and highest count in shop->sell tab


## Related issue(s) or discussion(s)

none


## Changelog

- added 2 sort options to sell tab
- added keys/values to strings.xml for all locales
- a comment change in unrelated file to the feature in this pull

## Anything else?

- changed unrelated to the current pull comment in [app/src/main/kotlin/com/fantasyidler/simulator/CombatSimulator.kt] since logic changed and didnt want to create separate pull just to change a comment.