### PR TITLE
Add the total combat attack, strength and defense to gear screen

### DIFF
--- a/app/src/main/kotlin/com/fantasyidler/ui/screen/CombatScreen.kt
+++ b/app/src/main/kotlin/com/fantasyidler/ui/screen/CombatScreen.kt
@@ -265,6 +265,9 @@ fun CombatScreen(
                             allEquipment   = invState.resolvedEquipment(inventoryVm.allEquipment),
                             heirloomXp     = invState.heirloomXp,
                             context        = context,
+                            totalAttack    = state.totalAttack,
+                            totalStrength  = state.totalStrength,
+                            totalDefense   = state.totalDefense,
                             activeWeaponSlot    = state.selectedWeaponSlot,
                             foodEatThresholdPct = invState.foodEatThresholdPct,
                             foodEatOrder        = invState.foodEatOrder,
@@ -357,6 +360,9 @@ fun CombatScreen(
                             allEquipment   = invState.resolvedEquipment(inventoryVm.allEquipment),
                             heirloomXp     = invState.heirloomXp,
                             context        = context,
+                            totalAttack    = state.totalAttack,
+                            totalStrength  = state.totalStrength,
+                            totalDefense   = state.totalDefense,
                             activeWeaponSlot    = state.selectedWeaponSlot,
                             foodEatThresholdPct = invState.foodEatThresholdPct,
                             foodEatOrder        = invState.foodEatOrder,
@@ -632,6 +638,9 @@ private fun CombatGearTab(
     allEquipment: Map<String, EquipmentData>,
     heirloomXp: Map<String, Long>,
     context: Context,
+    totalAttack: Int,
+    totalStrength: Int,
+    totalDefense: Int,
     activeWeaponSlot: String?,
     foodEatThresholdPct: Int,
     foodEatOrder: String,
@@ -693,6 +702,16 @@ private fun CombatGearTab(
                     )
                 }
             }
+        }
+        item {
+            Text(
+                text = "${stringResource(R.string.combat_atk)} $totalAttack  " +
+                    "${stringResource(R.string.combat_str)} $totalStrength  " +
+                    "${stringResource(R.string.combat_def)} $totalDefense",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
+            )
         }
         // Only the active style's own weapon is shown/selectable here — never another
         // style's weapon, since each style has its own separate weapon slot.

--- a/app/src/main/kotlin/com/fantasyidler/ui/viewmodel/CombatViewModel.kt
+++ b/app/src/main/kotlin/com/fantasyidler/ui/viewmodel/CombatViewModel.kt
@@ -82,6 +82,9 @@ data class CombatUiState(
     val snackbarMessage: String? = null,
     /** Non-null when a new pet was found; drives the pet-found dialog. Consumed by the UI. */
     val petFoundName: String? = null,
+    val totalAttack: Int = 0,
+    val totalStrength: Int = 0,
+    val totalDefense: Int = 0,
     val totalAttackBonus: Int = 0,
     val totalStrengthBonus: Int = 0,
     val totalDefenseBonus: Int = 0,
@@ -261,6 +264,18 @@ class CombatViewModel @Inject constructor(
                 else     -> equippedWeapon?.strengthBonus ?: 0
             }
             val totalDef = armorDef + (equippedWeapon?.defenseBonus  ?: 0)
+            val potionKey = extra.selectedPotionKey ?: flags.activePotionKey
+            val potionBonuses = potionKey?.takeIf { (inventory[it] ?: 0) > 0 }
+                ?.let { boostRepo.boostedPotionEffects(flags, gameData.potionEffects[it] ?: emptyMap()) } ?: emptyMap()
+            fun effectiveLevel(skill: String): Int = (levels[skill] ?: 1) +
+                boostRepo.combatStatBonus(skill, flags, levels[skill] ?: 1) +
+                (potionBonuses[skill] ?: 0)
+            val attackSkill = when (displayStyle) {
+                "ranged" -> Skills.RANGED
+                "magic" -> Skills.MAGIC
+                else -> Skills.ATTACK
+            }
+            val spell = extra.selectedSpell ?: flags.activeSpell?.let { gameData.spells[it] }
             val skillLevels = playerRepo.getSkillLevels()
             extra.copy(
                 isLoading               = false,
@@ -272,6 +287,15 @@ class CombatViewModel @Inject constructor(
                 equippedWeapons         = equippedWeapons,
                 selectedWeaponSlot      = activeWeaponSlot,
                 combatSession           = combatSession,
+                totalAttack             = effectiveLevel(attackSkill) + totalAtk,
+                totalStrength           = when (displayStyle) {
+                    "ranged" -> effectiveLevel(Skills.RANGED) + totalStr
+                    "magic" -> (spell?.maxHit ?: 0) + (equippedWeapon?.magicDamageBonus ?: 0) +
+                        EquipSlot.ARMOR_SLOTS.sumOf { equipMap[equipped[it]]?.magicDamageBonus ?: 0 }
+                    else -> effectiveLevel(Skills.STRENGTH) + totalStr
+                },
+                totalDefense            = effectiveLevel(Skills.DEFENSE) + totalDef +
+                    ChurchRepository.defBonus(flags, blessingPrayerCapeMult(flags, equipped, inventory.keys, gameData)),
                 totalAttackBonus        = totalAtk,
                 totalStrengthBonus      = totalStr,
                 totalDefenseBonus       = totalDef,


### PR DESCRIPTION
## Before submitting

- [x] I've tested any changes with the appropriate tests (eg. Unit tests, validation scripts)
- [x] I've pulled and merged the latest changes from the repository

## Summary

Added the total combat attack, strength and defense for the selected combat style to the gear screen. So you dont have to start a combat session to see what total stats you have with the equipped items for the combat style you have selected.


## Related issue(s) or discussion(s)

none


## Changelog

Added combat style's attack strength and defense in gear screen.


## Anything else

I saw that the code doesnt show the added bonus for arrows in the total stats, just uses it when calculates the dmg, so i left if same/unchanged for the gear screen. But maybe it should be changed to show it?! But since the stats are cached when u start a combat session, i decided not to touch it, until its decided to be shown and dynamically added on top of the total so it can change when u ran out of one type of arrows and change to another type mid combat.