### PR TITLE
Add option to choose how many backup files to keep

### DIFF
--- a/app/src/main/kotlin/com/fantasyidler/data/model/PlayerModels.kt
+++ b/app/src/main/kotlin/com/fantasyidler/data/model/PlayerModels.kt
@@ -145,6 +145,7 @@ data class PlayerFlags(
     @SerialName("backup_folder_uri") val backupFolderUri: String = "",
     /** Automatic backup frequency: ""|"hourly"|"daily"|"weekly". */
     @SerialName("backup_frequency") val backupFrequency: String = "",
+    @SerialName("backup_count") val backupCount: Int = 1,
     @SerialName("last_backup_at") val lastBackupAt: Long = 0L,
     @SerialName("last_backup_ok") val lastBackupOk: Boolean = true,
     @SerialName("last_backup_error") val lastBackupError: String = "",

--- a/app/src/main/kotlin/com/fantasyidler/repository/BackupScheduler.kt
+++ b/app/src/main/kotlin/com/fantasyidler/repository/BackupScheduler.kt
@@ -90,14 +90,12 @@ class BackupScheduler @Inject constructor(
             Log.w(TAG, "Backup reschedule failed", e)
         }
         if (flags.backupFolderUri.isEmpty()) return false
-        // Per-character file names: each save slot keeps its own backup, so switching
+        // Per-character file names: each save slot keeps its own backups, so switching
         // characters no longer overwrites another character's auto backup.
         val activeSlot = globalStateRepo.getActiveSaveSlot()
         val slotPrefix = autoBackupSlotPrefix(activeSlot)
-        val finalName  = autoBackupFileName(activeSlot, flags.characterName)
-        val tempName   = finalName + TEMP_SUFFIX
+        val backupCount = flags.backupCount.coerceAtLeast(1)
         var tempUri: Uri? = null
-        var oldDocsDeleted = false
         var failureMsg = ""
         val ok = try {
             val sessions = buildList {
@@ -112,6 +110,19 @@ class BackupScheduler @Inject constructor(
             val treeUri   = Uri.parse(flags.backupFolderUri)
             val treeDocId = DocumentsContract.getTreeDocumentId(treeUri)
             val cr        = context.contentResolver
+            val existingDocs = childDocuments(cr, treeUri, treeDocId)
+                .filter { (_, name) ->
+                    name == slotPrefix || name.startsWith("${slotPrefix}_") ||
+                        name == "$slotPrefix.json" || name == slotPrefix + TEMP_SUFFIX ||
+                        name == "$slotPrefix$TEMP_SUFFIX.json"
+                }
+            val generation = maxOf(
+                System.currentTimeMillis(),
+                (existingDocs.maxOfOrNull { backupGeneration(it.second) } ?: 0L) + 1L,
+            )
+            val baseName = autoBackupFileName(activeSlot, flags.characterName)
+            val finalName = "${baseName}_at_$generation"
+            val tempName = finalName + TEMP_SUFFIX
 
             val created = DocumentsContract.createDocument(
                 cr,
@@ -138,25 +149,29 @@ class BackupScheduler @Inject constructor(
                 throw IllegalStateException("temp document bytes differ from exported save")
             }
 
-            val currentTempId = DocumentsContract.getDocumentId(created)
-            val doomedIds = childDocuments(cr, treeUri, treeDocId)
-                .filter { (docId, name) ->
-                    docId != currentTempId && name.startsWith(slotPrefix)
-                }
-                .map { it.first }
-            oldDocsDeleted = true
-            doomedIds.forEach { docId ->
-                DocumentsContract.deleteDocument(cr, DocumentsContract.buildDocumentUriUsingTree(treeUri, docId))
-            }
-
-            DocumentsContract.renameDocument(cr, created, finalName)
+            val renamed = DocumentsContract.renameDocument(cr, created, finalName)
                 ?: throw IllegalStateException("backup provider failed to swap temp document to final name")
             tempUri = null
 
+            val renamedId = DocumentsContract.getDocumentId(renamed)
             val swappedIn = childDocuments(cr, treeUri, treeDocId)
-                .any { it.second.startsWith(finalName) && !it.second.endsWith(TEMP_SUFFIX) }
+                .any { (id, name) -> id == renamedId && (name == finalName || name == "$finalName.json") }
             if (!swappedIn) {
                 throw IllegalStateException("renamed backup document not found after swap")
+            }
+
+            // Only prune older backups after the new file is verified and finalized.
+            val retainedIds = existingDocs
+                .filterNot { it.second.removeSuffix(".json").endsWith(TEMP_SUFFIX) }
+                .sortedByDescending { backupGeneration(it.second) }
+                .take(backupCount - 1)
+                .map { it.first }
+                .toSet()
+            val doomedIds = existingDocs
+                .filterNot { it.first in retainedIds }
+                .map { it.first }
+            doomedIds.forEach { docId ->
+                DocumentsContract.deleteDocument(cr, DocumentsContract.buildDocumentUriUsingTree(treeUri, docId))
             }
 
             true
@@ -166,7 +181,7 @@ class BackupScheduler @Inject constructor(
             false
         }
 
-        if (!ok && !oldDocsDeleted) {
+        if (!ok) {
             tempUri?.let { temp ->
                 try { DocumentsContract.deleteDocument(context.contentResolver, temp) } catch (_: Exception) {}
             }
@@ -230,7 +245,11 @@ class BackupScheduler @Inject constructor(
         private fun sanitizeCharacterName(name: String): String =
             name.filter { it.isLetterOrDigit() }.take(24)
 
-        /** Slot prefix scoping backup cleanup: one backup per slot, other slots' files untouched. */
+        private fun backupGeneration(name: String): Long =
+            name.removeSuffix(".json").removeSuffix(TEMP_SUFFIX)
+                .substringAfterLast("_at_", "").toLongOrNull() ?: 0L
+
+        /** Slot prefix scoping backup cleanup, leaving other slots' files untouched. */
         internal fun autoBackupSlotPrefix(slot: Int) = "${AUTO_BASE}_$slot"
 
         /** Per-character backup name, e.g. fantasyidler_auto_2_IronDragon (name part omitted when blank). */

--- a/app/src/main/kotlin/com/fantasyidler/ui/screen/SettingsScreen.kt
+++ b/app/src/main/kotlin/com/fantasyidler/ui/screen/SettingsScreen.kt
@@ -87,6 +87,7 @@ fun SettingsScreen(
     val profileLayout          by viewModel.profileLayout.collectAsState()
     val backupFolderUri  by viewModel.backupFolderUri.collectAsState()
     val backupFrequency  by viewModel.backupFrequency.collectAsState()
+    val backupCount      by viewModel.backupCount.collectAsState()
     val backupStatus     by viewModel.backupStatus.collectAsState()
     var notificationsEnabled by remember { mutableStateOf(false) }
     var showResetConfirm1    by remember { mutableStateOf(false) }
@@ -584,6 +585,42 @@ fun SettingsScreen(
                         }
                     }
                 }
+            )
+
+            SettingsRow(
+                title = stringResource(R.string.settings_backup_count),
+                subtitle = "",
+                trailing = {
+                    var countExpanded by remember { mutableStateOf(false) }
+                    ExposedDropdownMenuBox(
+                        expanded = countExpanded,
+                        onExpandedChange = { countExpanded = it },
+                    ) {
+                        OutlinedTextField(
+                            value = backupCount.toString(),
+                            onValueChange = {},
+                            readOnly = true,
+                            trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = countExpanded) },
+                            modifier = Modifier.menuAnchor().width(150.dp),
+                            textStyle = MaterialTheme.typography.bodySmall,
+                            singleLine = true,
+                        )
+                        ExposedDropdownMenu(
+                            expanded = countExpanded,
+                            onDismissRequest = { countExpanded = false },
+                        ) {
+                            listOf(1, 3, 5, 10, 30).forEach { count ->
+                                DropdownMenuItem(
+                                    text = { Text(count.toString()) },
+                                    onClick = {
+                                        viewModel.setBackupCount(count)
+                                        countExpanded = false
+                                    },
+                                )
+                            }
+                        }
+                    }
+                },
             )
 
             val statusSubtitle = if (backupStatus.lastBackupAt == 0L) {

--- a/app/src/main/kotlin/com/fantasyidler/ui/viewmodel/SettingsViewModel.kt
+++ b/app/src/main/kotlin/com/fantasyidler/ui/viewmodel/SettingsViewModel.kt
@@ -106,6 +106,14 @@ class SettingsViewModel @Inject constructor(
         }
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), "")
 
+    val backupCount: StateFlow<Int> = playerRepo.playerFlow
+        .map { player ->
+            if (player == null) return@map 1
+            try { json.decodeFromString<PlayerFlags>(player.flags).backupCount }
+            catch (_: Exception) { 1 }
+        }
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), 1)
+
     val backupStatus: StateFlow<BackupStatus> = playerRepo.playerFlow
         .map { player ->
             if (player == null) return@map BackupStatus()
@@ -354,6 +362,14 @@ class SettingsViewModel @Inject constructor(
             val flags = playerRepo.getFlags()
             playerRepo.updateFlags(flags.copy(backupFrequency = frequency))
             backupScheduler.schedule(frequency)
+        }
+    }
+
+    fun setBackupCount(count: Int) {
+        viewModelScope.launch {
+            playerRepo.updateFlagsAtomically {
+                it.copy(backupCount = count.coerceAtLeast(1))
+            }
         }
     }
 

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -490,6 +490,7 @@
     <string name="settings_backup_no_folder">No folder selected</string> <!-- untranslated -->
     <string name="settings_backup_choose">Choose</string> <!-- untranslated -->
     <string name="settings_backup_frequency">Frequency</string> <!-- untranslated -->
+    <string name="settings_backup_count">Number of backups</string> <!-- untranslated -->
     <string name="settings_backup_off">Off</string> <!-- untranslated -->
     <string name="settings_backup_hourly">Hourly</string> <!-- untranslated -->
     <string name="settings_backup_daily">Daily</string> <!-- untranslated -->

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -490,6 +490,7 @@
     <string name="settings_backup_no_folder">No folder selected</string> <!-- untranslated -->
     <string name="settings_backup_choose">Choose</string> <!-- untranslated -->
     <string name="settings_backup_frequency">Frequency</string> <!-- untranslated -->
+    <string name="settings_backup_count">Number of backups</string> <!-- untranslated -->
     <string name="settings_backup_off">Off</string> <!-- untranslated -->
     <string name="settings_backup_hourly">Hourly</string> <!-- untranslated -->
     <string name="settings_backup_daily">Daily</string> <!-- untranslated -->

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -502,6 +502,7 @@
     <string name="settings_backup_no_folder">Nebyla vybrána žádná složka</string>
     <string name="settings_backup_choose">Vybrat</string>
     <string name="settings_backup_frequency">Četnost</string>
+    <string name="settings_backup_count">Number of backups</string> <!-- untranslated -->
     <string name="settings_backup_off">Vypnuto</string>
     <string name="settings_backup_hourly">Každou hodinu</string>
     <string name="settings_backup_daily">Denně</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -490,6 +490,7 @@
     <string name="settings_backup_no_folder">Kein Verzeichnis ausgewählt</string>
     <string name="settings_backup_choose">Auswählen</string>
     <string name="settings_backup_frequency">Häufigkeit</string>
+    <string name="settings_backup_count">Number of backups</string> <!-- untranslated -->
     <string name="settings_backup_off">Aus</string>
     <string name="settings_backup_hourly">Stündlich</string>
     <string name="settings_backup_daily">Täglich</string>

--- a/app/src/main/res/values-es-rES/strings.xml
+++ b/app/src/main/res/values-es-rES/strings.xml
@@ -490,6 +490,7 @@
     <string name="settings_backup_no_folder">No folder selected</string> <!-- untranslated -->
     <string name="settings_backup_choose">Choose</string> <!-- untranslated -->
     <string name="settings_backup_frequency">Frequency</string> <!-- untranslated -->
+    <string name="settings_backup_count">Number of backups</string> <!-- untranslated -->
     <string name="settings_backup_off">Off</string> <!-- untranslated -->
     <string name="settings_backup_hourly">Hourly</string> <!-- untranslated -->
     <string name="settings_backup_daily">Daily</string> <!-- untranslated -->

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -490,6 +490,7 @@
     <string name="settings_backup_no_folder">No folder selected</string> <!-- untranslated -->
     <string name="settings_backup_choose">Choose</string> <!-- untranslated -->
     <string name="settings_backup_frequency">Frequency</string> <!-- untranslated -->
+    <string name="settings_backup_count">Number of backups</string> <!-- untranslated -->
     <string name="settings_backup_off">Off</string> <!-- untranslated -->
     <string name="settings_backup_hourly">Hourly</string> <!-- untranslated -->
     <string name="settings_backup_daily">Daily</string> <!-- untranslated -->

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -490,6 +490,7 @@
     <string name="settings_backup_no_folder">Aucun dossier sélectionné</string>
     <string name="settings_backup_choose">Choisir</string>
     <string name="settings_backup_frequency">Fréquence</string>
+    <string name="settings_backup_count">Number of backups</string> <!-- untranslated -->
     <string name="settings_backup_off">Désactivé</string>
     <string name="settings_backup_hourly">chaque heure</string>
     <string name="settings_backup_daily">chaque jour</string>

--- a/app/src/main/res/values-ga/strings.xml
+++ b/app/src/main/res/values-ga/strings.xml
@@ -518,6 +518,7 @@
     <string name="settings_backup_no_folder">Níl Aon Fillteán Roghnaithe</string>
     <string name="settings_backup_choose">Roghnaigh</string>
     <string name="settings_backup_frequency">Minicíocht</string>
+    <string name="settings_backup_count">Number of backups</string> <!-- untranslated -->
     <string name="settings_backup_off">As</string>
     <string name="settings_backup_hourly">Gach Uair An Chloig</string>
     <string name="settings_backup_daily">Laethúil</string>

--- a/app/src/main/res/values-he/strings.xml
+++ b/app/src/main/res/values-he/strings.xml
@@ -490,6 +490,7 @@
     <string name="settings_backup_no_folder">No folder selected</string> <!-- untranslated -->
     <string name="settings_backup_choose">Choose</string> <!-- untranslated -->
     <string name="settings_backup_frequency">Frequency</string> <!-- untranslated -->
+    <string name="settings_backup_count">Number of backups</string> <!-- untranslated -->
     <string name="settings_backup_off">Off</string> <!-- untranslated -->
     <string name="settings_backup_hourly">Hourly</string> <!-- untranslated -->
     <string name="settings_backup_daily">Daily</string> <!-- untranslated -->

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -483,6 +483,7 @@
     <string name="settings_backup_no_folder">Tidak ada folder yang dipilih</string>
     <string name="settings_backup_choose">Memilih</string>
     <string name="settings_backup_frequency">Frekuensi</string>
+    <string name="settings_backup_count">Number of backups</string> <!-- untranslated -->
     <string name="settings_backup_off">Mati</string>
     <string name="settings_backup_hourly">Per jam</string>
     <string name="settings_backup_daily">Harian</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -490,6 +490,7 @@
     <string name="settings_backup_no_folder">Nessuna cartella selezionata</string>
     <string name="settings_backup_choose">Seleziona</string>
     <string name="settings_backup_frequency">Frequenza</string>
+    <string name="settings_backup_count">Number of backups</string> <!-- untranslated -->
     <string name="settings_backup_off">Nessuno</string>
     <string name="settings_backup_hourly">Orario</string>
     <string name="settings_backup_daily">Giornaliero</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -490,6 +490,7 @@
     <string name="settings_backup_no_folder">フォルダが選択されていません</string>
     <string name="settings_backup_choose">選択</string>
     <string name="settings_backup_frequency">頻度</string>
+    <string name="settings_backup_count">Number of backups</string> <!-- untranslated -->
     <string name="settings_backup_off">オフ</string>
     <string name="settings_backup_hourly">1時間ごと</string>
     <string name="settings_backup_daily">毎日</string>

--- a/app/src/main/res/values-lt/strings.xml
+++ b/app/src/main/res/values-lt/strings.xml
@@ -490,6 +490,7 @@
     <string name="settings_backup_no_folder">No folder selected</string> <!-- untranslated -->
     <string name="settings_backup_choose">Choose</string> <!-- untranslated -->
     <string name="settings_backup_frequency">Frequency</string> <!-- untranslated -->
+    <string name="settings_backup_count">Number of backups</string> <!-- untranslated -->
     <string name="settings_backup_off">Off</string> <!-- untranslated -->
     <string name="settings_backup_hourly">Hourly</string> <!-- untranslated -->
     <string name="settings_backup_daily">Daily</string> <!-- untranslated -->

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -490,6 +490,7 @@
     <string name="settings_backup_no_folder">Geen map geselecteerd</string>
     <string name="settings_backup_choose">Kies</string>
     <string name="settings_backup_frequency">Frequentie</string>
+    <string name="settings_backup_count">Number of backups</string> <!-- untranslated -->
     <string name="settings_backup_off">Uit</string>
     <string name="settings_backup_hourly">Uurlijks</string>
     <string name="settings_backup_daily">Dagelijks</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -504,6 +504,7 @@
     <string name="settings_backup_no_folder">Nie wybrano folderu</string>
     <string name="settings_backup_choose">Wybierz</string>
     <string name="settings_backup_frequency">Częstotliwość</string>
+    <string name="settings_backup_count">Number of backups</string> <!-- untranslated -->
     <string name="settings_backup_off">Wyłączona</string>
     <string name="settings_backup_hourly">Co godzinę</string>
     <string name="settings_backup_daily">Codziennie</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -490,6 +490,7 @@
     <string name="settings_backup_no_folder">Nenhuma pasta selecionada</string>
     <string name="settings_backup_choose">Escolher</string>
     <string name="settings_backup_frequency">Frequência</string>
+    <string name="settings_backup_count">Number of backups</string> <!-- untranslated -->
     <string name="settings_backup_off">Desativado</string>
     <string name="settings_backup_hourly">A cada hora</string>
     <string name="settings_backup_daily">Diariamente</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -506,6 +506,7 @@
     <string name="settings_backup_no_folder">Папка не выбрана</string>
     <string name="settings_backup_choose">Выбрать</string>
     <string name="settings_backup_frequency">Частота</string>
+    <string name="settings_backup_count">Number of backups</string> <!-- untranslated -->
     <string name="settings_backup_off">Выкл</string>
     <string name="settings_backup_hourly">Каждый час</string>
     <string name="settings_backup_daily">Ежедневно</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -490,6 +490,7 @@
     <string name="settings_backup_no_folder">Klasör seçilmedi</string>
     <string name="settings_backup_choose">Seç</string>
     <string name="settings_backup_frequency">Yedekleme Sıklığı</string>
+    <string name="settings_backup_count">Number of backups</string> <!-- untranslated -->
     <string name="settings_backup_off">Kapalı</string>
     <string name="settings_backup_hourly">Saatlik</string>
     <string name="settings_backup_daily">Günlük</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -490,6 +490,7 @@
     <string name="settings_backup_no_folder">未选择文件夹</string>
     <string name="settings_backup_choose">选择</string>
     <string name="settings_backup_frequency">频率</string>
+    <string name="settings_backup_count">Number of backups</string> <!-- untranslated -->
     <string name="settings_backup_off">关闭</string>
     <string name="settings_backup_hourly">每小时</string>
     <string name="settings_backup_daily">每天</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -490,6 +490,7 @@
     <string name="settings_backup_no_folder">No folder selected</string>
     <string name="settings_backup_choose">Choose</string>
     <string name="settings_backup_frequency">Frequency</string>
+    <string name="settings_backup_count">Number of backups</string>
     <string name="settings_backup_off">Off</string>
     <string name="settings_backup_hourly">Hourly</string>
     <string name="settings_backup_daily">Daily</string>

--- a/app/src/test/kotlin/com/fantasyidler/repository/BackupSchedulerTest.kt
+++ b/app/src/test/kotlin/com/fantasyidler/repository/BackupSchedulerTest.kt
@@ -89,12 +89,13 @@ class BackupSchedulerTest {
         val ok = scheduler.performBackup(playerRepo)
 
         assertTrue(ok)
-        assertEquals(listOf("create", "write", "readback", "delete", "rename"), docs.events)
+        assertEquals(listOf("create", "write", "readback", "rename", "delete"), docs.events)
         assertEquals(listOf(OLD_DOC_ID), docs.deletedDocIds)
         assertEquals(1, docs.renamedFrom.size)
         assertFalse(docs.children.containsKey(OLD_DOC_ID))
         assertEquals(LEGACY_BACKUP_NAME, docs.children[LEGACY_DOC_ID])
-        assertEquals(listOf(LEGACY_BACKUP_NAME, FINAL_BACKUP_NAME), docs.children.values.sorted())
+        assertEquals(2, docs.children.size)
+        assertTimestampedBackup(DocumentsContract.getDocumentId(docs.createdUris.single()))
         assertEquals(
             normalized(playerRepo.exportSave()),
             normalized(String(docs.bufferFor(docs.createdUris.single()))),
@@ -103,6 +104,49 @@ class BackupSchedulerTest {
         assertTrue(flags.lastBackupOk)
         assertNotEquals(0L, flags.lastBackupAt)
         assertEquals("", flags.lastBackupError)
+    }
+
+    @Test
+    fun `retention keeps newest backups for each supported count and protects other slots`() = runBlocking {
+        docs.seed("other_slot", "fantasyidler_auto_10_Other")
+        docs.seed("manual_export", "fantasyidler_save_1_Manual.json")
+        for (count in listOf(30, 10, 7, 5, 3, 1)) {
+            playerRepo.updateFlagsAtomically { it.copy(backupCount = count) }
+            repeat(count + 1) { assertTrue(scheduler.performBackup(playerRepo)) }
+            val slotDocs = docs.children.filterValues {
+                it == FINAL_BACKUP_NAME || it.startsWith("${FINAL_BACKUP_NAME}_")
+            }
+            assertEquals(count, slotDocs.size)
+            val newestIds = docs.createdUris.takeLast(count)
+                .map { DocumentsContract.getDocumentId(it) }.toSet()
+            assertEquals(newestIds, slotDocs.keys)
+            assertTrue(docs.children.containsKey("other_slot"))
+            assertTrue(docs.children.containsKey("manual_export"))
+            assertTrue(docs.children.containsKey(LEGACY_DOC_ID))
+        }
+    }
+
+    @Test
+    fun `failed write does not prune retained backups`() = runBlocking {
+        playerRepo.updateFlagsAtomically { it.copy(backupCount = 3) }
+        repeat(3) { assertTrue(scheduler.performBackup(playerRepo)) }
+        val before = docs.children.toMap()
+        docs.writeThrows = true
+        assertFalse(scheduler.performBackup(playerRepo))
+        assertEquals(before, docs.children)
+    }
+
+    @Test
+    fun `old saves default to one backup and backup count survives serialization`() {
+        assertEquals(1, json.decodeFromString<PlayerFlags>("{}").backupCount)
+        val encoded = json.encodeToString(PlayerFlags.serializer(), PlayerFlags(backupCount = 10))
+        assertEquals(10, json.decodeFromString<PlayerFlags>(encoded).backupCount)
+    }
+
+    private fun assertTimestampedBackup(docId: String) {
+        val name = docs.children[docId].orEmpty()
+        assertTrue(name.startsWith("${FINAL_BACKUP_NAME}_at_"))
+        assertTrue((name.substringAfterLast("_at_").toLongOrNull() ?: 0L) > 0L)
     }
 
     private fun normalized(raw: String): String {
@@ -161,16 +205,16 @@ class BackupSchedulerTest {
     }
 
     @Test
-    fun `failure after delete pass preserves verified temp file`() = runBlocking {
+    fun `rename failure keeps old backup and cleans temp file`() = runBlocking {
         docs.renameFails = true
 
         val ok = scheduler.performBackup(playerRepo)
 
         assertFalse(ok)
         val tempId = DocumentsContract.getDocumentId(docs.createdUris.single())
-        assertFalse(docs.deletedDocIds.contains(tempId))
-        assertTrue(docs.deletedDocIds.contains(OLD_DOC_ID))
-        assertEquals("fantasyidler_auto_1.tmp", docs.children[tempId])
+        assertTrue(docs.deletedDocIds.contains(tempId))
+        assertEquals(OLD_BACKUP_NAME, docs.children[OLD_DOC_ID])
+        assertFalse(docs.deletedDocIds.contains(OLD_DOC_ID))
         val flags = playerRepo.getFlags()
         assertFalse(flags.lastBackupOk)
         assertTrue(flags.lastBackupError.isNotEmpty())
@@ -187,13 +231,13 @@ class BackupSchedulerTest {
         assertTrue(docs.deletedDocIds.contains(OLD_DOC_ID))
         val tempId = DocumentsContract.getDocumentId(docs.createdUris.single())
         assertFalse(docs.deletedDocIds.contains(tempId))
-        assertEquals("fantasyidler_auto_1", docs.children[tempId])
+        assertTimestampedBackup(tempId)
         assertFalse(docs.children.containsKey("doc_stale_tmp"))
     }
 
     @Test
     fun `unverifiable post-rename swap fails backup and preserves renamed document`() = runBlocking {
-        docs.queryThrowsAfterDelete = true
+        docs.queryThrowsAfterRename = true
 
         val ok = scheduler.performBackup(playerRepo)
 
@@ -204,12 +248,13 @@ class BackupSchedulerTest {
         assertNotEquals(0L, flags.lastBackupAt)
         val tempId = DocumentsContract.getDocumentId(docs.createdUris.single())
         assertFalse(docs.deletedDocIds.contains(tempId))
-        assertEquals("fantasyidler_auto_1", docs.children[tempId])
-        assertTrue(docs.deletedDocIds.contains(OLD_DOC_ID))
+        assertTimestampedBackup(tempId)
+        assertEquals(OLD_BACKUP_NAME, docs.children[OLD_DOC_ID])
+        assertTrue(docs.deletedDocIds.isEmpty())
     }
 
     @Test
-    fun `rename returning null fails backup and preserves verified temp`() = runBlocking {
+    fun `rename returning null keeps old backup and cleans temp file`() = runBlocking {
         docs.renameReturnsNull = true
 
         val ok = scheduler.performBackup(playerRepo)
@@ -219,9 +264,9 @@ class BackupSchedulerTest {
         assertFalse(flags.lastBackupOk)
         assertTrue(flags.lastBackupError.isNotEmpty())
         val tempId = DocumentsContract.getDocumentId(docs.createdUris.single())
-        assertFalse(docs.deletedDocIds.contains(tempId))
-        assertEquals("fantasyidler_auto_1.tmp", docs.children[tempId])
-        assertTrue(docs.deletedDocIds.contains(OLD_DOC_ID))
+        assertTrue(docs.deletedDocIds.contains(tempId))
+        assertEquals(OLD_BACKUP_NAME, docs.children[OLD_DOC_ID])
+        assertFalse(docs.deletedDocIds.contains(OLD_DOC_ID))
     }
 
     @Test
@@ -264,7 +309,7 @@ private class FakeDocsProvider(private val authority: String) : ContentProvider(
     var readbackOverride: ByteArray? = null
     var renameFails = false
     var renameReturnsNull = false
-    var queryThrowsAfterDelete = false
+    var queryThrowsAfterRename = false
 
     private val buffers = HashMap<Uri, ByteArray>()
     private var nextDocNum = 0
@@ -329,8 +374,8 @@ private class FakeDocsProvider(private val authority: String) : ContentProvider(
         selectionArgs: Array<out String>?,
         sortOrder: String?,
     ): Cursor? {
-        if (queryThrowsAfterDelete && deletedDocIds.isNotEmpty()) {
-            throw RuntimeException("simulated provider query failure after deletion")
+        if (queryThrowsAfterRename && renamedFrom.isNotEmpty()) {
+            throw RuntimeException("simulated provider query failure after rename")
         }
         val cols = projection?.toList()
             ?: listOf(DocumentsContract.Document.COLUMN_DOCUMENT_ID, DocumentsContract.Document.COLUMN_DISPLAY_NAME)


### PR DESCRIPTION
## Before submitting

- [x] I've tested any changes with the appropriate tests (eg. Unit tests, validation scripts)
- [x] I've pulled and merged the latest changes from the repository

## Summary

Added option to pick how many older backups to keep when auto backup is turned on or you use the backup now button.
The option is per character slot, so char1 can have 3, char2 can have 10 and char3 can have 1 or however many they want/picked.


## Related issue(s) or discussion(s)

https://github.com/tristinbaker/IdleFantasy/discussions/1652
https://github.com/tristinbaker/IdleFantasy/discussions/725


## Changelog

- Added the option in settings to pick the number of backups kept: 1,3,5...
- Added/Changed the tests for auto backups where needed.
- Added the new string value to all locales
- Deleting older saves is done after creating and checking the new one for validity.


## Anything else?

