### PR TITLE
feature: align combat XP display with skills, show XP to 99 near cap

### DIFF
--- a/app/src/main/kotlin/com/fantasyidler/ui/screen/CombatScreen.kt
+++ b/app/src/main/kotlin/com/fantasyidler/ui/screen/CombatScreen.kt
@@ -95,7 +95,10 @@ import com.fantasyidler.ui.theme.ScaledSheetContent
 import com.fantasyidler.ui.viewmodel.CombatViewModel
 import com.fantasyidler.ui.viewmodel.InventoryViewModel
 import com.fantasyidler.ui.viewmodel.combatLevelFrom
+import com.fantasyidler.ui.viewmodel.nextLevelThreshold
 import com.fantasyidler.ui.viewmodel.xpProgressFraction
+import com.fantasyidler.ui.viewmodel.xpToMaxLevel
+import com.fantasyidler.ui.viewmodel.xpToNextLevel
 import com.fantasyidler.util.GameStrings
 import com.fantasyidler.util.formatXp
 
@@ -975,35 +978,28 @@ private fun CombatSkillRow(
         }
         Spacer(Modifier.width(12.dp))
         Column(Modifier.weight(1f)) {
-            Row(modifier = Modifier.fillMaxWidth()) {
-                // FlowRow + weight(1f): long localised bonus labels wrap to the next line
-                // instead of being starved into a one-letter-per-line sliver that also
-                // pushed the XP value out of view (issue #1765).
-                FlowRow(
-                    modifier              = Modifier.weight(1f),
-                    horizontalArrangement = Arrangement.spacedBy(6.dp),
-                ) {
-                    Text(name, style = MaterialTheme.typography.bodyLarge, fontWeight = FontWeight.Medium)
-                    if (gearBonus > 0) {
-                        Text(
-                            text     = stringResource(R.string.combat_gear_bonus, gearBonus),
-                            style    = MaterialTheme.typography.labelSmall,
-                            color    = MaterialTheme.colorScheme.primary,
-                            modifier = Modifier.align(Alignment.CenterVertically),
-                        )
-                    }
-                    if (prestigeBonus > 0) {
-                        Text(
-                            text     = stringResource(R.string.combat_prestige_bonus, prestigeBonus),
-                            style    = MaterialTheme.typography.labelSmall,
-                            color    = MaterialTheme.colorScheme.primary,
-                            modifier = Modifier.align(Alignment.CenterVertically),
-                        )
-                    }
-                }
-                Spacer(Modifier.width(8.dp))
+            Row(
+                modifier              = Modifier.fillMaxWidth(),
+                verticalAlignment     = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.SpaceBetween,
+            ) {
                 Text(
-                    text  = "${xp.formatXp()} ${stringResource(R.string.label_xp)}",
+                    text       = name,
+                    style      = MaterialTheme.typography.bodyLarge,
+                    fontWeight = FontWeight.Medium,
+                    modifier   = Modifier.weight(1f, fill = false),
+                )
+                Spacer(Modifier.width(8.dp))
+                val remainingToCap = xpToMaxLevel(xp)
+                val xpText = when {
+                    remainingToCap in 1 until 100_000L ->
+                        stringResource(R.string.xp_to_99, remainingToCap.formatXp())
+                    xpToNextLevel(xp) > 0L ->
+                        "${xp.formatXp()} / ${nextLevelThreshold(xp).formatXp()} XP"
+                    else -> "${xp.formatXp()} ${stringResource(R.string.label_xp)}"
+                }
+                Text(
+                    text  = xpText,
                     style = MaterialTheme.typography.bodySmall,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                 )
@@ -1020,8 +1016,29 @@ private fun CombatSkillRow(
                 color            = MaterialTheme.colorScheme.primary,
                 trackColor       = MaterialTheme.colorScheme.surfaceVariant,
             )
+            if (gearBonus > 0 || prestigeBonus > 0) {
+                Spacer(Modifier.height(6.dp))
+                FlowRow(
+                    modifier              = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.spacedBy(6.dp),
+                ) {
+                    if (gearBonus > 0) {
+                        Text(
+                            text  = stringResource(R.string.combat_gear_bonus, gearBonus),
+                            style = MaterialTheme.typography.labelSmall,
+                            color = MaterialTheme.colorScheme.primary,
+                        )
+                    }
+                    if (prestigeBonus > 0) {
+                        Text(
+                            text  = stringResource(R.string.combat_prestige_bonus, prestigeBonus),
+                            style = MaterialTheme.typography.labelSmall,
+                            color = MaterialTheme.colorScheme.primary,
+                        )
+                    }
+                }
+            }
             if (prestigeLevel > 0 || (onOpenPrestige != null && level >= 99)) {
-                Spacer(Modifier.height(4.dp))
                 Row(
                     modifier              = Modifier.fillMaxWidth(),
                     verticalAlignment     = Alignment.CenterVertically,

--- a/app/src/main/kotlin/com/fantasyidler/ui/screen/SkillsScreen.kt
+++ b/app/src/main/kotlin/com/fantasyidler/ui/screen/SkillsScreen.kt
@@ -103,6 +103,7 @@ import com.fantasyidler.ui.viewmodel.SkillsUiState
 import com.fantasyidler.ui.viewmodel.SkillsViewModel
 import com.fantasyidler.ui.viewmodel.xpProgressFraction
 import com.fantasyidler.ui.viewmodel.nextLevelThreshold
+import com.fantasyidler.ui.viewmodel.xpToMaxLevel
 import com.fantasyidler.ui.viewmodel.xpToNextLevel
 import com.fantasyidler.util.GameStrings
 import com.fantasyidler.util.toTitleCase
@@ -1010,10 +1011,14 @@ internal fun SkillRow(
                             color = MaterialTheme.colorScheme.primary,
                         )
                     } else {
-                        val xpText = if (xpToNextLevel(xp) > 0L)
-                            "${xp.formatXp()} / ${nextLevelThreshold(xp).formatXp()} XP"
-                        else
-                            "${xp.formatXp()} XP"
+                        val remainingToCap = xpToMaxLevel(xp)
+                        val xpText = when {
+                            remainingToCap in 1 until 100_000L ->
+                                stringResource(R.string.xp_to_99, remainingToCap.formatXp())
+                            xpToNextLevel(xp) > 0L ->
+                                "${xp.formatXp()} / ${nextLevelThreshold(xp).formatXp()} XP"
+                            else -> "${xp.formatXp()} XP"
+                        }
                         Text(
                             text  = xpText,
                             style = MaterialTheme.typography.bodySmall,

--- a/app/src/main/kotlin/com/fantasyidler/ui/viewmodel/SkillsViewModel.kt
+++ b/app/src/main/kotlin/com/fantasyidler/ui/viewmodel/SkillsViewModel.kt
@@ -1543,3 +1543,6 @@ fun xpToNextLevel(xp: Long): Long = XpTable.xpToNextLevel(xp)
 
 /** Total XP required for the next level (absolute threshold). */
 fun nextLevelThreshold(xp: Long): Long = XpTable.nextLevelThreshold(xp)
+
+/** XP still needed to reach level 99 (the level cap), or 0 if already there. */
+fun xpToMaxLevel(xp: Long): Long = (XpTable.xpForLevel(99) - xp).coerceAtLeast(0L)

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -202,6 +202,7 @@
     <string name="format_level_xp">مستوى %1$d — %2$s نقاط</string>
     <!-- Translator note: %1$s = formatted XP amount, %2$d = target level number -->
     <string name="format_xp_to_next">%1$s نقاط للمستوى %2$d</string>
+    <string name="xp_to_99">%1$s XP to 99</string> <!-- untranslated -->
     <!-- Translator note: %1$s = time string (e.g. "42m 10s") -->
     <string name="format_time_remaining">%1$s متبقي</string>
     <!-- Translator note: %1$s = relative time (e.g. "5m ago") -->

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -202,6 +202,7 @@
     <string name="format_level_xp">Level %1$d — %2$s XP</string> <!-- untranslated -->
     <!-- Translator note: %1$s = formatted XP amount, %2$d = target level number -->
     <string name="format_xp_to_next">%1$s XP to level %2$d</string> <!-- untranslated -->
+    <string name="xp_to_99">%1$s XP to 99</string> <!-- untranslated -->
     <!-- Translator note: %1$s = time string (e.g. "42m 10s") -->
     <string name="format_time_remaining">%1$s remaining</string> <!-- untranslated -->
     <!-- Translator note: %1$s = relative time (e.g. "5m ago") -->

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -202,6 +202,7 @@
     <string name="format_level_xp">Úroveň %1$d — %2$s XP</string>
     <!-- Translator note: %1$s = formatted XP amount, %2$d = target level number -->
     <string name="format_xp_to_next">%1$s XP na úroveň %2$d</string>
+    <string name="xp_to_99">%1$s XP to 99</string> <!-- untranslated -->
     <!-- Translator note: %1$s = time string (e.g. "42m 10s") -->
     <string name="format_time_remaining">Zbývá %1$s</string>
     <!-- Translator note: %1$s = relative time (e.g. "5m ago") -->

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -202,6 +202,7 @@
     <string name="format_level_xp">Level %1$d — %2$s EP</string>
     <!-- Translator note: %1$s = formatted XP amount, %2$d = target level number -->
     <string name="format_xp_to_next">%1$s EP bis Level %2$d</string>
+    <string name="xp_to_99">%1$s XP to 99</string> <!-- untranslated -->
     <!-- Translator note: %1$s = time string (e.g. "42m 10s") -->
     <string name="format_time_remaining">%1$s verbleibend</string>
     <!-- Translator note: %1$s = relative time (e.g. "5m ago") -->

--- a/app/src/main/res/values-es-rES/strings.xml
+++ b/app/src/main/res/values-es-rES/strings.xml
@@ -202,6 +202,7 @@
     <string name="format_level_xp">Nivel %1$d — %2$s XP</string>
     <!-- Translator note: %1$s = formatted XP amount, %2$d = target level number -->
     <string name="format_xp_to_next">%1$s XP para nivel %2$d</string>
+    <string name="xp_to_99">%1$s XP to 99</string> <!-- untranslated -->
     <!-- Translator note: %1$s = time string (e.g. "42m 10s") -->
     <string name="format_time_remaining">%1$s restante</string>
     <!-- Translator note: %1$s = relative time (e.g. "5m ago") -->

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -202,6 +202,7 @@
     <string name="format_level_xp">Nivel %1$d — %2$s XP</string>
     <!-- Translator note: %1$s = formatted XP amount, %2$d = target level number -->
     <string name="format_xp_to_next">%1$s XP para nivel %2$d</string>
+    <string name="xp_to_99">%1$s XP to 99</string> <!-- untranslated -->
     <!-- Translator note: %1$s = time string (e.g. "42m 10s") -->
     <string name="format_time_remaining">%1$s restante</string>
     <!-- Translator note: %1$s = relative time (e.g. "5m ago") -->

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -202,6 +202,7 @@
     <string name="format_level_xp">Niveau %1$d — %2$s XP</string>
     <!-- Translator note: %1$s = formatted XP amount, %2$d = target level number -->
     <string name="format_xp_to_next">%1$s pour atteindre le niveau %2$d</string>
+    <string name="xp_to_99">%1$s XP to 99</string> <!-- untranslated -->
     <!-- Translator note: %1$s = time string (e.g. "42m 10s") -->
     <string name="format_time_remaining">%1$s restante(s)</string>
     <!-- Translator note: %1$s = relative time (e.g. "5m ago") -->

--- a/app/src/main/res/values-ga/strings.xml
+++ b/app/src/main/res/values-ga/strings.xml
@@ -202,6 +202,7 @@
     <string name="format_level_xp">Leibhéal %1$d — %2$s Taithí</string>
     <!-- Translator note: %1$s = formatted XP amount, %2$d = target level number -->
     <string name="format_xp_to_next">%1$s taithí go leibhéal %2$d</string>
+    <string name="xp_to_99">%1$s XP to 99</string> <!-- untranslated -->
     <!-- Translator note: %1$s = time string (e.g. "42m 10s") -->
     <string name="format_time_remaining">%1$s fágtha</string>
     <!-- Translator note: %1$s = relative time (e.g. "5m ago") -->

--- a/app/src/main/res/values-he/strings.xml
+++ b/app/src/main/res/values-he/strings.xml
@@ -202,6 +202,7 @@
     <string name="format_level_xp">Level %1$d — %2$s XP</string> <!-- untranslated -->
     <!-- Translator note: %1$s = formatted XP amount, %2$d = target level number -->
     <string name="format_xp_to_next">%1$s XP to level %2$d</string> <!-- untranslated -->
+    <string name="xp_to_99">%1$s XP to 99</string> <!-- untranslated -->
     <!-- Translator note: %1$s = time string (e.g. "42m 10s") -->
     <string name="format_time_remaining">%1$s remaining</string> <!-- untranslated -->
     <!-- Translator note: %1$s = relative time (e.g. "5m ago") -->

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -202,6 +202,7 @@
     <string name="format_level_xp">Level %1$d — %2$s XP</string> <!-- untranslated -->
     <!-- Translator note: %1$s = formatted XP amount, %2$d = target level number -->
     <string name="format_xp_to_next">%1$s XP untuk naik level %2$d</string>
+    <string name="xp_to_99">%1$s XP to 99</string> <!-- untranslated -->
     <!-- Translator note: %1$s = time string (e.g. "42m 10s") -->
     <string name="format_time_remaining">%1$s tersisa</string>
     <!-- Translator note: %1$s = relative time (e.g. "5m ago") -->

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -202,6 +202,7 @@
     <string name="format_level_xp">Livello %1$d — %2$s XP</string>
     <!-- Translator note: %1$s = formatted XP amount, %2$d = target level number -->
     <string name="format_xp_to_next">%1$s XP per il livello %2$d</string>
+    <string name="xp_to_99">%1$s XP to 99</string> <!-- untranslated -->
     <!-- Translator note: %1$s = time string (e.g. "42m 10s") -->
     <string name="format_time_remaining">%1$s rimasti</string>
     <!-- Translator note: %1$s = relative time (e.g. "5m ago") -->

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -202,6 +202,7 @@
     <string name="format_level_xp">レベル %1$d — %2$s XP</string>
     <!-- Translator note: %1$s = formatted XP amount, %2$d = target level number -->
     <string name="format_xp_to_next">レベル %2$d まであと %1$s XP</string>
+    <string name="xp_to_99">%1$s XP to 99</string> <!-- untranslated -->
     <!-- Translator note: %1$s = time string (e.g. "42m 10s") -->
     <string name="format_time_remaining">残り時間: %1$s</string>
     <!-- Translator note: %1$s = relative time (e.g. "5m ago") -->

--- a/app/src/main/res/values-lt/strings.xml
+++ b/app/src/main/res/values-lt/strings.xml
@@ -202,6 +202,7 @@
     <string name="format_level_xp">Lygys %1$d — %2$s XP</string>
     <!-- Translator note: %1$s = formatted XP amount, %2$d = target level number -->
     <string name="format_xp_to_next">%1$s XP to Lygio %2$d</string>
+    <string name="xp_to_99">%1$s XP to 99</string> <!-- untranslated -->
     <!-- Translator note: %1$s = time string (e.g. "42m 10s") -->
     <string name="format_time_remaining">%1$s Liko</string>
     <!-- Translator note: %1$s = relative time (e.g. "5m ago") -->

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -202,6 +202,7 @@
     <string name="format_level_xp">Level %1$d — %2$s XP</string> <!-- untranslated -->
     <!-- Translator note: %1$s = formatted XP amount, %2$d = target level number -->
     <string name="format_xp_to_next">%1$s XP naar level %2$d</string>
+    <string name="xp_to_99">%1$s XP to 99</string> <!-- untranslated -->
     <!-- Translator note: %1$s = time string (e.g. "42m 10s") -->
     <string name="format_time_remaining">%1$s te gaan</string>
     <!-- Translator note: %1$s = relative time (e.g. "5m ago") -->

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -202,6 +202,7 @@
     <string name="format_level_xp">Poziom %1$d — %2$s XP</string>
     <!-- Translator note: %1$s = formatted XP amount, %2$d = target level number -->
     <string name="format_xp_to_next">%1$s XP do poziomu %2$d</string>
+    <string name="xp_to_99">%1$s XP to 99</string> <!-- untranslated -->
     <!-- Translator note: %1$s = time string (e.g. "42m 10s") -->
     <string name="format_time_remaining">Pozostało: %1$s</string>
     <!-- Translator note: %1$s = relative time (e.g. "5m ago") -->

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -202,6 +202,7 @@
     <string name="format_level_xp">Nível %1$d — %2$s XP</string>
     <!-- Translator note: %1$s = formatted XP amount, %2$d = target level number -->
     <string name="format_xp_to_next">%1$s XP para o nível %2$d</string>
+    <string name="xp_to_99">%1$s XP to 99</string> <!-- untranslated -->
     <!-- Translator note: %1$s = time string (e.g. "42m 10s") -->
     <string name="format_time_remaining">%1$s restante</string>
     <!-- Translator note: %1$s = relative time (e.g. "5m ago") -->

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -202,6 +202,7 @@
     <string name="format_level_xp">Уровень %1$d — %2$s опыта</string>
     <!-- Translator note: %1$s = formatted XP amount, %2$d = target level number -->
     <string name="format_xp_to_next">%1$s опыта до уровня %2$d</string>
+    <string name="xp_to_99">%1$s XP to 99</string> <!-- untranslated -->
     <!-- Translator note: %1$s = time string (e.g. "42m 10s") -->
     <string name="format_time_remaining">Осталось %1$s</string>
     <!-- Translator note: %1$s = relative time (e.g. "5m ago") -->

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -202,6 +202,7 @@
     <string name="format_level_xp">Seviye %1$d — %2$s XP</string>
     <!-- Translator note: %1$s = formatted XP amount, %2$d = target level number -->
     <string name="format_xp_to_next">Seviye %2$d olmak için %1$s XP</string>
+    <string name="xp_to_99">%1$s XP to 99</string> <!-- untranslated -->
     <!-- Translator note: %1$s = time string (e.g. "42m 10s") -->
     <string name="format_time_remaining">%1$s kaldı</string>
     <!-- Translator note: %1$s = relative time (e.g. "5m ago") -->

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -202,6 +202,7 @@
     <string name="format_level_xp">等级 %1$d — %2$s 经验</string>
     <!-- Translator note: %1$s = formatted XP amount, %2$d = target level number -->
     <string name="format_xp_to_next">距 %2$d 级还需 %1$s 经验</string>
+    <string name="xp_to_99">%1$s XP to 99</string> <!-- untranslated -->
     <!-- Translator note: %1$s = time string (e.g. "42m 10s") -->
     <string name="format_time_remaining">剩余 %1$s</string>
     <!-- Translator note: %1$s = relative time (e.g. "5m ago") -->

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -202,6 +202,8 @@
     <string name="format_level_xp">Level %1$d — %2$s XP</string>
     <!-- Translator note: %1$s = formatted XP amount, %2$d = target level number -->
     <string name="format_xp_to_next">%1$s XP to level %2$d</string>
+    <!-- Translator note: %1$s = formatted XP amount remaining to reach the level cap (99) -->
+    <string name="xp_to_99">%1$s XP to 99</string>
     <!-- Translator note: %1$s = time string (e.g. "42m 10s") -->
     <string name="format_time_remaining">%1$s remaining</string>
     <!-- Translator note: %1$s = relative time (e.g. "5m ago") -->


### PR DESCRIPTION
## Before submitting

- [x] I've tested any changes with the appropriate tests (eg. Unit tests, validation scripts)
- [x] I've pulled and merged the latest changes from the repository

## Summary

- Aligns the Combat screen's skill rows with the Skill screen's XP display
- Fix issue with very large text and different language issue in combat skill screen.
- add a near-prestige "XP to 99" to both skill screens when XP < 100,000 and level = 98

<img width="449" height="88" alt="image" src="https://github.com/user-attachments/assets/82a8afa6-2950-4d5f-ae21-dd694549a588" />

<img width="467" height="696" alt="image" src="https://github.com/user-attachments/assets/18df3734-fa43-4c68-9b38-ff44af85ac5c" />

## Related issue(s) or discussion(s)

## Changelog

- Combat screen now shows `current / next-level XP` (matching the Skill screen), instead of just the raw current XP
- Combat screen's gear/prestige bonus chips moved into their own row, between the progress bar and the prestige row
- Skills screen now show near-prestige xp required

## Anything else?